### PR TITLE
Add Podman support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,12 +158,12 @@ endef
 # $(call run_integration_test, tests/cluster-layers, run build --force --debug -p 2 --logs)
 
 self-test-cluster-layers:
-	$(call run_integration_test, tests/cluster-layers, run build --force --debug -p 2 --logs)
+	$(call run_integration_test, tests/cluster-layers, run build --force --debug -p 2 --logs --containertool docker)
 
 self-test-multirefs:
-	$(call run_integration_test, tests/multirefs, run build --force --debug -p 2 --logs)
+	$(call run_integration_test, tests/multirefs, run build --force --debug -p 2 --logs --containertool docker)
 
 self-test-simple:
-	$(call run_integration_test, tests/simple, run build --force --debug -p 2 --logs)
+	$(call run_integration_test, tests/simple, run build --force --debug -p 2 --logs --containertool docker)
 
 self-test-all: publish self-test-cluster-layers self-test-multirefs self-test-simple

--- a/src/Terrabuild.Extensibility/Extensions.fs
+++ b/src/Terrabuild.Extensibility/Extensions.fs
@@ -31,6 +31,7 @@ type ActionContext = {
     CI: bool
     Command: string
     Hash: string
+    ContainerTool: string option
 }
 
 [<RequireQualifiedAccess>]

--- a/src/Terrabuild.Extensions/Cargo.fs
+++ b/src/Terrabuild.Extensions/Cargo.fs
@@ -19,7 +19,6 @@ module CargoHelpers =
 /// <summary>
 /// Add support for cargo (rust) projects.
 /// </summary>
-
 type Cargo() =
 
     /// <summary>

--- a/src/Terrabuild.Extensions/Container.fs
+++ b/src/Terrabuild.Extensions/Container.fs
@@ -1,0 +1,83 @@
+namespace Terrabuild.Extensions
+
+open Terrabuild.Extensibility
+
+/// <summary>
+/// Add support for container projects using Docker or Podman/Skopeo.
+/// </summary>
+type Container() =
+
+    /// <summary>
+    /// Build a Dockerfile.
+    /// </summary>
+    /// <param name="dockerfile" example="&quot;Containerfile&quot;">Use alternative Containerfile. Default is Dockerfile.</param>
+    /// <param name="platform" required="false" example="&quot;linux/amd64&quot;">Target platform. Default is host.</param>
+    /// <param name="image" required="true" example="&quot;ghcr.io/example/project&quot;">Docker image to build.</param>
+    /// <param name="arguments" example="{ configuration: &quot;Release&quot; }">Named arguments to build image (see Dockerfile [ARG](https://docs.docker.com/reference/dockerfile/#arg)).</param> 
+    static member build (context: ActionContext) (dockerfile: string option) (platform: string option) (image: string) (arguments: Map<string, string>) (tool: string option) =
+        let containerTool =
+            match tool with
+            | Some "podman" -> "podman"
+            | Some "docker" -> "docker"
+            | _ -> context.ContainerTool |> Option.defaultValue "docker"
+
+        let dockerfile = dockerfile |> Option.defaultValue "Dockerfile"
+
+        let platform =
+            match platform with
+            | Some platform -> $" --platform {platform}"
+            | _ -> ""
+
+        let args = arguments |> Seq.fold (fun acc kvp -> $"{acc} --build-arg {kvp.Key}=\"{kvp.Value}\"") ""
+
+        let ops = 
+            [
+                let buildArgs = $"build --file {dockerfile} --tag {image}:{context.Hash}{args}{platform} ."
+                if context.CI then
+                    shellOp containerTool buildArgs
+                    shellOp containerTool $"push {image}:{context.Hash}"
+                else
+                    shellOp containerTool buildArgs
+            ]
+
+        let cacheability =
+            if context.CI then Cacheability.Remote
+            else Cacheability.Local
+
+        execRequest cacheability ops
+
+
+    /// <summary>
+    /// Push target container image to registry.
+    /// </summary>
+    /// <param name="image" required="true" example="&quot;ghcr.io/example/project&quot;">Container image to build.</param>
+    /// <param name="tag" required="true" example="&quot;1.2.3-stable&quot;">Apply tag on image (use branch or tag otherwise).</param>
+    static member push (context: ActionContext) (image: string) (tag: string) (tool: string option) =
+        let containerTool =
+            match tool with
+            | Some "podman" -> "podman"
+            | Some "docker" -> "docker"
+            | _ -> context.ContainerTool |> Option.defaultValue "docker"
+
+        let ops =
+            match containerTool with
+            | "podman" ->
+                [
+                    if context.CI then
+                        shellOp "skopeo" $"copy {image}:{context.Hash} {image}:{tag}"
+                    else
+                        shellOp "podman" $"tag {image}:{context.Hash} {image}:{tag}"
+                ]
+            | _ ->
+                [
+                    if context.CI then
+                        shellOp "docker" $"buildx imagetools create -t {image}:{tag} {image}:{context.Hash}"
+                    else
+                        shellOp "docker" $"tag {image}:{context.Hash} {image}:{tag}"
+                ]
+
+        let cacheability =
+            if context.CI then Cacheability.Remote
+            else Cacheability.Local
+
+        execRequest cacheability ops

