### PR TITLE
container not part of hash

### DIFF
--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -350,7 +350,7 @@ let read (options: ConfigOptions.Options) =
                             |> List.ofSeq
 
                         let hash =
-                            [ step.Extension; step.Command ] @ usedVariables
+                            [ step.Extension; step.Command; $"{extension.Container}" ] @ usedVariables
                             |> Hash.sha256strings
 
                         let targetContext = {
@@ -376,8 +376,7 @@ let read (options: ConfigOptions.Options) =
                         workspaceConfig.Targets
                         |> Map.tryFind targetName
                         |> Option.map (fun target -> target.DependsOn)
-                        |> Option.defaultValue Set.empty
-                    )
+                        |> Option.defaultValue Set.empty)
 
                 let outputs =
                     match target.Outputs with

--- a/tests/cluster-layers/results/terrabuild-debug.build-graph.json
+++ b/tests/cluster-layers/results/terrabuild-debug.build-graph.json
@@ -6,7 +6,7 @@
       "project": "A",
       "target": "build",
       "configurationTarget": {
-        "hash": "B942B51B15FA8E4F694D5CE107303EC8D5E9EED56CFF35EBC02DC4C8C195B882",
+        "hash": "C53C9169120094BA775853CA620C100D989CF1EE983D8AAFE6E992E61C52EDE6",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -21,7 +21,7 @@
         ],
         "operations": [
           {
-            "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+            "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
             "container": null,
             "containerVariables": [],
             "extension": "@shell",
@@ -38,7 +38,7 @@
             ]
           },
           {
-            "hash": "49C77F0CC375A791BF822BAA5F2D11EA68FC0FE0C628ACD1863BAF7ED6649BEC",
+            "hash": "CEA159C860EAAD627DB52237F71B27FE2A6E5E652F32DDEA82AEFEF47152B360",
             "container": null,
             "containerVariables": [],
             "extension": "@dotnet",
@@ -61,7 +61,7 @@
         "obj/*.targets"
       ],
       "projectHash": "1331212E360E341B3A07B89233CA975DD8814EE7E1A31F4CFB97FE46E162F45C",
