### PR TITLE
rename ProjectHash as Hash

### DIFF
--- a/src/Terrabuild.Extensibility/Extensions.fs
+++ b/src/Terrabuild.Extensibility/Extensions.fs
@@ -30,7 +30,7 @@ type ActionContext = {
     Debug: bool
     CI: bool
     Command: string
-    ProjectHash: string
+    Hash: string
 }
 
 [<RequireQualifiedAccess>]

--- a/src/Terrabuild.Extensions/Docker.fs
+++ b/src/Terrabuild.Extensions/Docker.fs
@@ -24,10 +24,10 @@ type Docker() =
 
         let ops = 
             [
-                let buildArgs = $"build --file {dockerfile} --tag {image}:{context.ProjectHash}{args}{platform} ."
+                let buildArgs = $"build --file {dockerfile} --tag {image}:{context.Hash}{args}{platform} ."
                 if context.CI then
                     shellOp "docker" buildArgs
-                    shellOp "docker" $"push {image}:{context.ProjectHash}"
+                    shellOp "docker" $"push {image}:{context.Hash}"
                 else
                     shellOp "docker" buildArgs
             ]
@@ -48,9 +48,9 @@ type Docker() =
         let ops =
             [
                 if context.CI then
-                    shellOp "docker" $"buildx imagetools create -t {image}:{tag} {image}:{context.ProjectHash}"
+                    shellOp "docker" $"buildx imagetools create -t {image}:{tag} {image}:{context.Hash}"
                 else
-                    shellOp "docker" $"tag {image}:{context.ProjectHash} {image}:{tag}"
+                    shellOp "docker" $"tag {image}:{context.Hash} {image}:{tag}"
             ]
 
         let cacheability =

--- a/src/Terrabuild/Core/Builder.fs
+++ b/src/Terrabuild/Core/Builder.fs
@@ -83,7 +83,7 @@ let build (options: ConfigOptions.Options) (configuration: Configuration.Workspa
                             Terrabuild.Extensibility.ActionContext.Debug = options.Debug
                             Terrabuild.Extensibility.ActionContext.CI = options.CI.IsSome
                             Terrabuild.Extensibility.ActionContext.Command = operation.Command
-                            Terrabuild.Extensibility.ActionContext.ProjectHash = projectConfig.Hash
+                            Terrabuild.Extensibility.ActionContext.Hash = projectConfig.Hash
                         }
 
                         let parameters = 


### PR DESCRIPTION
Back and forth again. Feels like `Hash` is easier to read 🤷‍♂️