--- a/src/Terrabuild.Extensions/Docker.fs
+++ b/src/Terrabuild.Extensions/Docker.fs
@@ -2,7 +2,9 @@ namespace Terrabuild.Extensions
 
 open Terrabuild.Extensibility
 
-/// `terraform` extension provides commands to handle a Terraform project.
+/// <summary>
+/// Add support for Docker projects.
+/// </summary>
 type Docker() =
 
     /// <summary>
@@ -40,7 +42,7 @@ type Docker() =
 
 
     /// <summary>
-    /// Push a docker image to registry.
+    /// Push target container image to registry.
     /// </summary>
     /// <param name="image" required="true" example="&quot;ghcr.io/example/project&quot;">Docker image to build.</param>
     /// <param name="tag" required="true" example="&quot;1.2.3-stable&quot;">Apply tag on image (use branch or tag otherwise).</param>

--- a/src/Terrabuild.Extensions/Dotnet.fs
+++ b/src/Terrabuild.Extensions/Dotnet.fs
@@ -53,7 +53,6 @@ module DotnetHelpers =
 /// <summary>
 /// Add support for .net projects.
 /// </summary>
-
 type Dotnet() =
 
     static let buildRequest (context: ActionContext) buildOps =

--- a/src/Terrabuild.Extensions/Factory.fs
+++ b/src/Terrabuild.Extensions/Factory.fs
@@ -12,4 +12,5 @@ let systemScripts =
         "@shell", typeof<Shell>
         "@terraform", typeof<Terraform>
         "@cargo", typeof<Cargo>
+        "@container", typeof<Container>
     ]

--- a/src/Terrabuild.Extensions/Make.fs
+++ b/src/Terrabuild.Extensions/Make.fs
@@ -2,7 +2,9 @@ namespace Terrabuild.Extensions
 
 open Terrabuild.Extensibility
 
-/// `make` extension provides support for Makefile.
+/// <summary>
+/// Add support for Makefile.
+/// </summary>
 type Make() =
 
     /// <summary>

--- a/src/Terrabuild.Extensions/Terrabuild.Extensions.fsproj
+++ b/src/Terrabuild.Extensions/Terrabuild.Extensions.fsproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Compile Include="Cargo.fs" />
+    <Compile Include="Container.fs" />
     <Compile Include="Docker.fs" />
     <Compile Include="Dotnet.fs" />
     <Compile Include="Gradle.fs" />

--- a/src/Terrabuild.Extensions/Terraform.fs
+++ b/src/Terrabuild.Extensions/Terraform.fs
@@ -3,11 +3,13 @@ namespace Terrabuild.Extensions
 open Terrabuild.Extensibility
 
 
+/// <summary>
 /// `terraform` extension provides commands to handle a Terraform project.
 ///
 /// {{< callout type="warning"  >}}
 /// This extension relies on external Terraform state.
 /// {{< /callout >}}
+/// </summary>
 type Terraform() =
 
     /// <summary>