-      "targetHash": "63E2E3248F4C306ECC86A1715BF4ECBC07970446FB8870626BC0668BDC42003B",
+      "targetHash": "7EBFD005C7D57A6622988FA04DF075F6A563974693D920458AD15BD1009C03CD",
       "operations": [
         {
           "container": null,
@@ -99,7 +99,7 @@
       "project": "B",
       "target": "build",
       "configurationTarget": {
-        "hash": "B942B51B15FA8E4F694D5CE107303EC8D5E9EED56CFF35EBC02DC4C8C195B882",
+        "hash": "C53C9169120094BA775853CA620C100D989CF1EE983D8AAFE6E992E61C52EDE6",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -114,7 +114,7 @@
         ],
         "operations": [
           {
-            "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+            "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
             "container": null,
             "containerVariables": [],
             "extension": "@shell",
@@ -131,7 +131,7 @@
             ]
           },
           {
-            "hash": "49C77F0CC375A791BF822BAA5F2D11EA68FC0FE0C628ACD1863BAF7ED6649BEC",
+            "hash": "CEA159C860EAAD627DB52237F71B27FE2A6E5E652F32DDEA82AEFEF47152B360",
             "container": null,
             "containerVariables": [],
             "extension": "@dotnet",
@@ -154,7 +154,7 @@
         "obj/*.targets"
       ],
       "projectHash": "CC8C96EF544914A3802A18E8EF8C10503BDEAE040D90EF613402F34962BD4104",
-      "targetHash": "42F9DDBF160016079E4C227B4287249C23DE4EEE31AFFED39BE5E47596A6247B",
+      "targetHash": "9C481CB82F7A12182EF6C9627CA681034A35FB3D0E16460A8CEB9C4194448E0C",
       "operations": [
         {
           "container": null,
@@ -192,7 +192,7 @@
       "project": "C",
       "target": "build",
       "configurationTarget": {
-        "hash": "7CBFCD2D010F460CED07F894949A860B35492555250E183E1BEB1C76EFB8181B",
+        "hash": "5C7E7DFFA261BEF9A0C49DE6F3304DD9C89611A612E930192A151032A71FAD9C",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -202,7 +202,7 @@
         ],
         "operations": [
           {
-            "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+            "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
             "container": null,
             "containerVariables": [],
             "extension": "@shell",
@@ -219,7 +219,7 @@
             ]
           },
           {
-            "hash": "8020766CA6489DE8B88803B5BE7CBC336B9BB27FEE455F2AA4A96306A85EB557",
+            "hash": "F639A19EC2B9D128AA9827C17B393FE63EBEBAF37E3F083EB60EE735E1F5A630",
             "container": null,
             "containerVariables": [],
             "extension": "@npm",
@@ -240,7 +240,7 @@
         "dist/"
       ],
       "projectHash": "429BA3285F3F1AB8712C6475C79FBCDCA29DFABDDDB30D7B56828B382506D3E9",
-      "targetHash": "765010FC9C2C165C213A8B0950A97808774A9A8E4DD9F39F639DB69860F04679",
+      "targetHash": "9A282733134758E92F4F614FF97F458F13FFEF10412EB156926367897AB82242",
       "operations": [
         {
           "container": null,
@@ -291,7 +291,7 @@
       "project": "D",
       "target": "build",
       "configurationTarget": {
-        "hash": "6E8C12A2191A68C0FB487801C6B0DE041AE5E838E618AC904F835885E713C1D6",
+        "hash": "8F2185E438FCE288BDB21FD53361C11CCEA977302BF8736BA6BE107203827A7C",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -306,7 +306,7 @@
         ],
         "operations": [
           {
-            "hash": "49C77F0CC375A791BF822BAA5F2D11EA68FC0FE0C628ACD1863BAF7ED6649BEC",
+            "hash": "CEA159C860EAAD627DB52237F71B27FE2A6E5E652F32DDEA82AEFEF47152B360",
             "container": null,
             "containerVariables": [],
             "extension": "@dotnet",
@@ -331,7 +331,7 @@
         "obj/*.targets"
       ],
       "projectHash": "48EF5EAF4D5BF0D575315F0C1901BCF5BC83DB8D22530E496764B8BC328FE3B0",
-      "targetHash": "97928F3FC667BDC0E61A90E520D885DB84A1A4D506E67AF015FFBDF63013C5D0",
+      "targetHash": "F20B22D62053D00BF1815159B3B3A53F7FA166B55CB7FA44715B0CF0C6A0F668",
       "operations": [
         {
           "container": null,
@@ -356,7 +356,7 @@
       "project": "E",
       "target": "build",
       "configurationTarget": {
-        "hash": "6E8C12A2191A68C0FB487801C6B0DE041AE5E838E618AC904F835885E713C1D6",
+        "hash": "8F2185E438FCE288BDB21FD53361C11CCEA977302BF8736BA6BE107203827A7C",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -371,7 +371,7 @@
         ],
         "operations": [
           {
-            "hash": "49C77F0CC375A791BF822BAA5F2D11EA68FC0FE0C628ACD1863BAF7ED6649BEC",
+            "hash": "CEA159C860EAAD627DB52237F71B27FE2A6E5E652F32DDEA82AEFEF47152B360",
             "container": null,
             "containerVariables": [],
             "extension": "@dotnet",
@@ -396,7 +396,7 @@
         "obj/*.targets"
       ],
       "projectHash": "C0258BC9A2BBDE8B5300E3594D728190C18D187B421A690AABE51B589ED7E2FA",
-      "targetHash": "B61D947D93CAA67B9A289FCDF5CE5151F0B79580E519BFFF7BCCF97A42604FAB",
+      "targetHash": "31CB56B5B18025C7F093AB715A6776C15E545D54CCB514FD84982B95D9BAD3C7",
       "operations": [
         {
           "container": null,
@@ -421,7 +421,7 @@
       "project": "F",
       "target": "build",
       "configurationTarget": {
-        "hash": "3E35FE4CDBC58941D9C1FD7D9ACAC561D8397441268E863F8BFDD72EC9AE1E1A",
+        "hash": "AB4A209061EF1E489C6EE1C1A18CEAF7627A67112E95B75EF6937B7C5A488BF2",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -431,7 +431,7 @@
         ],
         "operations": [
           {
-            "hash": "8020766CA6489DE8B88803B5BE7CBC336B9BB27FEE455F2AA4A96306A85EB557",
+            "hash": "F639A19EC2B9D128AA9827C17B393FE63EBEBAF37E3F083EB60EE735E1F5A630",
             "container": null,
             "containerVariables": [],
             "extension": "@npm",
@@ -452,7 +452,7 @@
         "dist/"
       ],
       "projectHash": "4189AF367DD05BFA3DD8519B640CE28F48E188BFEA9F77C4085E0967DFFA9DB5",
-      "targetHash": "24F5134247026320EDCABDA652FDC752CA576ED27E4898B9C4C2972E2992E194",
+      "targetHash": "AF1ABB2B86E7767BB9F2688D91B62B0FBA0F98090F2495960DF2F59F5B0925C6",
       "operations": [
         {
           "container": null,
@@ -490,7 +490,7 @@
       "project": "G",
       "target": "build",
       "configurationTarget": {
-        "hash": "3E35FE4CDBC58941D9C1FD7D9ACAC561D8397441268E863F8BFDD72EC9AE1E1A",
+        "hash": "AB4A209061EF1E489C6EE1C1A18CEAF7627A67112E95B75EF6937B7C5A488BF2",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -500,7 +500,7 @@
         ],
         "operations": [
           {
-            "hash": "8020766CA6489DE8B88803B5BE7CBC336B9BB27FEE455F2AA4A96306A85EB557",
+            "hash": "F639A19EC2B9D128AA9827C17B393FE63EBEBAF37E3F083EB60EE735E1F5A630",
             "container": null,
             "containerVariables": [],
             "extension": "@npm",
@@ -520,7 +520,7 @@
         "dist/"
       ],
       "projectHash": "BAD12DC7581DAE34275B88A0C98FAABBDBB7A1969FC0C091F8FA82446A8509B9",
-      "targetHash": "A2410BED8127F9D6EE73671494BAF4B05735024377CBBAE8001F825405716B4F",
+      "targetHash": "F48C797AFAD6E8B0B890E681B40A890328330F5BB66886545FB4A3A335D683DA",
       "operations": [
         {
           "container": null,

--- a/tests/cluster-layers/results/terrabuild-debug.config.json
+++ b/tests/cluster-layers/results/terrabuild-debug.config.json
@@ -32,7 +32,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "B942B51B15FA8E4F694D5CE107303EC8D5E9EED56CFF35EBC02DC4C8C195B882",
+          "hash": "C53C9169120094BA775853CA620C100D989CF1EE983D8AAFE6E992E61C52EDE6",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -47,7 +47,7 @@
           ],
           "operations": [
             {
-              "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+              "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
               "container": null,
               "containerVariables": [],
               "extension": "@shell",
@@ -64,7 +64,7 @@
               ]
             },
             {
-              "hash": "49C77F0CC375A791BF822BAA5F2D11EA68FC0FE0C628ACD1863BAF7ED6649BEC",
+              "hash": "CEA159C860EAAD627DB52237F71B27FE2A6E5E652F32DDEA82AEFEF47152B360",
               "container": null,
               "containerVariables": [],
               "extension": "@dotnet",
@@ -91,7 +91,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "B942B51B15FA8E4F694D5CE107303EC8D5E9EED56CFF35EBC02DC4C8C195B882",
+          "hash": "C53C9169120094BA775853CA620C100D989CF1EE983D8AAFE6E992E61C52EDE6",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -106,7 +106,7 @@
           ],
           "operations": [
             {
-              "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+              "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
               "container": null,
               "containerVariables": [],
               "extension": "@shell",
@@ -123,7 +123,7 @@
               ]
             },
             {
-              "hash": "49C77F0CC375A791BF822BAA5F2D11EA68FC0FE0C628ACD1863BAF7ED6649BEC",
+              "hash": "CEA159C860EAAD627DB52237F71B27FE2A6E5E652F32DDEA82AEFEF47152B360",
               "container": null,
               "containerVariables": [],
               "extension": "@dotnet",
@@ -153,7 +153,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "7CBFCD2D010F460CED07F894949A860B35492555250E183E1BEB1C76EFB8181B",
+          "hash": "5C7E7DFFA261BEF9A0C49DE6F3304DD9C89611A612E930192A151032A71FAD9C",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -163,7 +163,7 @@
           ],
           "operations": [
             {
-              "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+              "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
               "container": null,
               "containerVariables": [],
               "extension": "@shell",
@@ -180,7 +180,7 @@
               ]
             },
             {
-              "hash": "8020766CA6489DE8B88803B5BE7CBC336B9BB27FEE455F2AA4A96306A85EB557",
+              "hash": "F639A19EC2B9D128AA9827C17B393FE63EBEBAF37E3F083EB60EE735E1F5A630",
               "container": null,
               "containerVariables": [],
               "extension": "@npm",
@@ -209,7 +209,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "6E8C12A2191A68C0FB487801C6B0DE041AE5E838E618AC904F835885E713C1D6",
+          "hash": "8F2185E438FCE288BDB21FD53361C11CCEA977302BF8736BA6BE107203827A7C",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -224,7 +224,7 @@
           ],
           "operations": [
             {
-              "hash": "49C77F0CC375A791BF822BAA5F2D11EA68FC0FE0C628ACD1863BAF7ED6649BEC",
+              "hash": "CEA159C860EAAD627DB52237F71B27FE2A6E5E652F32DDEA82AEFEF47152B360",
               "container": null,
               "containerVariables": [],
               "extension": "@dotnet",
@@ -253,7 +253,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "6E8C12A2191A68C0FB487801C6B0DE041AE5E838E618AC904F835885E713C1D6",
+          "hash": "8F2185E438FCE288BDB21FD53361C11CCEA977302BF8736BA6BE107203827A7C",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -268,7 +268,7 @@
           ],
           "operations": [
             {
-              "hash": "49C77F0CC375A791BF822BAA5F2D11EA68FC0FE0C628ACD1863BAF7ED6649BEC",
+              "hash": "CEA159C860EAAD627DB52237F71B27FE2A6E5E652F32DDEA82AEFEF47152B360",
               "container": null,
               "containerVariables": [],
               "extension": "@dotnet",
@@ -298,7 +298,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "3E35FE4CDBC58941D9C1FD7D9ACAC561D8397441268E863F8BFDD72EC9AE1E1A",
+          "hash": "AB4A209061EF1E489C6EE1C1A18CEAF7627A67112E95B75EF6937B7C5A488BF2",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -308,7 +308,7 @@
           ],
           "operations": [
             {
-              "hash": "8020766CA6489DE8B88803B5BE7CBC336B9BB27FEE455F2AA4A96306A85EB557",
+              "hash": "F639A19EC2B9D128AA9827C17B393FE63EBEBAF37E3F083EB60EE735E1F5A630",
               "container": null,
               "containerVariables": [],
               "extension": "@npm",
@@ -337,7 +337,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "3E35FE4CDBC58941D9C1FD7D9ACAC561D8397441268E863F8BFDD72EC9AE1E1A",
+          "hash": "AB4A209061EF1E489C6EE1C1A18CEAF7627A67112E95B75EF6937B7C5A488BF2",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -347,7 +347,7 @@
           ],
           "operations": [
             {
-              "hash": "8020766CA6489DE8B88803B5BE7CBC336B9BB27FEE455F2AA4A96306A85EB557",
+              "hash": "F639A19EC2B9D128AA9827C17B393FE63EBEBAF37E3F083EB60EE735E1F5A630",
               "container": null,
               "containerVariables": [],
               "extension": "@npm",

--- a/tests/multirefs/results/terrabuild-debug.build-graph.json
+++ b/tests/multirefs/results/terrabuild-debug.build-graph.json
@@ -6,7 +6,7 @@
       "project": "A",
       "target": "build",
       "configurationTarget": {
-        "hash": "8B56DAA76BB451252D58A9AFF5D2E5A77D0568D8681204549E53A422C9FBDBF0",
+        "hash": "0341B3880E8535A9BAFF30EEE460728143051EF2E2C2E028EAEA72F125282841",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -14,7 +14,7 @@
         "outputs": [],
         "operations": [
           {
-            "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+            "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
             "container": null,
             "containerVariables": [],
             "extension": "@shell",
@@ -38,7 +38,7 @@
       ],
       "outputs": [],
       "projectHash": "50F53DAE0A28CB085245C3DAA8E068FA1026C7B0A13395C1A60BEE8B56DDA77E",
-      "targetHash": "65DBBF9ADFB332D1EFABD6FFE9C3F09779FF5D7F7DC853C5567A2178ADC5E87B",
+      "targetHash": "212CAFA2C7707FFDF91D257F2693EBBB516213880324A4653F23391163967766",
       "operations": [
         {
           "container": null,
@@ -63,7 +63,7 @@
       "project": "B",
       "target": "build",
       "configurationTarget": {
-        "hash": "8B56DAA76BB451252D58A9AFF5D2E5A77D0568D8681204549E53A422C9FBDBF0",
+        "hash": "0341B3880E8535A9BAFF30EEE460728143051EF2E2C2E028EAEA72F125282841",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -71,7 +71,7 @@
         "outputs": [],
         "operations": [
           {
-            "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+            "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
             "container": null,
             "containerVariables": [],
             "extension": "@shell",
@@ -94,7 +94,7 @@
       ],
       "outputs": [],
       "projectHash": "0058E0305878067C8E3793E674633FEE00820654CFD00805FD0664FA9033718F",
-      "targetHash": "AB2E8E2EB65DCF6223D4B42D1C909AAFD1B78C6D84D979FDB609702F3AEFACA2",
+      "targetHash": "83693BFDFA2B5F93BE9252B3B48C56B69F4C02B6FC8ED96648C1D2E320D51688",
       "operations": [
         {
           "container": null,
@@ -119,7 +119,7 @@
       "project": "C",
       "target": "build",
       "configurationTarget": {
-        "hash": "8B56DAA76BB451252D58A9AFF5D2E5A77D0568D8681204549E53A422C9FBDBF0",
+        "hash": "0341B3880E8535A9BAFF30EEE460728143051EF2E2C2E028EAEA72F125282841",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -127,7 +127,7 @@
         "outputs": [],
         "operations": [
           {
-            "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+            "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
             "container": null,
             "containerVariables": [],
             "extension": "@shell",
@@ -148,7 +148,7 @@
       "dependencies": [],
       "outputs": [],
       "projectHash": "0EFEA7392B648CE721962FA473E3D5E1B52006332B3DC8ED8B81FB24D2101481",
-      "targetHash": "A9BAEAAA1C770FBEF9E8DA9F1DD54CC031D9BE0240F2919770B170B4C4E0ECE8",
+      "targetHash": "432FECF0802964A3B58ED74BD862334CC8988AD76774B30E9C7F9798E1A2E06E",
       "operations": [
         {
           "container": null,

--- a/tests/multirefs/results/terrabuild-debug.config.json
+++ b/tests/multirefs/results/terrabuild-debug.config.json
@@ -57,7 +57,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "8B56DAA76BB451252D58A9AFF5D2E5A77D0568D8681204549E53A422C9FBDBF0",
+          "hash": "0341B3880E8535A9BAFF30EEE460728143051EF2E2C2E028EAEA72F125282841",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -65,7 +65,7 @@
           "outputs": [],
           "operations": [
             {
-              "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+              "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
               "container": null,
               "containerVariables": [],
               "extension": "@shell",
@@ -97,7 +97,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "8B56DAA76BB451252D58A9AFF5D2E5A77D0568D8681204549E53A422C9FBDBF0",
+          "hash": "0341B3880E8535A9BAFF30EEE460728143051EF2E2C2E028EAEA72F125282841",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -105,7 +105,7 @@
           "outputs": [],
           "operations": [
             {
-              "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+              "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
               "container": null,
               "containerVariables": [],
               "extension": "@shell",
@@ -135,7 +135,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "8B56DAA76BB451252D58A9AFF5D2E5A77D0568D8681204549E53A422C9FBDBF0",
+          "hash": "0341B3880E8535A9BAFF30EEE460728143051EF2E2C2E028EAEA72F125282841",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -143,7 +143,7 @@
           "outputs": [],
           "operations": [
             {
-              "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+              "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
               "container": null,
               "containerVariables": [],
               "extension": "@shell",

--- a/tests/simple/results/terrabuild-debug.build-graph.json
+++ b/tests/simple/results/terrabuild-debug.build-graph.json
@@ -6,7 +6,7 @@
       "project": "deployments/terraform-deploy",
       "target": "build",
       "configurationTarget": {
-        "hash": "FD4E492BBC14063F951BD573395F7044BB64448F0CCA60851019067618B27C70",
+        "hash": "558D543D764E88E2DC4D9002F7A5B9AE683EF3ABC1978ACD515D5E13358DE3C5",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -16,7 +16,7 @@
         ],
         "operations": [
           {
-            "hash": "8BA1A0F5EC354F7CA3A6E46BAD0B652F6767230BC5323A1AB1841ED9EF7B0AC2",
+            "hash": "CC1EC86EC45E69DBDCD61330F7E9BC1EBE9B2475F37AAC2A67600B64D503FE11",
             "container": null,
             "containerVariables": [],
             "extension": "@terraform",
@@ -55,7 +55,7 @@
         "*.planfile"
       ],
       "projectHash": "825FA904BFCC88377654659B6021610C28A2856B44369D63969377A7699A4AF3",
-      "targetHash": "04248F14331991CE6BFB33A59B4A2B2E129E1B5702DB0A9200719D8344D18C0E",
+      "targetHash": "A5653BEA7F7AED397EF01AF82159411525AD55119BCA83C8A100DA0C527DE31B",
       "operations": [
         {
           "container": null,
@@ -110,7 +110,7 @@
       "project": "libraries/dotnet-lib",
       "target": "build",
       "configurationTarget": {
-        "hash": "A649F97242CEFE0737701431018990998E0849E9CB990AB8B9C0B1CA39FD9C6F",
+        "hash": "A77A8BB09AE6C2F8776D290521292CBFF294061AAB23865902ACB94E2E455490",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -125,7 +125,7 @@
         ],
         "operations": [
           {
-            "hash": "F3D3F187F94C685E6C8F336F181B75DAE61F04FFE23AF4E7F5B858CAA1D5DFC6",
+            "hash": "43FA4FF74E2825A696B6004C5044FBB69D2BE7EB9BEAC01DB0B885D6F7B81B39",
             "container": null,
             "containerVariables": [],
             "extension": "@dotnet",
@@ -153,7 +153,7 @@
         "obj/*.targets"
       ],
       "projectHash": "666908E6236D9394711779EEAB166ED8BC6341DF1EEEF724C7DE083D0C9709DC",
-      "targetHash": "2B54545A15F538FD93FD4ADAAF642161D3E25A5BBC709C099D3EB615CCC22E9D",
+      "targetHash": "C9796472B22BC56383AE800294AB0B1EB64BD3A8A799D3BDF4E49134AF9F4338",
       "operations": [
         {
           "container": null,
@@ -178,7 +178,7 @@
       "project": "libraries/shell-lib",
       "target": "build",
       "configurationTarget": {
-        "hash": "8B56DAA76BB451252D58A9AFF5D2E5A77D0568D8681204549E53A422C9FBDBF0",
+        "hash": "0341B3880E8535A9BAFF30EEE460728143051EF2E2C2E028EAEA72F125282841",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -186,7 +186,7 @@
         "outputs": [],
         "operations": [
           {
-            "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+            "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
             "container": null,
             "containerVariables": [],
             "extension": "@shell",
@@ -207,7 +207,7 @@
       "dependencies": [],
       "outputs": [],
       "projectHash": "60F9371D05141EC9C0E9CC759730C62EC37C01D9EEB1330EFE2737AA01F557A6",
-      "targetHash": "C432095DAA33C07EE1C2E6A4F053F065373D320CB24C6C500259772EF208608E",
+      "targetHash": "AFB46B9888301BC44A7A5EFF1BA92E706B1D54B149C537DF91F8D1916EBF6049",
       "operations": [
         {
           "container": null,
@@ -232,7 +232,7 @@
       "project": "projects/dotnet-app",
       "target": "build",
       "configurationTarget": {
-        "hash": "A649F97242CEFE0737701431018990998E0849E9CB990AB8B9C0B1CA39FD9C6F",
+        "hash": "A77A8BB09AE6C2F8776D290521292CBFF294061AAB23865902ACB94E2E455490",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -247,7 +247,7 @@
         ],
         "operations": [
           {
-            "hash": "F3D3F187F94C685E6C8F336F181B75DAE61F04FFE23AF4E7F5B858CAA1D5DFC6",
+            "hash": "43FA4FF74E2825A696B6004C5044FBB69D2BE7EB9BEAC01DB0B885D6F7B81B39",
             "container": null,
             "containerVariables": [],
             "extension": "@dotnet",
@@ -277,7 +277,7 @@
         "obj/*.targets"
       ],
       "projectHash": "3EE0CC7786480EF592E5E7FB73BC2691CA3328D8CDFC5CFDA16CBEE006389364",
-      "targetHash": "DDBE336631053045F003A619F764069C3644E78FAAE597140FCC2B968FB31989",
+      "targetHash": "F5A09E8ADE35F306D5D2218B830ACF1E0272022B696E41CCC474C7409E50B7F7",
       "operations": [
         {
           "container": null,
@@ -302,7 +302,7 @@
       "project": "projects/make-app",
       "target": "build",
       "configurationTarget": {
-        "hash": "D75E1B5F09A68010CF5A342EF04AB73E0FDE53F31E8A83B5DF5FF248DE965D24",
+        "hash": "DDB2BEF64A6F49A17550F90874551200DCCCE242ED16A281EE476510DF3D6E70",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -312,7 +312,7 @@
         ],
         "operations": [
           {
-            "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+            "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
             "container": null,
             "containerVariables": [],
             "extension": "@shell",
@@ -329,7 +329,7 @@
             ]
           },
           {
-            "hash": "60078A7AEF8007B4B5DC060CE7889241884A0FDE6A440EB5732A3FD31ED2D857",
+            "hash": "6698E1890E9170D6F14DC92E94D5F340B227D6AC23F4B13F0AAA398A6D0A5C20",
             "container": null,
             "containerVariables": [],
             "extension": "@make",
@@ -359,7 +359,7 @@
         "dist"
       ],
       "projectHash": "47A18E4D676C50894D393158B4C1CE5C7736BD65C6C15CC542E764E876CB2E68",
-      "targetHash": "9BDFE24BBEFCEA185D8216BFBB1B52C3CA61B82F25A512ACD9E66BCBFE1B0458",
+      "targetHash": "0F7CD2896337326C3501CC348F771251B787B4DA93B101763134312DC58138C5",
       "operations": [
         {
           "container": null,
@@ -397,7 +397,7 @@
       "project": "projects/npm-app",
       "target": "build",
       "configurationTarget": {
-        "hash": "3E35FE4CDBC58941D9C1FD7D9ACAC561D8397441268E863F8BFDD72EC9AE1E1A",
+        "hash": "A11BAF927B2D99D6A1D297ABB919A342B3812C0BB76539941D8DE8DB15BCA5CF",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -407,7 +407,7 @@
         ],
         "operations": [
           {
-            "hash": "8020766CA6489DE8B88803B5BE7CBC336B9BB27FEE455F2AA4A96306A85EB557",
+            "hash": "60DE3F4D7EA1AD9FFDC44065ED4329B4D45FAD88B2378D03F07864598170C8F0",
             "container": "node:20",
             "containerVariables": [],
             "extension": "@npm",
@@ -425,7 +425,7 @@
         "dist/"
       ],
       "projectHash": "A440C869D51BECC00CA8E1AADDFEEF52676E0E9A543260A6970ED95CB00EB63E",
-      "targetHash": "B864E5E2441D5ABDFB79E333250443A85D34E2FA72C676175DA6CEFE84A30999",
+      "targetHash": "8F14AB143EE9F095804557AA7ED5FE1963A94C1B7FEC334BFBEB68CEBEEF43B4",
       "operations": [
         {
           "container": "node:20",
@@ -463,7 +463,7 @@
       "project": "projects/rust-app",
       "target": "build",
       "configurationTarget": {
-        "hash": "11AAF8064C94EB13A5DBBABB74D237968373D8BA36EDC3C0DAE6A303E3FB71FE",
+        "hash": "223C3EEB2DF2F8E0B63197B401B77808F5CD208A0E7F9283D00BE9A4DB31A843",
         "rebuild": false,
         "dependsOn": [
           "^build"
@@ -474,7 +474,7 @@
         ],
         "operations": [
           {
-            "hash": "A8ECD5C3F84E52E8C5C9B4BC04D9FDDC0FA81CE3FE190F10117DE2759DDAAC1D",
+            "hash": "204DF94006509227A57A9C6725273A44599072093D52E768BA5E47A36AB650E8",
             "container": "rust:1.81.0-slim",
             "containerVariables": [],
             "extension": "@cargo",
@@ -493,7 +493,7 @@
         "target/release/"
       ],
       "projectHash": "15CDC8C81F5A3D2B0215AE61D6D429F52345A71EE01246776049C72C2351CAE1",
-      "targetHash": "A994964CCA6A6A873538561EDBAF950D4308A0925D87D1D034FE9FCA0F900E4A",
+      "targetHash": "95D186996CAF56B5E6C7F0A12B5D1A51322E33266944F7ACC50855597BC6304F",
       "operations": [
         {
           "container": "rust:1.81.0-slim",

--- a/tests/simple/results/terrabuild-debug.config.json
+++ b/tests/simple/results/terrabuild-debug.config.json
@@ -73,7 +73,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "FD4E492BBC14063F951BD573395F7044BB64448F0CCA60851019067618B27C70",
+          "hash": "558D543D764E88E2DC4D9002F7A5B9AE683EF3ABC1978ACD515D5E13358DE3C5",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -83,7 +83,7 @@
           ],
           "operations": [
             {
-              "hash": "8BA1A0F5EC354F7CA3A6E46BAD0B652F6767230BC5323A1AB1841ED9EF7B0AC2",
+              "hash": "CC1EC86EC45E69DBDCD61330F7E9BC1EBE9B2475F37AAC2A67600B64D503FE11",
               "container": null,
               "containerVariables": [],
               "extension": "@terraform",
@@ -115,7 +115,7 @@
           ]
         },
         "deploy": {
-          "hash": "43974ADCF2902200291242CF6A7E94FC3FED2764DFC627CF410BCDA6283AD8AF",
+          "hash": "BE6C8A8A87E630C6FE24124277ACB6DD3B5ADBADB6D467292B724BC6540C7B92",
           "rebuild": false,
           "dependsOn": [
             "push"
@@ -125,7 +125,7 @@
           ],
           "operations": [
             {
-              "hash": "84DDD67346617D06E275A0B16955228851AFA5211E0262DF72EB4CD8D9917092",
+              "hash": "9CFD86F037EA910944E73924C39821DEE1386F0FB345ABFE50D472C84DEFDB83",
               "container": null,
               "containerVariables": [],
               "extension": "@terraform",
@@ -159,7 +159,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "A649F97242CEFE0737701431018990998E0849E9CB990AB8B9C0B1CA39FD9C6F",
+          "hash": "A77A8BB09AE6C2F8776D290521292CBFF294061AAB23865902ACB94E2E455490",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -174,7 +174,7 @@
           ],
           "operations": [
             {
-              "hash": "F3D3F187F94C685E6C8F336F181B75DAE61F04FFE23AF4E7F5B858CAA1D5DFC6",
+              "hash": "43FA4FF74E2825A696B6004C5044FBB69D2BE7EB9BEAC01DB0B885D6F7B81B39",
               "container": null,
               "containerVariables": [],
               "extension": "@dotnet",
@@ -204,7 +204,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "8B56DAA76BB451252D58A9AFF5D2E5A77D0568D8681204549E53A422C9FBDBF0",
+          "hash": "0341B3880E8535A9BAFF30EEE460728143051EF2E2C2E028EAEA72F125282841",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -212,7 +212,7 @@
           "outputs": [],
           "operations": [
             {
-              "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+              "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
               "container": null,
               "containerVariables": [],
               "extension": "@shell",
@@ -248,7 +248,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "A649F97242CEFE0737701431018990998E0849E9CB990AB8B9C0B1CA39FD9C6F",
+          "hash": "A77A8BB09AE6C2F8776D290521292CBFF294061AAB23865902ACB94E2E455490",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -263,7 +263,7 @@
           ],
           "operations": [
             {
-              "hash": "F3D3F187F94C685E6C8F336F181B75DAE61F04FFE23AF4E7F5B858CAA1D5DFC6",
+              "hash": "43FA4FF74E2825A696B6004C5044FBB69D2BE7EB9BEAC01DB0B885D6F7B81B39",
               "container": null,
               "containerVariables": [],
               "extension": "@dotnet",
@@ -282,7 +282,7 @@
           ]
         },
         "dist": {
-          "hash": "1C058F7AEE7F28E71B314DFF9426988F723EC1420B6EC2E39F5320CABC15CAB4",
+          "hash": "36DD90FD147D8AFE40A2CFE2944E006D3256F637EE7379974EBF2A54ED730DF6",
           "rebuild": false,
           "dependsOn": [
             "build"
@@ -297,7 +297,7 @@
           ],
           "operations": [
             {
-              "hash": "1311F62C9C27453F0B03B878877FCB24E63B6EB246A8B3696689DB068197846E",
+              "hash": "A9DE21EC18803ED6B7650FD9BF6985C6C46F86FF2E00E63BDE16495A0EE47091",
               "container": null,
               "containerVariables": [],
               "extension": "@dotnet",
@@ -316,7 +316,7 @@
           ]
         },
         "docker": {
-          "hash": "B2968AD5F493351AE9DDBE6B6349DAF6CA18C306DCE1DE55C51BEBA430CD3A78",
+          "hash": "F10EDA1717829CD3B50D0215D79AFB6F0FDEA1645918532B446B498838DF987B",
           "rebuild": false,
           "dependsOn": [
             "dist"
@@ -331,7 +331,7 @@
           ],
           "operations": [
             {
-              "hash": "2FBDD2F2C31193CA71F958A6F4B9A9579FB1AFB4D5075063C3826EF9C5F1BE28",
+              "hash": "C1E251CB223FB9ABD7D51AA7BC7AFE7C6E19E7620E7924704F6C6A78103E4EEE",
               "container": null,
               "containerVariables": [],
               "extension": "@docker",
@@ -359,7 +359,7 @@
           ]
         },
         "push": {
-          "hash": "DCE5C493853172D5CA5AF33AD12D2D6DE0EEA440D430C23100216B0E3AC335A9",
+          "hash": "296CB2CBCB0FD811AC2D7AC639105F6C21F5A7FE14681D2144760DB6BE34D2FB",
           "rebuild": false,
           "dependsOn": [
             "docker"
@@ -374,7 +374,7 @@
           ],
           "operations": [
             {
-              "hash": "AEF1A65D32F57084416DFD132194426A5BA16C83F444DD18070A887A68C1CA91",
+              "hash": "BB0DD618A97C6F53CBFF8981235A217FB8994CFAFC6808E92A69C048B3B01C31",
               "container": null,
               "containerVariables": [],
               "extension": "@docker",
@@ -419,7 +419,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "D75E1B5F09A68010CF5A342EF04AB73E0FDE53F31E8A83B5DF5FF248DE965D24",
+          "hash": "DDB2BEF64A6F49A17550F90874551200DCCCE242ED16A281EE476510DF3D6E70",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -429,7 +429,7 @@
           ],
           "operations": [
             {
-              "hash": "9A6077978162678FAB571475352B8B0AF63E6C2EED1A61094BCBDD35D8BDCCB2",
+              "hash": "54D19E217002AB89DE07F5FD0BD4C6D9377B9BBC763DD1FE2C09FC56953343B2",
               "container": null,
               "containerVariables": [],
               "extension": "@shell",
@@ -446,7 +446,7 @@
               ]
             },
             {
-              "hash": "60078A7AEF8007B4B5DC060CE7889241884A0FDE6A440EB5732A3FD31ED2D857",
+              "hash": "6698E1890E9170D6F14DC92E94D5F340B227D6AC23F4B13F0AAA398A6D0A5C20",
               "container": null,
               "containerVariables": [],
               "extension": "@make",
@@ -487,7 +487,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "3E35FE4CDBC58941D9C1FD7D9ACAC561D8397441268E863F8BFDD72EC9AE1E1A",
+          "hash": "A11BAF927B2D99D6A1D297ABB919A342B3812C0BB76539941D8DE8DB15BCA5CF",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -497,7 +497,7 @@
           ],
           "operations": [
             {
-              "hash": "8020766CA6489DE8B88803B5BE7CBC336B9BB27FEE455F2AA4A96306A85EB557",
+              "hash": "60DE3F4D7EA1AD9FFDC44065ED4329B4D45FAD88B2378D03F07864598170C8F0",
               "container": "node:20",
               "containerVariables": [],
               "extension": "@npm",
@@ -527,7 +527,7 @@
       ],
       "targets": {
         "build": {
-          "hash": "11AAF8064C94EB13A5DBBABB74D237968373D8BA36EDC3C0DAE6A303E3FB71FE",
+          "hash": "223C3EEB2DF2F8E0B63197B401B77808F5CD208A0E7F9283D00BE9A4DB31A843",
           "rebuild": false,
           "dependsOn": [
             "^build"
@@ -538,7 +538,7 @@
           ],
           "operations": [
             {
-              "hash": "A8ECD5C3F84E52E8C5C9B4BC04D9FDDC0FA81CE3FE190F10117DE2759DDAAC1D",
+              "hash": "204DF94006509227A57A9C6725273A44599072093D52E768BA5E47A36AB650E8",
               "container": "rust:1.81.0-slim",
               "containerVariables": [],
               "extension": "@cargo",


### PR DESCRIPTION
Container was missing from the target command. Now, changing container (for eg updating the tag) leads to recompilation of the target.