### PR TITLE
remove BranchOrTag in command context

### DIFF
--- a/src/Terrabuild.Extensibility/Extensions.fs
+++ b/src/Terrabuild.Extensibility/Extensions.fs
@@ -30,7 +30,6 @@ type ActionContext = {
     Debug: bool
     CI: bool
     Command: string
-    BranchOrTag: string
     ProjectHash: string
 }
 

--- a/src/Terrabuild.Extensions/Docker.fs
+++ b/src/Terrabuild.Extensions/Docker.fs
@@ -45,17 +45,12 @@ type Docker() =
     /// <param name="image" required="true" example="&quot;ghcr.io/example/project&quot;">Docker image to build.</param>
     /// <param name="tag" required="false" example="&quot;1.2.3-stable&quot;">Apply tag on image (use branch or tag otherwise).</param>
     static member push (context: ActionContext) (image: string) (tag: string option)=
-        let imageTag =
-            match tag with
-            | Some tag -> tag
-            | _ -> context.BranchOrTag.Replace("/", "-")
-
         let ops =
             [
                 if context.CI then
-                    shellOp "docker" $"buildx imagetools create -t {image}:{imageTag} {image}:{context.ProjectHash}"
+                    shellOp "docker" $"buildx imagetools create -t {image}:{tag} {image}:{context.ProjectHash}"
                 else
-                    shellOp "docker" $"tag {image}:{context.ProjectHash} {image}:{imageTag}"
+                    shellOp "docker" $"tag {image}:{context.ProjectHash} {image}:{tag}"
             ]
 
         let cacheability =

--- a/src/Terrabuild/Core/Builder.fs
+++ b/src/Terrabuild/Core/Builder.fs
@@ -83,7 +83,6 @@ let build (options: ConfigOptions.Options) (configuration: Configuration.Workspa
                             Terrabuild.Extensibility.ActionContext.Debug = options.Debug
                             Terrabuild.Extensibility.ActionContext.CI = options.CI.IsSome
                             Terrabuild.Extensibility.ActionContext.Command = operation.Command
-                            Terrabuild.Extensibility.ActionContext.BranchOrTag = options.BranchOrTag
                             Terrabuild.Extensibility.ActionContext.ProjectHash = projectConfig.Hash
                         }
 


### PR DESCRIPTION
Data available as `terrabuild_branch_or_tag` - using this variable also forces a tracking which was not done before (could miss a rebuild for a different branch with same commit).