--- a/src/Terrabuild/CLI.fs
+++ b/src/Terrabuild/CLI.fs
@@ -44,6 +44,7 @@ type RunArgs =
     | [<Unique; AltCommandLine("-cs")>] CheckState
     | [<Unique; AltCommandLine("-n")>] Note of note:string
     | [<Unique; AltCommandLine("-t")>] Tag of tag:string
+    | [<Unique; AltCommandLine("-ct")>] ContainerTool of tool:string
     | [<Unique>] Logs
     | [<Unique; Inherit>] WhatIf
 with
@@ -64,6 +65,7 @@ with
             | Note _ -> "Note for the build."
             | Logs -> "Output logs for impacted projects."
             | Tag _ -> "Tag for build."
+            | ContainerTool _ -> "Container Tool to use (docker or podman)."
             | WhatIf -> "Prepare the action but do not apply."
 
 [<RequireQualifiedAccess>]

--- a/src/Terrabuild/CLI.fs
+++ b/src/Terrabuild/CLI.fs
@@ -2,6 +2,11 @@ module CLI
 open Argu
 
 [<RequireQualifiedAccess>]
+type ContainerTool =
+    | Docker
+    | Podman
+
+[<RequireQualifiedAccess>]
 type ScaffoldArgs =
     | [<Unique; AltCommandLine("-w")>] Workspace of path:string
     | [<Unique>] Force
@@ -44,7 +49,7 @@ type RunArgs =
     | [<Unique; AltCommandLine("-cs")>] CheckState
     | [<Unique; AltCommandLine("-n")>] Note of note:string
     | [<Unique; AltCommandLine("-t")>] Tag of tag:string
-    | [<Unique; AltCommandLine("-ct")>] ContainerTool of tool:string
+    | [<Unique; AltCommandLine("-ct")>] ContainerTool of tool:ContainerTool
     | [<Unique>] Logs
     | [<Unique; Inherit>] WhatIf
 with

--- a/src/Terrabuild/Contracts/ConfigOptions.fs
+++ b/src/Terrabuild/Contracts/ConfigOptions.fs
@@ -25,4 +25,5 @@ type Options = {
     Tag: string option
     Labels: string set option
     Variables: Map<string, string>
+    ContainerTool: string option
 }

