### PR TITLE
isolate consistency computation

### DIFF
--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -141,8 +141,10 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
             let graph = GraphBuilder.build configOptions config
             if options.Debug then logGraph graph "config"
 
-            let tryGetSummaryOnly useRemote id = cache.TryGetSummaryOnly useRemote id |> Option.map (fun (_, summary) -> summary)
-            let consistentGraph = GraphConsistency.enforce configOptions tryGetSummaryOnly graph
+            let tryGetSummaryOnly id =
+                let allowRemoteCache = options.LocalOnly |> not
+                cache.TryGetSummaryOnly allowRemoteCache id |> Option.map (fun (_, summary) -> summary)
+            let consistentGraph = GraphConsistency.enforce configOptions.StartedAt configOptions.Force configOptions.Retry tryGetSummaryOnly graph
             if options.Debug then logGraph consistentGraph "consistent"
 
             let transformGraph = GraphTransformer.transform consistentGraph


### PR DESCRIPTION
Reduce dependencies for consistency computation - idea is to be able to offload computation to service later on