--- a/src/Terrabuild/Core/Build.fs
+++ b/src/Terrabuild/Core/Build.fs
@@ -67,7 +67,7 @@ let execCommands (node: GraphDef.Node) (cacheEntry: Cache.IEntry) (options: Conf
     let allCommands =
         node.Operations
         |> List.map (fun operation ->
-            let cmd = "docker"
+            let cmd = options.ContainerTool |> Option.defaultValue "docker"
             let wsDir = Environment.CurrentDirectory
 
             let getContainerUserHome (container: string) =

--- a/src/Terrabuild/Core/Builder.fs
+++ b/src/Terrabuild/Core/Builder.fs
@@ -84,6 +84,7 @@ let build (options: ConfigOptions.Options) (configuration: Configuration.Workspa
                             Terrabuild.Extensibility.ActionContext.CI = options.CI.IsSome
                             Terrabuild.Extensibility.ActionContext.Command = operation.Command
                             Terrabuild.Extensibility.ActionContext.Hash = projectConfig.Hash
+                            Terrabuild.Extensibility.ActionContext.ContainerTool = options.ContainerTool
                         }
 
                         let parameters = 

--- a/src/Terrabuild/Core/Cache.fs
+++ b/src/Terrabuild/Core/Cache.fs
@@ -60,7 +60,9 @@ let private summaryFilename = "summary.json"
 let private originFilename = "origin"
 
 let terrabuildHome =
-    FS.combinePath (Environment.GetEnvironmentVariable("HOME")) ".terrabuild"
+    let tbDir = FS.combinePath (Environment.GetEnvironmentVariable("HOME")) ".terrabuild"
+    IO.createDirectory tbDir
+    tbDir
 
 let private buildCacheDirectory =
     let cacheDir = FS.combinePath terrabuildHome "buildcache"

--- a/src/Terrabuild/Core/Cache.fs
+++ b/src/Terrabuild/Core/Cache.fs
@@ -294,4 +294,5 @@ type Cache(storage: Contracts.IStorage) =
 
         member _.CreateHomeDir nodeHash: string =
             let homeDir = FS.combinePath homeDirectory nodeHash
+            IO.createDirectory homeDir
             homeDir

--- a/src/Terrabuild/PROJECT
+++ b/src/Terrabuild/PROJECT
@@ -4,7 +4,7 @@ project @dotnet {
                "dotnet"]
 }
 
-extension @docker {
+extension @container {
   defaults = {
     image: "ghcr.io/magnusopera/terrabuild"
   }

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -195,7 +195,11 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let logs = runArgs.Contains(RunArgs.Logs)
         let tag = runArgs.TryGetResult(RunArgs.Tag)
         let whatIf = runArgs.Contains(RunArgs.WhatIf)
-        let containerTool = runArgs.TryGetResult(RunArgs.ContainerTool)
+        let containerTool =
+            match runArgs.TryGetResult(RunArgs.ContainerTool) with
+            | Some ContainerTool.Docker -> Some "docker"
+            | Some ContainerTool.Podman -> Some "podman"
+            | _ -> None
 
         let options = { RunTargetOptions.Workspace = wsDir |> FS.fullPath
                         RunTargetOptions.WhatIf = whatIf

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -26,6 +26,7 @@ type RunTargetOptions = {
     Tag: string option
     Labels: string set option
     Variables: Map<string, string>
+    ContainerTool: string option
 }
 
 
@@ -117,6 +118,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
             ConfigOptions.Options.Tag = options.Tag
             ConfigOptions.Options.Labels = options.Labels
             ConfigOptions.Options.Variables = options.Variables
+            ConfigOptions.Options.ContainerTool = options.ContainerTool
         }
 
         if options.Debug then
@@ -192,7 +194,8 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let checkState = runArgs.Contains(RunArgs.CheckState)
         let logs = runArgs.Contains(RunArgs.Logs)
         let tag = runArgs.TryGetResult(RunArgs.Tag)
-        let whatIf = runArgs.Contains(RunArgs.WhatIf) 
+        let whatIf = runArgs.Contains(RunArgs.WhatIf)
+        let containerTool = runArgs.TryGetResult(RunArgs.ContainerTool)
 
         let options = { RunTargetOptions.Workspace = wsDir |> FS.fullPath
                         RunTargetOptions.WhatIf = whatIf
@@ -210,7 +213,8 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
                         RunTargetOptions.Note = note
                         RunTargetOptions.Tag = tag
                         RunTargetOptions.Labels = labels
-                        RunTargetOptions.Variables = variables }
+                        RunTargetOptions.Variables = variables
+                        RunTargetOptions.ContainerTool = containerTool }
         runTarget logs options
 
     let logs (logsArgs: ParseResults<LogsArgs>) =
@@ -225,6 +229,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let configuration = logsArgs.TryGetResult(LogsArgs.Configuration) |> Option.defaultValue "default" |> String.toLower
         let labels = logsArgs.TryGetResult(LogsArgs.Label) |> Option.map (fun labels -> labels |> Seq.map String.toLower |> Set)
         let variables = logsArgs.GetResults(LogsArgs.Variable) |> Seq.map (fun (k, v) -> k, v) |> Map
+
         let options = { RunTargetOptions.Workspace = wsDir |> FS.fullPath
                         RunTargetOptions.WhatIf = true
                         RunTargetOptions.Debug = debug
@@ -241,7 +246,8 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
                         RunTargetOptions.Note = None
                         RunTargetOptions.Tag = None
                         RunTargetOptions.Labels = labels
-                        RunTargetOptions.Variables = variables }
+                        RunTargetOptions.Variables = variables
+                        RunTargetOptions.ContainerTool = None }
         runTarget true options
 
     let clear (clearArgs: ParseResults<ClearArgs>) =

--- a/tests/simple/projects/dotnet-app/PROJECT
+++ b/tests/simple/projects/dotnet-app/PROJECT
@@ -1,5 +1,5 @@
 
-extension @docker {
+extension @container {
     defaults = {
         image: "ghcr.io/magnusopera/dotnet-app"
         arguments: { configuration: $configuration }
@@ -25,9 +25,9 @@ target dist {
 }
 
 target docker {
-    @docker build { }
+    @container build { }
 }
 
 target push {
-    @docker push { }
+    @container push { }
 }

--- a/tests/simple/projects/rust-app/PROJECT
+++ b/tests/simple/projects/rust-app/PROJECT
@@ -1,11 +1,4 @@
 
-extension @docker {
-    defaults = {
-        image: "ghcr.io/magnusopera/rust-app"
-        arguments: { profile: $configuration }
-    }
-}
-
 project @cargo {
     labels = [ "app"
                "rust" ]

--- a/tests/simple/results/terrabuild-debug.build-graph.json
+++ b/tests/simple/results/terrabuild-debug.build-graph.json
@@ -30,7 +30,7 @@
                   {
                     "dotnet_app_version": [
                       "string",
-                      "3EE0CC7786480EF592E5E7FB73BC2691CA3328D8CDFC5CFDA16CBEE006389364"
+                      "3030D2BE5BAACEC957EB7AE699E69160A68B1DAA932F02F4E6EE9A61342CF28E"
                     ],
                     "npm_app_version": [
                       "string",
@@ -54,8 +54,8 @@
       "outputs": [
         "*.planfile"
       ],
-      "projectHash": "825FA904BFCC88377654659B6021610C28A2856B44369D63969377A7699A4AF3",
-      "targetHash": "E96887A83E69C309C87661FA91B22AEC8C0D6FC25610EAA177360B3794ED6021",
+      "projectHash": "0A5B81547090BA469D428B9C3E69C3DB96F5571451E8CBD1B61765721D1F1B03",
+      "targetHash": "9CCA83F6CEACF179BE0821A2CC28000FDFE0D24E50E81AB928A69894E13AFC42",
       "operations": [
         {
           "container": null,
@@ -88,7 +88,7 @@
           "containerVariables": [],
           "metaCommand": "@terraform plan",
           "command": "terraform",
-          "arguments": "plan -detailed-exitcode -out=terrabuild.planfile -var=\u0022dotnet_app_version=3EE0CC7786480EF592E5E7FB73BC2691CA3328D8CDFC5CFDA16CBEE006389364\u0022 -var=\u0022npm_app_version=A440C869D51BECC00CA8E1AADDFEEF52676E0E9A543260A6970ED95CB00EB63E\u0022",
+          "arguments": "plan -detailed-exitcode -out=terrabuild.planfile -var=\u0022dotnet_app_version=3030D2BE5BAACEC957EB7AE699E69160A68B1DAA932F02F4E6EE9A61342CF28E\u0022 -var=\u0022npm_app_version=A440C869D51BECC00CA8E1AADDFEEF52676E0E9A543260A6970ED95CB00EB63E\u0022",
           "exitCodes": [
             [
               0,
@@ -276,8 +276,8 @@
         "obj/*.props",
         "obj/*.targets"
       ],
-      "projectHash": "3EE0CC7786480EF592E5E7FB73BC2691CA3328D8CDFC5CFDA16CBEE006389364",
-      "targetHash": "DDBE336631053045F003A619F764069C3644E78FAAE597140FCC2B968FB31989",
+      "projectHash": "3030D2BE5BAACEC957EB7AE699E69160A68B1DAA932F02F4E6EE9A61342CF28E",
+      "targetHash": "666292DCE28BBD81F67FF2A987B06A497D293CCD3004E88CD2EE6E1860C37CFA",
       "operations": [
         {
           "container": null,
@@ -492,8 +492,8 @@
         "target/debug/",
         "target/release/"
       ],
-      "projectHash": "15CDC8C81F5A3D2B0215AE61D6D429F52345A71EE01246776049C72C2351CAE1",
-      "targetHash": "01352F59D33340734D5DC13053AFCCCE77ED0010491CDAB74F58CF715848AA77",
+      "projectHash": "73C109F30331258C43B747E614DED629DC2709C0EBFDA63D38C2E3CC9BD6F2D8",
+      "targetHash": "8B1735F7730A8E2BAE402811400A87915562027ABF0CA81892FDD53FFF8E4A9C",
       "operations": [
         {
           "container": "rust:1.81.0-slim",

--- a/tests/simple/results/terrabuild-debug.config.json
+++ b/tests/simple/results/terrabuild-debug.config.json
@@ -59,7 +59,7 @@
   "projects": {
     "deployments/terraform-deploy": {
       "id": "deployments/terraform-deploy",
-      "hash": "825FA904BFCC88377654659B6021610C28A2856B44369D63969377A7699A4AF3",
+      "hash": "0A5B81547090BA469D428B9C3E69C3DB96F5571451E8CBD1B61765721D1F1B03",
       "dependencies": [
         "projects/dotnet-app",
         "projects/npm-app"
@@ -97,7 +97,7 @@
                     {
                       "dotnet_app_version": [
                         "string",
-                        "3EE0CC7786480EF592E5E7FB73BC2691CA3328D8CDFC5CFDA16CBEE006389364"
+                        "3030D2BE5BAACEC957EB7AE699E69160A68B1DAA932F02F4E6EE9A61342CF28E"
                       ],
                       "npm_app_version": [
                         "string",
@@ -235,7 +235,7 @@
     },
     "projects/dotnet-app": {
       "id": "projects/dotnet-app",
-      "hash": "3EE0CC7786480EF592E5E7FB73BC2691CA3328D8CDFC5CFDA16CBEE006389364",
+      "hash": "3030D2BE5BAACEC957EB7AE699E69160A68B1DAA932F02F4E6EE9A61342CF28E",
       "dependencies": [
         "libraries/dotnet-lib"
       ],
@@ -316,7 +316,7 @@
           ]
         },
         "docker": {
-          "hash": "B2968AD5F493351AE9DDBE6B6349DAF6CA18C306DCE1DE55C51BEBA430CD3A78",
+          "hash": "C06A2293E8572F31C46818B2B14A4DAE6CBDFF6AD3A9D77BF35E9360E540A984",
           "rebuild": false,
           "dependsOn": [
             "dist"
@@ -331,10 +331,10 @@
           ],
           "operations": [
             {
-              "hash": "2FBDD2F2C31193CA71F958A6F4B9A9579FB1AFB4D5075063C3826EF9C5F1BE28",
+              "hash": "89C283A8FBD1534DE3941241D180ACFDE16919C1B3723477F3408227CED0B5E0",
               "container": null,
               "containerVariables": [],
-              "extension": "@docker",
+              "extension": "@container",
               "command": "build",
               "script": {},
               "context": [
@@ -359,7 +359,7 @@
           ]
         },
         "push": {
-          "hash": "DCE5C493853172D5CA5AF33AD12D2D6DE0EEA440D430C23100216B0E3AC335A9",
+          "hash": "FA1C5DB596E37CF56E3E54D4C6A3EDD18D821B24ED62B8E571B6A5F26996F3BF",
           "rebuild": false,
           "dependsOn": [
             "docker"
@@ -374,10 +374,10 @@
           ],
           "operations": [
             {
-              "hash": "AEF1A65D32F57084416DFD132194426A5BA16C83F444DD18070A887A68C1CA91",
+              "hash": "AC87E09842A6927D322B8AA58397AC633E3BCF134FE3CD095D4C75D1000B9818",
               "container": null,
               "containerVariables": [],
-              "extension": "@docker",
+              "extension": "@container",
               "command": "push",
               "script": {},
               "context": [
@@ -517,7 +517,7 @@
     },
     "projects/rust-app": {
       "id": "projects/rust-app",
-      "hash": "15CDC8C81F5A3D2B0215AE61D6D429F52345A71EE01246776049C72C2351CAE1",
+      "hash": "73C109F30331258C43B747E614DED629DC2709C0EBFDA63D38C2E3CC9BD6F2D8",
       "dependencies": [],
       "files": [
         "Cargo.lock",


### PR DESCRIPTION
Docker has strange behavior regarding ownership on volume:
- they are owned by docker USER (often root)
- despite volumes are mapped to non-root user

This poses several problems to get back files on volume. This PR introduces a new container action (`@container`), with both support for Docker and Podman/Skopeo alonside a flag to indicate which container runtime to use globally (`--containertool`).

Locally, this means you can use Docker - in CI, it's advised to use `--containertool podman` as it's more reliable.