### PR TITLE
function expression use tuple syntax (comma separated)

### DIFF
--- a/src/Terrabuild.Configuration.Tests/TestFiles/WORKSPACE2
+++ b/src/Terrabuild.Configuration.Tests/TestFiles/WORKSPACE2
@@ -39,7 +39,7 @@ configuration {
         secret:  $map.toto == "prod" ? 1234 : 5678
         secret2: $list.2
         secret3: !false + !true
-        secret4: format("1" 2 $toto true nothing)
+        secret4: format("1", 2, $toto, true, nothing)
     }
 }
 
@@ -48,7 +48,7 @@ extension dotnet {
   defaults = {
     configuration1: $map.toto
     configuration2: $map.?titi
-    configuration3: replace("toto titi" "toto" "titi")
+    configuration3: replace("toto titi", "toto", "titi")
   }
 }
 

--- a/src/Terrabuild.Configuration/Gen/ProjectParser.fs
+++ b/src/Terrabuild.Configuration/Gen/ProjectParser.fs
@@ -374,21 +374,22 @@ let prodIdxToNonTerminal (prodIdx:int) =
     | 77 -> NONTERM_ExprTuple 
     | 78 -> NONTERM_ExprTupleContent 
     | 79 -> NONTERM_ExprTupleContent 
-    | 80 -> NONTERM_ExprList 
-    | 81 -> NONTERM_ExprListContent 
+    | 80 -> NONTERM_ExprTupleContent 
+    | 81 -> NONTERM_ExprList 
     | 82 -> NONTERM_ExprListContent 
-    | 83 -> NONTERM_ExprMap 
-    | 84 -> NONTERM_ExprMapContent 
+    | 83 -> NONTERM_ExprListContent 
+    | 84 -> NONTERM_ExprMap 
     | 85 -> NONTERM_ExprMapContent 
-    | 86 -> NONTERM_ListOfString 
-    | 87 -> NONTERM_Strings 
+    | 86 -> NONTERM_ExprMapContent 
+    | 87 -> NONTERM_ListOfString 
     | 88 -> NONTERM_Strings 
-    | 89 -> NONTERM_ListOfIdentifiers 
-    | 90 -> NONTERM_Identifiers 
+    | 89 -> NONTERM_Strings 
+    | 90 -> NONTERM_ListOfIdentifiers 
     | 91 -> NONTERM_Identifiers 
-    | 92 -> NONTERM_ListOfTargetIdentifiers 
-    | 93 -> NONTERM_TargetIdentifiers 
+    | 92 -> NONTERM_Identifiers 
+    | 93 -> NONTERM_ListOfTargetIdentifiers 
     | 94 -> NONTERM_TargetIdentifiers 
+    | 95 -> NONTERM_TargetIdentifiers 
     | _ -> failwith "prodIdxToNonTerminal: bad production index"
 
 let _fsyacc_endOfInputTag = 55 
@@ -507,18 +508,18 @@ let _fsyacc_dataOfToken (t:token) =
   | NOTHING  -> (null : System.Object) 
   | TRUE  -> (null : System.Object) 
   | FALSE  -> (null : System.Object) 
-let _fsyacc_gotos = [| 0us;65535us;1us;65535us;0us;1us;1us;65535us;0us;2us;1us;65535us;2us;5us;1us;65535us;9us;10us;1us;65535us;10us;12us;1us;65535us;10us;13us;1us;65535us;10us;14us;1us;65535us;10us;15us;1us;65535us;2us;4us;2us;65535us;29us;30us;33us;34us;2us;65535us;30us;36us;34us;36us;2us;65535us;30us;37us;34us;37us;2us;65535us;30us;38us;34us;38us;2us;65535us;30us;39us;34us;39us;2us;65535us;30us;40us;34us;40us;2us;65535us;30us;41us;34us;41us;1us;65535us;2us;6us;1us;65535us;62us;63us;1us;65535us;63us;65us;1us;65535us;63us;66us;1us;65535us;63us;67us;1us;65535us;63us;68us;12us;65535us;73us;74us;103us;89us;104us;90us;105us;91us;106us;92us;121us;93us;122us;94us;123us;95us;124us;96us;133us;97us;136us;97us;141us;98us;1us;65535us;147us;149us;3us;65535us;7us;8us;28us;32us;63us;78us;2us;65535us;99us;100us;101us;102us;0us;65535us;3us;65535us;17us;18us;23us;24us;143us;145us;7us;65535us;107us;108us;109us;110us;111us;112us;113us;114us;115us;116us;117us;118us;119us;120us;0us;65535us;12us;65535us;73us;87us;103us;87us;104us;87us;105us;87us;106us;87us;121us;87us;122us;87us;123us;87us;124us;87us;133us;87us;136us;87us;141us;87us;2us;65535us;132us;133us;135us;136us;14us;65535us;26us;27us;73us;88us;79us;80us;103us;88us;104us;88us;105us;88us;106us;88us;121us;88us;122us;88us;123us;88us;124us;88us;133us;88us;136us;88us;141us;88us;1us;65535us;138us;139us;8us;65535us;20us;21us;43us;44us;46us;47us;49us;50us;52us;53us;55us;56us;58us;59us;76us;77us;1us;65535us;142us;143us;0us;65535us;0us;65535us;1us;65535us;70us;71us;1us;65535us;146us;147us;|]
-let _fsyacc_sparseGotoTableRowOffsets = [|0us;1us;3us;5us;7us;9us;11us;13us;15us;17us;19us;22us;25us;28us;31us;34us;37us;40us;42us;44us;46us;48us;50us;52us;65us;67us;71us;74us;75us;79us;87us;88us;101us;104us;119us;121us;130us;132us;133us;134us;136us;|]
-let _fsyacc_stateToProdIdxsTableElements = [| 1us;0us;1us;0us;4us;1us;3us;4us;5us;1us;1us;1us;3us;1us;4us;1us;5us;1us;6us;1us;6us;1us;6us;5us;6us;8us;9us;10us;11us;1us;6us;1us;8us;1us;9us;1us;10us;1us;11us;1us;12us;1us;12us;1us;12us;1us;13us;1us;13us;1us;13us;1us;14us;1us;14us;1us;14us;1us;15us;1us;15us;1us;15us;4us;16us;17us;18us;19us;1us;17us;7us;17us;21us;22us;23us;24us;25us;26us;1us;17us;2us;18us;19us;1us;19us;7us;19us;21us;22us;23us;24us;25us;26us;1us;19us;1us;21us;1us;22us;1us;23us;1us;24us;1us;25us;1us;26us;1us;27us;1us;27us;1us;27us;1us;28us;1us;28us;1us;28us;1us;29us;1us;29us;1us;29us;1us;30us;1us;30us;1us;30us;1us;31us;1us;31us;1us;31us;1us;32us;1us;32us;1us;32us;1us;33us;1us;33us;1us;33us;5us;33us;35us;36us;37us;38us;1us;33us;1us;35us;1us;36us;1us;37us;1us;38us;1us;39us;1us;39us;1us;39us;1us;40us;1us;40us;9us;40us;52us;53us;54us;55us;56us;57us;65us;66us;1us;41us;1us;41us;1us;41us;2us;42us;43us;2us;42us;43us;1us;43us;1us;44us;1us;45us;1us;46us;1us;47us;1us;48us;1us;49us;1us;50us;1us;51us;9us;52us;53us;54us;54us;55us;56us;57us;65us;66us;9us;52us;53us;54us;55us;55us;56us;57us;65us;66us;9us;52us;53us;54us;55us;56us;56us;57us;65us;66us;9us;52us;53us;54us;55us;56us;57us;57us;65us;66us;9us;52us;53us;54us;55us;56us;57us;65us;65us;66us;9us;52us;53us;54us;55us;56us;57us;65us;66us;66us;9us;52us;53us;54us;55us;56us;57us;65us;66us;66us;9us;52us;53us;54us;55us;56us;57us;65us;66us;67us;9us;52us;53us;54us;55us;56us;57us;65us;66us;82us;9us;52us;53us;54us;55us;56us;57us;65us;66us;85us;1us;52us;1us;52us;1us;53us;1us;53us;1us;54us;1us;55us;1us;56us;1us;57us;1us;58us;1us;58us;1us;59us;1us;59us;1us;60us;1us;60us;1us;61us;1us;61us;1us;62us;1us;62us;1us;63us;1us;63us;1us;64us;1us;64us;1us;65us;1us;66us;1us;66us;1us;67us;1us;68us;1us;69us;1us;70us;1us;71us;1us;72us;1us;73us;1us;76us;1us;77us;2us;77us;82us;1us;77us;1us;80us;2us;80us;82us;1us;80us;1us;83us;2us;83us;85us;1us;83us;1us;85us;1us;86us;2us;86us;88us;1us;86us;1us;88us;1us;92us;2us;92us;94us;1us;92us;1us;94us;|]
-let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us;2us;4us;9us;11us;13us;15us;17us;19us;21us;23us;29us;31us;33us;35us;37us;39us;41us;43us;45us;47us;49us;51us;53us;55us;57us;59us;61us;63us;68us;70us;78us;80us;83us;85us;93us;95us;97us;99us;101us;103us;105us;107us;109us;111us;113us;115us;117us;119us;121us;123us;125us;127us;129us;131us;133us;135us;137us;139us;141us;143us;145us;147us;149us;155us;157us;159us;161us;163us;165us;167us;169us;171us;173us;175us;185us;187us;189us;191us;194us;197us;199us;201us;203us;205us;207us;209us;211us;213us;215us;225us;235us;245us;255us;265us;275us;285us;295us;305us;315us;317us;319us;321us;323us;325us;327us;329us;331us;333us;335us;337us;339us;341us;343us;345us;347us;349us;351us;353us;355us;357us;359us;361us;363us;365us;367us;369us;371us;373us;375us;377us;379us;381us;383us;386us;388us;390us;393us;395us;397us;400us;402us;404us;406us;409us;411us;413us;415us;418us;420us;|]
-let _fsyacc_action_rows = 150
-let _fsyacc_actionTableElements = [|0us;16386us;0us;49152us;4us;32768us;14us;28us;15us;7us;16us;60us;17us;3us;0us;16385us;0us;16387us;0us;16388us;0us;16389us;2us;32768us;47us;127us;48us;128us;1us;32768us;41us;9us;0us;16391us;5us;32768us;6us;19us;7us;16us;9us;22us;12us;25us;42us;11us;0us;16390us;0us;16392us;0us;16393us;0us;16394us;0us;16395us;1us;32768us;32us;17us;1us;32768us;49us;131us;0us;16396us;1us;32768us;32us;20us;1us;32768us;39us;142us;0us;16397us;1us;32768us;32us;23us;1us;32768us;49us;131us;0us;16398us;1us;32768us;32us;26us;1us;32768us;41us;138us;0us;16399us;3us;16400us;41us;29us;47us;127us;48us;128us;0us;16404us;7us;32768us;0us;42us;1us;45us;2us;48us;3us;51us;4us;54us;5us;57us;42us;31us;0us;16401us;1us;16402us;41us;33us;0us;16404us;7us;32768us;0us;42us;1us;45us;2us;48us;3us;51us;4us;54us;5us;57us;42us;35us;0us;16403us;0us;16405us;0us;16406us;0us;16407us;0us;16408us;0us;16409us;0us;16410us;1us;32768us;32us;43us;1us;32768us;39us;142us;0us;16411us;1us;32768us;32us;46us;1us;32768us;39us;142us;0us;16412us;1us;32768us;32us;49us;1us;32768us;39us;142us;0us;16413us;1us;32768us;32us;52us;1us;32768us;39us;142us;0us;16414us;1us;32768us;32us;55us;1us;32768us;39us;142us;0us;16415us;1us;32768us;32us;58us;1us;32768us;39us;142us;0us;16416us;1us;32768us;48us;61us;1us;32768us;41us;62us;0us;16418us;6us;32768us;2us;75us;10us;69us;11us;72us;42us;64us;47us;127us;48us;128us;0us;16417us;0us;16419us;0us;16420us;0us;16421us;0us;16422us;1us;32768us;32us;70us;1us;32768us;39us;146us;0us;16423us;1us;32768us;32us;73us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;8us;16424us;18us;121us;19us;122us;29us;106us;30us;105us;33us;103us;34us;104us;37us;99us;38us;101us;1us;32768us;32us;76us;1us;32768us;39us;142us;0us;16425us;1us;32768us;48us;79us;1us;16426us;41us;138us;0us;16427us;0us;16428us;0us;16429us;0us;16430us;0us;16431us;0us;16432us;0us;16433us;0us;16434us;0us;16435us;4us;16438us;29us;106us;30us;105us;37us;99us;38us;101us;4us;16439us;29us;106us;30us;105us;37us;99us;38us;101us;2us;16440us;37us;99us;38us;101us;3us;16441us;30us;105us;37us;99us;38us;101us;6us;16449us;29us;106us;30us;105us;33us;103us;34us;104us;37us;99us;38us;101us;9us;32768us;18us;121us;19us;122us;20us;123us;29us;106us;30us;105us;33us;103us;34us;104us;37us;99us;38us;101us;8us;16450us;18us;121us;19us;122us;29us;106us;30us;105us;33us;103us;34us;104us;37us;99us;38us;101us;0us;16451us;8us;16466us;18us;121us;19us;122us;29us;106us;30us;105us;33us;103us;34us;104us;37us;99us;38us;101us;8us;16469us;18us;121us;19us;122us;29us;106us;30us;105us;33us;103us;34us;104us;37us;99us;38us;101us;2us;32768us;43us;129us;48us;130us;0us;16436us;2us;32768us;43us;129us;48us;130us;0us;16437us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;1us;32768us;35us;132us;0us;16442us;1us;32768us;35us;132us;0us;16443us;1us;32768us;35us;132us;0us;16444us;1us;32768us;35us;132us;0us;16445us;1us;32768us;35us;132us;0us;16446us;1us;32768us;35us;132us;0us;16447us;1us;32768us;35us;132us;0us;16448us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16452us;0us;16453us;0us;16454us;0us;16455us;0us;16456us;0us;16457us;0us;16460us;0us;16465us;17us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;36us;134us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16461us;0us;16465us;17us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;40us;137us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16464us;0us;16468us;2us;32768us;42us;140us;44us;141us;0us;16467us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16471us;2us;32768us;40us;144us;49us;131us;0us;16470us;0us;16472us;0us;16477us;3us;32768us;40us;148us;46us;125us;48us;126us;0us;16476us;0us;16478us;|]
-let _fsyacc_actionTableRowOffsets = [|0us;1us;2us;7us;8us;9us;10us;11us;14us;16us;17us;23us;24us;25us;26us;27us;28us;30us;32us;33us;35us;37us;38us;40us;42us;43us;45us;47us;48us;52us;53us;61us;62us;64us;65us;73us;74us;75us;76us;77us;78us;79us;80us;82us;84us;85us;87us;89us;90us;92us;94us;95us;97us;99us;100us;102us;104us;105us;107us;109us;110us;112us;114us;115us;122us;123us;124us;125us;126us;127us;129us;131us;132us;134us;151us;160us;162us;164us;165us;167us;169us;170us;171us;172us;173us;174us;175us;176us;177us;178us;183us;188us;191us;195us;202us;212us;221us;222us;231us;240us;243us;244us;247us;248us;265us;282us;299us;316us;318us;319us;321us;322us;324us;325us;327us;328us;330us;331us;333us;334us;336us;337us;354us;371us;388us;405us;406us;407us;408us;409us;410us;411us;412us;413us;431us;432us;433us;451us;452us;453us;456us;457us;474us;475us;478us;479us;480us;481us;485us;486us;|]
-let _fsyacc_reductionSymbolCounts = [|1us;2us;0us;2us;2us;2us;5us;0us;2us;2us;2us;2us;3us;3us;3us;3us;1us;4us;2us;5us;0us;2us;2us;2us;2us;2us;2us;3us;3us;3us;3us;3us;3us;5us;0us;2us;2us;2us;2us;3us;3us;3us;2us;3us;1us;1us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;1us;1us;1us;1us;3us;0us;3us;3us;0us;2us;3us;0us;3us;3us;0us;2us;3us;0us;2us;3us;0us;2us;|]
-let _fsyacc_productionToNonTerminalTable = [|0us;1us;2us;2us;2us;2us;3us;4us;4us;4us;4us;4us;5us;6us;7us;8us;9us;9us;9us;9us;10us;10us;10us;10us;10us;10us;10us;11us;12us;13us;14us;15us;16us;17us;18us;18us;18us;18us;18us;19us;20us;21us;22us;22us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;24us;24us;25us;25us;26us;26us;27us;27us;28us;29us;30us;30us;31us;32us;32us;33us;34us;34us;35us;36us;36us;37us;38us;38us;39us;40us;40us;|]
-let _fsyacc_immediateActions = [|65535us;49152us;65535us;16385us;16387us;16388us;16389us;65535us;65535us;65535us;65535us;16390us;16392us;16393us;16394us;16395us;65535us;65535us;16396us;65535us;65535us;16397us;65535us;65535us;16398us;65535us;65535us;16399us;65535us;65535us;65535us;16401us;65535us;65535us;65535us;16403us;16405us;16406us;16407us;16408us;16409us;16410us;65535us;65535us;16411us;65535us;65535us;16412us;65535us;65535us;16413us;65535us;65535us;16414us;65535us;65535us;16415us;65535us;65535us;16416us;65535us;65535us;65535us;65535us;16417us;16419us;16420us;16421us;16422us;65535us;65535us;16423us;65535us;65535us;65535us;65535us;65535us;16425us;65535us;65535us;16427us;16428us;16429us;16430us;16431us;16432us;16433us;16434us;16435us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16436us;65535us;16437us;65535us;65535us;65535us;65535us;65535us;16442us;65535us;16443us;65535us;16444us;65535us;16445us;65535us;16446us;65535us;16447us;65535us;16448us;65535us;65535us;65535us;65535us;16452us;16453us;16454us;16455us;16456us;16457us;16460us;65535us;65535us;16461us;65535us;65535us;16464us;65535us;65535us;16467us;65535us;65535us;65535us;16470us;16472us;65535us;65535us;16476us;16478us;|]
+let _fsyacc_gotos = [| 0us;65535us;1us;65535us;0us;1us;1us;65535us;0us;2us;1us;65535us;2us;5us;1us;65535us;9us;10us;1us;65535us;10us;12us;1us;65535us;10us;13us;1us;65535us;10us;14us;1us;65535us;10us;15us;1us;65535us;2us;4us;2us;65535us;29us;30us;33us;34us;2us;65535us;30us;36us;34us;36us;2us;65535us;30us;37us;34us;37us;2us;65535us;30us;38us;34us;38us;2us;65535us;30us;39us;34us;39us;2us;65535us;30us;40us;34us;40us;2us;65535us;30us;41us;34us;41us;1us;65535us;2us;6us;1us;65535us;62us;63us;1us;65535us;63us;65us;1us;65535us;63us;66us;1us;65535us;63us;67us;1us;65535us;63us;68us;13us;65535us;73us;74us;105us;89us;106us;90us;107us;91us;108us;92us;123us;93us;124us;94us;125us;95us;126us;96us;134us;97us;137us;98us;139us;99us;144us;100us;1us;65535us;150us;152us;3us;65535us;7us;8us;28us;32us;63us;78us;2us;65535us;101us;102us;103us;104us;0us;65535us;3us;65535us;17us;18us;23us;24us;146us;148us;7us;65535us;109us;110us;111us;112us;113us;114us;115us;116us;117us;118us;119us;120us;121us;122us;1us;65535us;134us;135us;13us;65535us;73us;87us;105us;87us;106us;87us;107us;87us;108us;87us;123us;87us;124us;87us;125us;87us;126us;87us;134us;87us;137us;87us;139us;87us;144us;87us;1us;65535us;138us;139us;15us;65535us;26us;27us;73us;88us;79us;80us;105us;88us;106us;88us;107us;88us;108us;88us;123us;88us;124us;88us;125us;88us;126us;88us;134us;88us;137us;88us;139us;88us;144us;88us;1us;65535us;141us;142us;8us;65535us;20us;21us;43us;44us;46us;47us;49us;50us;52us;53us;55us;56us;58us;59us;76us;77us;1us;65535us;145us;146us;0us;65535us;0us;65535us;1us;65535us;70us;71us;1us;65535us;149us;150us;|]
+let _fsyacc_sparseGotoTableRowOffsets = [|0us;1us;3us;5us;7us;9us;11us;13us;15us;17us;19us;22us;25us;28us;31us;34us;37us;40us;42us;44us;46us;48us;50us;52us;66us;68us;72us;75us;76us;80us;88us;90us;104us;106us;122us;124us;133us;135us;136us;137us;139us;|]
+let _fsyacc_stateToProdIdxsTableElements = [| 1us;0us;1us;0us;4us;1us;3us;4us;5us;1us;1us;1us;3us;1us;4us;1us;5us;1us;6us;1us;6us;1us;6us;5us;6us;8us;9us;10us;11us;1us;6us;1us;8us;1us;9us;1us;10us;1us;11us;1us;12us;1us;12us;1us;12us;1us;13us;1us;13us;1us;13us;1us;14us;1us;14us;1us;14us;1us;15us;1us;15us;1us;15us;4us;16us;17us;18us;19us;1us;17us;7us;17us;21us;22us;23us;24us;25us;26us;1us;17us;2us;18us;19us;1us;19us;7us;19us;21us;22us;23us;24us;25us;26us;1us;19us;1us;21us;1us;22us;1us;23us;1us;24us;1us;25us;1us;26us;1us;27us;1us;27us;1us;27us;1us;28us;1us;28us;1us;28us;1us;29us;1us;29us;1us;29us;1us;30us;1us;30us;1us;30us;1us;31us;1us;31us;1us;31us;1us;32us;1us;32us;1us;32us;1us;33us;1us;33us;1us;33us;5us;33us;35us;36us;37us;38us;1us;33us;1us;35us;1us;36us;1us;37us;1us;38us;1us;39us;1us;39us;1us;39us;1us;40us;1us;40us;9us;40us;52us;53us;54us;55us;56us;57us;65us;66us;1us;41us;1us;41us;1us;41us;2us;42us;43us;2us;42us;43us;1us;43us;1us;44us;1us;45us;1us;46us;1us;47us;1us;48us;1us;49us;1us;50us;1us;51us;9us;52us;53us;54us;54us;55us;56us;57us;65us;66us;9us;52us;53us;54us;55us;55us;56us;57us;65us;66us;9us;52us;53us;54us;55us;56us;56us;57us;65us;66us;9us;52us;53us;54us;55us;56us;57us;57us;65us;66us;9us;52us;53us;54us;55us;56us;57us;65us;65us;66us;9us;52us;53us;54us;55us;56us;57us;65us;66us;66us;9us;52us;53us;54us;55us;56us;57us;65us;66us;66us;9us;52us;53us;54us;55us;56us;57us;65us;66us;67us;9us;52us;53us;54us;55us;56us;57us;65us;66us;79us;9us;52us;53us;54us;55us;56us;57us;65us;66us;80us;9us;52us;53us;54us;55us;56us;57us;65us;66us;83us;9us;52us;53us;54us;55us;56us;57us;65us;66us;86us;1us;52us;1us;52us;1us;53us;1us;53us;1us;54us;1us;55us;1us;56us;1us;57us;1us;58us;1us;58us;1us;59us;1us;59us;1us;60us;1us;60us;1us;61us;1us;61us;1us;62us;1us;62us;1us;63us;1us;63us;1us;64us;1us;64us;1us;65us;1us;66us;1us;66us;1us;67us;1us;68us;1us;69us;1us;70us;1us;71us;1us;72us;1us;73us;1us;76us;1us;77us;2us;77us;80us;1us;77us;1us;80us;1us;81us;2us;81us;83us;1us;81us;1us;84us;2us;84us;86us;1us;84us;1us;86us;1us;87us;2us;87us;89us;1us;87us;1us;89us;1us;93us;2us;93us;95us;1us;93us;1us;95us;|]
+let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us;2us;4us;9us;11us;13us;15us;17us;19us;21us;23us;29us;31us;33us;35us;37us;39us;41us;43us;45us;47us;49us;51us;53us;55us;57us;59us;61us;63us;68us;70us;78us;80us;83us;85us;93us;95us;97us;99us;101us;103us;105us;107us;109us;111us;113us;115us;117us;119us;121us;123us;125us;127us;129us;131us;133us;135us;137us;139us;141us;143us;145us;147us;149us;155us;157us;159us;161us;163us;165us;167us;169us;171us;173us;175us;185us;187us;189us;191us;194us;197us;199us;201us;203us;205us;207us;209us;211us;213us;215us;225us;235us;245us;255us;265us;275us;285us;295us;305us;315us;325us;335us;337us;339us;341us;343us;345us;347us;349us;351us;353us;355us;357us;359us;361us;363us;365us;367us;369us;371us;373us;375us;377us;379us;381us;383us;385us;387us;389us;391us;393us;395us;397us;399us;401us;403us;406us;408us;410us;412us;415us;417us;419us;422us;424us;426us;428us;431us;433us;435us;437us;440us;442us;|]
+let _fsyacc_action_rows = 153
+let _fsyacc_actionTableElements = [|0us;16386us;0us;49152us;4us;32768us;14us;28us;15us;7us;16us;60us;17us;3us;0us;16385us;0us;16387us;0us;16388us;0us;16389us;2us;32768us;47us;129us;48us;130us;1us;32768us;41us;9us;0us;16391us;5us;32768us;6us;19us;7us;16us;9us;22us;12us;25us;42us;11us;0us;16390us;0us;16392us;0us;16393us;0us;16394us;0us;16395us;1us;32768us;32us;17us;1us;32768us;49us;133us;0us;16396us;1us;32768us;32us;20us;1us;32768us;39us;145us;0us;16397us;1us;32768us;32us;23us;1us;32768us;49us;133us;0us;16398us;1us;32768us;32us;26us;1us;32768us;41us;141us;0us;16399us;3us;16400us;41us;29us;47us;129us;48us;130us;0us;16404us;7us;32768us;0us;42us;1us;45us;2us;48us;3us;51us;4us;54us;5us;57us;42us;31us;0us;16401us;1us;16402us;41us;33us;0us;16404us;7us;32768us;0us;42us;1us;45us;2us;48us;3us;51us;4us;54us;5us;57us;42us;35us;0us;16403us;0us;16405us;0us;16406us;0us;16407us;0us;16408us;0us;16409us;0us;16410us;1us;32768us;32us;43us;1us;32768us;39us;145us;0us;16411us;1us;32768us;32us;46us;1us;32768us;39us;145us;0us;16412us;1us;32768us;32us;49us;1us;32768us;39us;145us;0us;16413us;1us;32768us;32us;52us;1us;32768us;39us;145us;0us;16414us;1us;32768us;32us;55us;1us;32768us;39us;145us;0us;16415us;1us;32768us;32us;58us;1us;32768us;39us;145us;0us;16416us;1us;32768us;48us;61us;1us;32768us;41us;62us;0us;16418us;6us;32768us;2us;75us;10us;69us;11us;72us;42us;64us;47us;129us;48us;130us;0us;16417us;0us;16419us;0us;16420us;0us;16421us;0us;16422us;1us;32768us;32us;70us;1us;32768us;39us;149us;0us;16423us;1us;32768us;32us;73us;16us;32768us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;8us;16424us;18us;123us;19us;124us;29us;108us;30us;107us;33us;105us;34us;106us;37us;101us;38us;103us;1us;32768us;32us;76us;1us;32768us;39us;145us;0us;16425us;1us;32768us;48us;79us;1us;16426us;41us;141us;0us;16427us;0us;16428us;0us;16429us;0us;16430us;0us;16431us;0us;16432us;0us;16433us;0us;16434us;0us;16435us;4us;16438us;29us;108us;30us;107us;37us;101us;38us;103us;4us;16439us;29us;108us;30us;107us;37us;101us;38us;103us;2us;16440us;37us;101us;38us;103us;3us;16441us;30us;107us;37us;101us;38us;103us;6us;16449us;29us;108us;30us;107us;33us;105us;34us;106us;37us;101us;38us;103us;9us;32768us;18us;123us;19us;124us;20us;125us;29us;108us;30us;107us;33us;105us;34us;106us;37us;101us;38us;103us;8us;16450us;18us;123us;19us;124us;29us;108us;30us;107us;33us;105us;34us;106us;37us;101us;38us;103us;0us;16451us;8us;16463us;18us;123us;19us;124us;29us;108us;30us;107us;33us;105us;34us;106us;37us;101us;38us;103us;8us;16464us;18us;123us;19us;124us;29us;108us;30us;107us;33us;105us;34us;106us;37us;101us;38us;103us;8us;16467us;18us;123us;19us;124us;29us;108us;30us;107us;33us;105us;34us;106us;37us;101us;38us;103us;8us;16470us;18us;123us;19us;124us;29us;108us;30us;107us;33us;105us;34us;106us;37us;101us;38us;103us;2us;32768us;43us;131us;48us;132us;0us;16436us;2us;32768us;43us;131us;48us;132us;0us;16437us;16us;32768us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;1us;32768us;35us;134us;0us;16442us;1us;32768us;35us;134us;0us;16443us;1us;32768us;35us;134us;0us;16444us;1us;32768us;35us;134us;0us;16445us;1us;32768us;35us;134us;0us;16446us;1us;32768us;35us;134us;0us;16447us;1us;32768us;35us;134us;0us;16448us;16us;32768us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16452us;0us;16453us;0us;16454us;0us;16455us;0us;16456us;0us;16457us;0us;16460us;16us;16462us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;2us;32768us;31us;137us;36us;136us;0us;16461us;16us;32768us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16466us;17us;32768us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;40us;140us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16465us;0us;16469us;2us;32768us;42us;143us;44us;144us;0us;16468us;16us;32768us;21us;126us;22us;109us;23us;111us;24us;113us;25us;115us;26us;117us;27us;119us;28us;121us;39us;138us;41us;141us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16472us;2us;32768us;40us;147us;49us;133us;0us;16471us;0us;16473us;0us;16478us;3us;32768us;40us;151us;46us;127us;48us;128us;0us;16477us;0us;16479us;|]
+let _fsyacc_actionTableRowOffsets = [|0us;1us;2us;7us;8us;9us;10us;11us;14us;16us;17us;23us;24us;25us;26us;27us;28us;30us;32us;33us;35us;37us;38us;40us;42us;43us;45us;47us;48us;52us;53us;61us;62us;64us;65us;73us;74us;75us;76us;77us;78us;79us;80us;82us;84us;85us;87us;89us;90us;92us;94us;95us;97us;99us;100us;102us;104us;105us;107us;109us;110us;112us;114us;115us;122us;123us;124us;125us;126us;127us;129us;131us;132us;134us;151us;160us;162us;164us;165us;167us;169us;170us;171us;172us;173us;174us;175us;176us;177us;178us;183us;188us;191us;195us;202us;212us;221us;222us;231us;240us;249us;258us;261us;262us;265us;266us;283us;300us;317us;334us;336us;337us;339us;340us;342us;343us;345us;346us;348us;349us;351us;352us;354us;355us;372us;389us;406us;423us;424us;425us;426us;427us;428us;429us;430us;447us;450us;451us;468us;469us;487us;488us;489us;492us;493us;510us;511us;514us;515us;516us;517us;521us;522us;|]
+let _fsyacc_reductionSymbolCounts = [|1us;2us;0us;2us;2us;2us;5us;0us;2us;2us;2us;2us;3us;3us;3us;3us;1us;4us;2us;5us;0us;2us;2us;2us;2us;2us;2us;3us;3us;3us;3us;3us;3us;5us;0us;2us;2us;2us;2us;3us;3us;3us;2us;3us;1us;1us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;1us;1us;1us;1us;3us;0us;1us;3us;3us;0us;2us;3us;0us;3us;3us;0us;2us;3us;0us;2us;3us;0us;2us;|]
+let _fsyacc_productionToNonTerminalTable = [|0us;1us;2us;2us;2us;2us;3us;4us;4us;4us;4us;4us;5us;6us;7us;8us;9us;9us;9us;9us;10us;10us;10us;10us;10us;10us;10us;11us;12us;13us;14us;15us;16us;17us;18us;18us;18us;18us;18us;19us;20us;21us;22us;22us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;24us;24us;25us;25us;26us;26us;27us;27us;28us;29us;30us;30us;30us;31us;32us;32us;33us;34us;34us;35us;36us;36us;37us;38us;38us;39us;40us;40us;|]
+let _fsyacc_immediateActions = [|65535us;49152us;65535us;16385us;16387us;16388us;16389us;65535us;65535us;65535us;65535us;16390us;16392us;16393us;16394us;16395us;65535us;65535us;16396us;65535us;65535us;16397us;65535us;65535us;16398us;65535us;65535us;16399us;65535us;65535us;65535us;16401us;65535us;65535us;65535us;16403us;16405us;16406us;16407us;16408us;16409us;16410us;65535us;65535us;16411us;65535us;65535us;16412us;65535us;65535us;16413us;65535us;65535us;16414us;65535us;65535us;16415us;65535us;65535us;16416us;65535us;65535us;65535us;65535us;16417us;16419us;16420us;16421us;16422us;65535us;65535us;16423us;65535us;65535us;65535us;65535us;65535us;16425us;65535us;65535us;16427us;16428us;16429us;16430us;16431us;16432us;16433us;16434us;16435us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16436us;65535us;16437us;65535us;65535us;65535us;65535us;65535us;16442us;65535us;16443us;65535us;16444us;65535us;16445us;65535us;16446us;65535us;16447us;65535us;16448us;65535us;65535us;65535us;65535us;16452us;16453us;16454us;16455us;16456us;16457us;16460us;65535us;65535us;16461us;65535us;65535us;65535us;16465us;65535us;65535us;16468us;65535us;65535us;65535us;16471us;16473us;65535us;65535us;16477us;16479us;|]
 let _fsyacc_reductions = lazy [|
-# 521 "Gen/ProjectParser.fs"
+# 522 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Terrabuild.Configuration.Project.AST.ProjectFile in
             Microsoft.FSharp.Core.Operators.box
@@ -527,485 +528,485 @@ let _fsyacc_reductions = lazy [|
                       raise (FSharp.Text.Parsing.Accept(Microsoft.FSharp.Core.Operators.box _1))
                    )
                  : 'gentype__startProjectFile));
-# 530 "Gen/ProjectParser.fs"
+# 531 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 55 "ProjectParser/Parser.fsy"
+# 56 "ProjectParser/Parser.fsy"
                                                        ProjectFile.Build _1 
                    )
-# 55 "ProjectParser/Parser.fsy"
+# 56 "ProjectParser/Parser.fsy"
                  : Terrabuild.Configuration.Project.AST.ProjectFile));
-# 541 "Gen/ProjectParser.fs"
+# 542 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 58 "ProjectParser/Parser.fsy"
+# 59 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 58 "ProjectParser/Parser.fsy"
+# 59 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 551 "Gen/ProjectParser.fs"
+# 552 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Project in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 59 "ProjectParser/Parser.fsy"
+# 60 "ProjectParser/Parser.fsy"
                                                            _1 @ [_2] 
                    )
-# 59 "ProjectParser/Parser.fsy"
+# 60 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 563 "Gen/ProjectParser.fs"
+# 564 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Extension in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 60 "ProjectParser/Parser.fsy"
+# 61 "ProjectParser/Parser.fsy"
                                                              _1 @ [_2] 
                    )
-# 60 "ProjectParser/Parser.fsy"
+# 61 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 575 "Gen/ProjectParser.fs"
+# 576 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Target in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 61 "ProjectParser/Parser.fsy"
+# 62 "ProjectParser/Parser.fsy"
                                                           _1 @ [_2] 
                    )
-# 61 "ProjectParser/Parser.fsy"
+# 62 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 587 "Gen/ProjectParser.fs"
+# 588 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionIdentifier in
             let _4 = parseState.GetInput(4) :?> 'gentype_ExtensionComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 65 "ProjectParser/Parser.fsy"
+# 66 "ProjectParser/Parser.fsy"
                                                                                              Extension.Build _2 _4 |> ProjectFileComponents.Extension 
                    )
-# 65 "ProjectParser/Parser.fsy"
+# 66 "ProjectParser/Parser.fsy"
                  : 'gentype_Extension));
-# 599 "Gen/ProjectParser.fs"
+# 600 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 67 "ProjectParser/Parser.fsy"
+# 68 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 67 "ProjectParser/Parser.fsy"
+# 68 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 609 "Gen/ProjectParser.fs"
+# 610 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionContainer in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 68 "ProjectParser/Parser.fsy"
+# 69 "ProjectParser/Parser.fsy"
                                                                     _1 @ [_2] 
                    )
-# 68 "ProjectParser/Parser.fsy"
+# 69 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 621 "Gen/ProjectParser.fs"
+# 622 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionVariables in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 69 "ProjectParser/Parser.fsy"
+# 70 "ProjectParser/Parser.fsy"
                                                                     _1 @ [_2] 
                    )
-# 69 "ProjectParser/Parser.fsy"
+# 70 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 633 "Gen/ProjectParser.fs"
+# 634 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionScript in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 70 "ProjectParser/Parser.fsy"
+# 71 "ProjectParser/Parser.fsy"
                                                                  _1 @ [_2] 
                    )
-# 70 "ProjectParser/Parser.fsy"
+# 71 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 645 "Gen/ProjectParser.fs"
+# 646 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionDefaults in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 71 "ProjectParser/Parser.fsy"
+# 72 "ProjectParser/Parser.fsy"
                                                                    _1 @ [_2] 
                    )
-# 71 "ProjectParser/Parser.fsy"
+# 72 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 657 "Gen/ProjectParser.fs"
+# 658 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 73 "ProjectParser/Parser.fsy"
+# 74 "ProjectParser/Parser.fsy"
                                                     ExtensionComponents.Container _3 
                    )
-# 73 "ProjectParser/Parser.fsy"
+# 74 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionContainer));
-# 668 "Gen/ProjectParser.fs"
+# 669 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 75 "ProjectParser/Parser.fsy"
+# 76 "ProjectParser/Parser.fsy"
                                                           ExtensionComponents.Variables _3 
                    )
-# 75 "ProjectParser/Parser.fsy"
+# 76 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionVariables));
-# 679 "Gen/ProjectParser.fs"
+# 680 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 77 "ProjectParser/Parser.fsy"
+# 78 "ProjectParser/Parser.fsy"
                                                  ExtensionComponents.Script _3 
                    )
-# 77 "ProjectParser/Parser.fsy"
+# 78 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionScript));
-# 690 "Gen/ProjectParser.fs"
+# 691 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprMap in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 79 "ProjectParser/Parser.fsy"
+# 80 "ProjectParser/Parser.fsy"
                                                     ExtensionComponents.Defaults _3 
                    )
-# 79 "ProjectParser/Parser.fsy"
+# 80 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionDefaults));
-# 701 "Gen/ProjectParser.fs"
+# 702 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 83 "ProjectParser/Parser.fsy"
+# 84 "ProjectParser/Parser.fsy"
                                      Project.Build None [] |> ProjectFileComponents.Project 
                    )
-# 83 "ProjectParser/Parser.fsy"
+# 84 "ProjectParser/Parser.fsy"
                  : 'gentype_Project));
-# 711 "Gen/ProjectParser.fs"
+# 712 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ProjectComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 84 "ProjectParser/Parser.fsy"
+# 85 "ProjectParser/Parser.fsy"
                                                                      Project.Build None _3 |> ProjectFileComponents.Project 
                    )
-# 84 "ProjectParser/Parser.fsy"
+# 85 "ProjectParser/Parser.fsy"
                  : 'gentype_Project));
-# 722 "Gen/ProjectParser.fs"
+# 723 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionIdentifier in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 85 "ProjectParser/Parser.fsy"
+# 86 "ProjectParser/Parser.fsy"
                                                          Project.Build (Some _2) [] |> ProjectFileComponents.Project 
                    )
-# 85 "ProjectParser/Parser.fsy"
+# 86 "ProjectParser/Parser.fsy"
                  : 'gentype_Project));
-# 733 "Gen/ProjectParser.fs"
+# 734 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionIdentifier in
             let _4 = parseState.GetInput(4) :?> 'gentype_ProjectComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 86 "ProjectParser/Parser.fsy"
+# 87 "ProjectParser/Parser.fsy"
                                                                                          Project.Build (Some _2) _4 |> ProjectFileComponents.Project 
                    )
-# 86 "ProjectParser/Parser.fsy"
+# 87 "ProjectParser/Parser.fsy"
                  : 'gentype_Project));
-# 745 "Gen/ProjectParser.fs"
+# 746 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 88 "ProjectParser/Parser.fsy"
+# 89 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 88 "ProjectParser/Parser.fsy"
+# 89 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 755 "Gen/ProjectParser.fs"
+# 756 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectDependencies in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 89 "ProjectParser/Parser.fsy"
+# 90 "ProjectParser/Parser.fsy"
                                                                    _1 @ [_2] 
                    )
-# 89 "ProjectParser/Parser.fsy"
+# 90 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 767 "Gen/ProjectParser.fs"
+# 768 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectLinks in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 90 "ProjectParser/Parser.fsy"
+# 91 "ProjectParser/Parser.fsy"
                                                             _1 @ [_2] 
                    )
-# 90 "ProjectParser/Parser.fsy"
+# 91 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 779 "Gen/ProjectParser.fs"
+# 780 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectOutputs in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 91 "ProjectParser/Parser.fsy"
+# 92 "ProjectParser/Parser.fsy"
                                                               _1 @ [_2] 
                    )
-# 91 "ProjectParser/Parser.fsy"
+# 92 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 791 "Gen/ProjectParser.fs"
+# 792 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectIgnores in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 92 "ProjectParser/Parser.fsy"
+# 93 "ProjectParser/Parser.fsy"
                                                               _1 @ [_2] 
                    )
-# 92 "ProjectParser/Parser.fsy"
+# 93 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 803 "Gen/ProjectParser.fs"
+# 804 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectIncludes in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 93 "ProjectParser/Parser.fsy"
+# 94 "ProjectParser/Parser.fsy"
                                                                _1 @ [_2] 
                    )
-# 93 "ProjectParser/Parser.fsy"
+# 94 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 815 "Gen/ProjectParser.fs"
+# 816 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectLabels in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 94 "ProjectParser/Parser.fsy"
+# 95 "ProjectParser/Parser.fsy"
                                                              _1 @ [_2] 
                    )
-# 94 "ProjectParser/Parser.fsy"
+# 95 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 827 "Gen/ProjectParser.fs"
+# 828 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 96 "ProjectParser/Parser.fsy"
+# 97 "ProjectParser/Parser.fsy"
                                                              ProjectComponents.Dependencies _3 
                    )
-# 96 "ProjectParser/Parser.fsy"
+# 97 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectDependencies));
-# 838 "Gen/ProjectParser.fs"
+# 839 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 98 "ProjectParser/Parser.fsy"
+# 99 "ProjectParser/Parser.fsy"
                                                       ProjectComponents.Links _3 
                    )
-# 98 "ProjectParser/Parser.fsy"
+# 99 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectLinks));
-# 849 "Gen/ProjectParser.fs"
+# 850 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 100 "ProjectParser/Parser.fsy"
+# 101 "ProjectParser/Parser.fsy"
                                                         ProjectComponents.Outputs _3 
                    )
-# 100 "ProjectParser/Parser.fsy"
+# 101 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectOutputs));
-# 860 "Gen/ProjectParser.fs"
+# 861 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 102 "ProjectParser/Parser.fsy"
+# 103 "ProjectParser/Parser.fsy"
                                                         ProjectComponents.Ignores _3 
                    )
-# 102 "ProjectParser/Parser.fsy"
+# 103 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectIgnores));
-# 871 "Gen/ProjectParser.fs"
+# 872 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 104 "ProjectParser/Parser.fsy"
+# 105 "ProjectParser/Parser.fsy"
                                                          ProjectComponents.Includes _3 
                    )
-# 104 "ProjectParser/Parser.fsy"
+# 105 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectIncludes));
-# 882 "Gen/ProjectParser.fs"
+# 883 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 106 "ProjectParser/Parser.fsy"
+# 107 "ProjectParser/Parser.fsy"
                                                        ProjectComponents.Labels _3 
                    )
-# 106 "ProjectParser/Parser.fsy"
+# 107 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectLabels));
-# 893 "Gen/ProjectParser.fs"
+# 894 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             let _4 = parseState.GetInput(4) :?> 'gentype_TargetComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 109 "ProjectParser/Parser.fsy"
+# 110 "ProjectParser/Parser.fsy"
                                                                               Target.Build _2 _4 |> ProjectFileComponents.Target 
                    )
-# 109 "ProjectParser/Parser.fsy"
+# 110 "ProjectParser/Parser.fsy"
                  : 'gentype_Target));
-# 905 "Gen/ProjectParser.fs"
+# 906 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 111 "ProjectParser/Parser.fsy"
+# 112 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 111 "ProjectParser/Parser.fsy"
+# 112 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 915 "Gen/ProjectParser.fs"
+# 916 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetDependsOn in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 112 "ProjectParser/Parser.fsy"
+# 113 "ProjectParser/Parser.fsy"
                                                               _1 @ [_2] 
                    )
-# 112 "ProjectParser/Parser.fsy"
+# 113 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 927 "Gen/ProjectParser.fs"
+# 928 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetRebuild in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 113 "ProjectParser/Parser.fsy"
+# 114 "ProjectParser/Parser.fsy"
                                                             _1 @ [_2] 
                    )
-# 113 "ProjectParser/Parser.fsy"
+# 114 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 939 "Gen/ProjectParser.fs"
+# 940 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetOutputs in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 114 "ProjectParser/Parser.fsy"
+# 115 "ProjectParser/Parser.fsy"
                                                             _1 @ [_2] 
                    )
-# 114 "ProjectParser/Parser.fsy"
+# 115 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 951 "Gen/ProjectParser.fs"
+# 952 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetStep in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 115 "ProjectParser/Parser.fsy"
+# 116 "ProjectParser/Parser.fsy"
                                                          _1 @ [_2] 
                    )
-# 115 "ProjectParser/Parser.fsy"
+# 116 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 963 "Gen/ProjectParser.fs"
+# 964 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfTargetIdentifiers in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 117 "ProjectParser/Parser.fsy"
+# 118 "ProjectParser/Parser.fsy"
                                                                       TargetComponents.DependsOn _3 
                    )
-# 117 "ProjectParser/Parser.fsy"
+# 118 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetDependsOn));
-# 974 "Gen/ProjectParser.fs"
+# 975 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 119 "ProjectParser/Parser.fsy"
+# 120 "ProjectParser/Parser.fsy"
                                                 TargetComponents.Rebuild _3 
                    )
-# 119 "ProjectParser/Parser.fsy"
+# 120 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetRebuild));
-# 985 "Gen/ProjectParser.fs"
+# 986 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 121 "ProjectParser/Parser.fsy"
+# 122 "ProjectParser/Parser.fsy"
                                                         TargetComponents.Outputs _3 
                    )
-# 121 "ProjectParser/Parser.fsy"
+# 122 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetOutputs));
-# 996 "Gen/ProjectParser.fs"
+# 997 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionIdentifier in
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 123 "ProjectParser/Parser.fsy"
+# 124 "ProjectParser/Parser.fsy"
                                                             TargetComponents.Step { Extension = _1; Command = _2; Parameters = Map.empty } 
                    )
-# 123 "ProjectParser/Parser.fsy"
+# 124 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetStep));
-# 1008 "Gen/ProjectParser.fs"
+# 1009 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionIdentifier in
             let _2 = parseState.GetInput(2) :?> string in
@@ -1013,258 +1014,258 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 124 "ProjectParser/Parser.fsy"
+# 125 "ProjectParser/Parser.fsy"
                                                                     TargetComponents.Step { Extension = _1; Command = _2; Parameters = _3 } 
                    )
-# 124 "ProjectParser/Parser.fsy"
+# 125 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetStep));
-# 1021 "Gen/ProjectParser.fs"
+# 1022 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 128 "ProjectParser/Parser.fsy"
+# 129 "ProjectParser/Parser.fsy"
                                      Expr.Nothing 
                    )
-# 128 "ProjectParser/Parser.fsy"
+# 129 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1031 "Gen/ProjectParser.fs"
+# 1032 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 129 "ProjectParser/Parser.fsy"
+# 130 "ProjectParser/Parser.fsy"
                                   Expr.Bool true 
                    )
-# 129 "ProjectParser/Parser.fsy"
+# 130 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1041 "Gen/ProjectParser.fs"
+# 1042 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 130 "ProjectParser/Parser.fsy"
+# 131 "ProjectParser/Parser.fsy"
                                    Expr.Bool false 
                    )
-# 130 "ProjectParser/Parser.fsy"
+# 131 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1051 "Gen/ProjectParser.fs"
+# 1052 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 131 "ProjectParser/Parser.fsy"
+# 132 "ProjectParser/Parser.fsy"
                                     Expr.String _1 
                    )
-# 131 "ProjectParser/Parser.fsy"
+# 132 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1062 "Gen/ProjectParser.fs"
+# 1063 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 132 "ProjectParser/Parser.fsy"
+# 133 "ProjectParser/Parser.fsy"
                                     Expr.Number _1 
                    )
-# 132 "ProjectParser/Parser.fsy"
+# 133 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1073 "Gen/ProjectParser.fs"
+# 1074 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 133 "ProjectParser/Parser.fsy"
+# 134 "ProjectParser/Parser.fsy"
                                       Expr.Variable _1 
                    )
-# 133 "ProjectParser/Parser.fsy"
+# 134 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1084 "Gen/ProjectParser.fs"
+# 1085 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprList in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 135 "ProjectParser/Parser.fsy"
+# 136 "ProjectParser/Parser.fsy"
                                       Expr.List _1 
                    )
-# 135 "ProjectParser/Parser.fsy"
+# 136 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1095 "Gen/ProjectParser.fs"
+# 1096 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprMap in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 136 "ProjectParser/Parser.fsy"
+# 137 "ProjectParser/Parser.fsy"
                                      Expr.Map _1 
                    )
-# 136 "ProjectParser/Parser.fsy"
+# 137 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1106 "Gen/ProjectParser.fs"
+# 1107 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 138 "ProjectParser/Parser.fsy"
+# 139 "ProjectParser/Parser.fsy"
                                                 Expr.Function (Function.Item, [_1;  _3]) 
                    )
-# 138 "ProjectParser/Parser.fsy"
+# 139 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1118 "Gen/ProjectParser.fs"
+# 1119 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 139 "ProjectParser/Parser.fsy"
+# 140 "ProjectParser/Parser.fsy"
                                                          Expr.Function (Function.TryItem, [_1; _3]) 
                    )
-# 139 "ProjectParser/Parser.fsy"
+# 140 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1130 "Gen/ProjectParser.fs"
+# 1131 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 140 "ProjectParser/Parser.fsy"
+# 141 "ProjectParser/Parser.fsy"
                                                     Expr.Function (Function.Equal, [_1; _3]) 
                    )
-# 140 "ProjectParser/Parser.fsy"
+# 141 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1142 "Gen/ProjectParser.fs"
+# 1143 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 141 "ProjectParser/Parser.fsy"
+# 142 "ProjectParser/Parser.fsy"
                                                  Expr.Function (Function.NotEqual, [_1; _3]) 
                    )
-# 141 "ProjectParser/Parser.fsy"
+# 142 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1154 "Gen/ProjectParser.fs"
+# 1155 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 142 "ProjectParser/Parser.fsy"
+# 143 "ProjectParser/Parser.fsy"
                                             Expr.Function (Function.Plus, [_1; _3]) 
                    )
-# 142 "ProjectParser/Parser.fsy"
+# 143 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1166 "Gen/ProjectParser.fs"
+# 1167 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 143 "ProjectParser/Parser.fsy"
+# 144 "ProjectParser/Parser.fsy"
                                              Expr.Function (Function.Minus, [_1; _3]) 
                    )
-# 143 "ProjectParser/Parser.fsy"
+# 144 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1178 "Gen/ProjectParser.fs"
+# 1179 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 144 "ProjectParser/Parser.fsy"
+# 145 "ProjectParser/Parser.fsy"
                                             Expr.Function (Function.Trim, _2) 
                    )
-# 144 "ProjectParser/Parser.fsy"
+# 145 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1189 "Gen/ProjectParser.fs"
+# 1190 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 145 "ProjectParser/Parser.fsy"
+# 146 "ProjectParser/Parser.fsy"
                                              Expr.Function (Function.Upper, _2) 
                    )
-# 145 "ProjectParser/Parser.fsy"
+# 146 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1200 "Gen/ProjectParser.fs"
+# 1201 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 146 "ProjectParser/Parser.fsy"
+# 147 "ProjectParser/Parser.fsy"
                                              Expr.Function (Function.Lower, _2) 
                    )
-# 146 "ProjectParser/Parser.fsy"
+# 147 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1211 "Gen/ProjectParser.fs"
+# 1212 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 147 "ProjectParser/Parser.fsy"
+# 148 "ProjectParser/Parser.fsy"
                                                Expr.Function (Function.Replace, _2) 
                    )
-# 147 "ProjectParser/Parser.fsy"
+# 148 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1222 "Gen/ProjectParser.fs"
+# 1223 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 148 "ProjectParser/Parser.fsy"
+# 149 "ProjectParser/Parser.fsy"
                                              Expr.Function (Function.Count, _2)
                    )
-# 148 "ProjectParser/Parser.fsy"
+# 149 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1233 "Gen/ProjectParser.fs"
+# 1234 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 149 "ProjectParser/Parser.fsy"
+# 150 "ProjectParser/Parser.fsy"
                                                Expr.Function (Function.Version, _2) 
                    )
-# 149 "ProjectParser/Parser.fsy"
+# 150 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1244 "Gen/ProjectParser.fs"
+# 1245 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 150 "ProjectParser/Parser.fsy"
+# 151 "ProjectParser/Parser.fsy"
                                               Expr.Function (Function.Format, _2) 
                    )
-# 150 "ProjectParser/Parser.fsy"
+# 151 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1255 "Gen/ProjectParser.fs"
+# 1256 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 151 "ProjectParser/Parser.fsy"
+# 152 "ProjectParser/Parser.fsy"
                                                        Expr.Function (Function.Coalesce, [_1; _3]) 
                    )
-# 151 "ProjectParser/Parser.fsy"
+# 152 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1267 "Gen/ProjectParser.fs"
+# 1268 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1272,207 +1273,218 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 152 "ProjectParser/Parser.fsy"
+# 153 "ProjectParser/Parser.fsy"
                                                            Expr.Function (Function.Ternary, [_1; _3; _5] ) 
                    )
-# 152 "ProjectParser/Parser.fsy"
+# 153 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1280 "Gen/ProjectParser.fs"
+# 1281 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 153 "ProjectParser/Parser.fsy"
+# 154 "ProjectParser/Parser.fsy"
                                        Expr.Function (Function.Not, [_2]) 
                    )
-# 153 "ProjectParser/Parser.fsy"
+# 154 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1291 "Gen/ProjectParser.fs"
+# 1292 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 156 "ProjectParser/Parser.fsy"
+# 157 "ProjectParser/Parser.fsy"
                                                _1 
                    )
-# 156 "ProjectParser/Parser.fsy"
+# 157 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetIdentifier));
-# 1302 "Gen/ProjectParser.fs"
+# 1303 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 157 "ProjectParser/Parser.fsy"
+# 158 "ProjectParser/Parser.fsy"
                                         _1 
                    )
-# 157 "ProjectParser/Parser.fsy"
+# 158 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetIdentifier));
-# 1313 "Gen/ProjectParser.fs"
+# 1314 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 160 "ProjectParser/Parser.fsy"
+# 161 "ProjectParser/Parser.fsy"
                                                   _1 
                    )
-# 160 "ProjectParser/Parser.fsy"
+# 161 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionIdentifier));
-# 1324 "Gen/ProjectParser.fs"
+# 1325 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 161 "ProjectParser/Parser.fsy"
+# 162 "ProjectParser/Parser.fsy"
                                         _1 
                    )
-# 161 "ProjectParser/Parser.fsy"
+# 162 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionIdentifier));
-# 1335 "Gen/ProjectParser.fs"
+# 1336 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 164 "ProjectParser/Parser.fsy"
+# 165 "ProjectParser/Parser.fsy"
                                     Expr.Number _1 
                    )
-# 164 "ProjectParser/Parser.fsy"
+# 165 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprIndex));
-# 1346 "Gen/ProjectParser.fs"
+# 1347 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 165 "ProjectParser/Parser.fsy"
+# 166 "ProjectParser/Parser.fsy"
                                         Expr.String _1 
                    )
-# 165 "ProjectParser/Parser.fsy"
+# 166 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprIndex));
-# 1357 "Gen/ProjectParser.fs"
+# 1358 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 168 "ProjectParser/Parser.fsy"
+# 169 "ProjectParser/Parser.fsy"
                                   true 
                    )
-# 168 "ProjectParser/Parser.fsy"
+# 169 "ProjectParser/Parser.fsy"
                  : 'gentype_Bool));
-# 1367 "Gen/ProjectParser.fs"
+# 1368 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 169 "ProjectParser/Parser.fsy"
+# 170 "ProjectParser/Parser.fsy"
                                    false 
                    )
-# 169 "ProjectParser/Parser.fsy"
+# 170 "ProjectParser/Parser.fsy"
                  : 'gentype_Bool));
-# 1377 "Gen/ProjectParser.fs"
+# 1378 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 172 "ProjectParser/Parser.fsy"
+# 173 "ProjectParser/Parser.fsy"
                                     _1 
                    )
-# 172 "ProjectParser/Parser.fsy"
+# 173 "ProjectParser/Parser.fsy"
                  : 'gentype_String));
-# 1388 "Gen/ProjectParser.fs"
+# 1389 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _2 = parseState.GetInput(2) :?> 'gentype_ExprListContent in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTupleContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 175 "ProjectParser/Parser.fsy"
-                                                           _2 
+# 176 "ProjectParser/Parser.fsy"
+                                                            _2 
                    )
-# 175 "ProjectParser/Parser.fsy"
+# 176 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprTuple));
-# 1399 "Gen/ProjectParser.fs"
+# 1400 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 177 "ProjectParser/Parser.fsy"
+# 178 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 177 "ProjectParser/Parser.fsy"
+# 178 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprTupleContent));
-# 1409 "Gen/ProjectParser.fs"
+# 1410 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _1 = parseState.GetInput(1) :?> 'gentype_ExprListContent in
+            let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 179 "ProjectParser/Parser.fsy"
+                                  [_1] 
+                   )
+# 179 "ProjectParser/Parser.fsy"
+                 : 'gentype_ExprTupleContent));
+# 1421 "Gen/ProjectParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            let _1 = parseState.GetInput(1) :?> 'gentype_ExprTupleContent in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 178 "ProjectParser/Parser.fsy"
-                                                        _1 @ [_3] 
+# 180 "ProjectParser/Parser.fsy"
+                                                         _1 @ [_3] 
                    )
-# 178 "ProjectParser/Parser.fsy"
+# 180 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprTupleContent));
-# 1421 "Gen/ProjectParser.fs"
+# 1433 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprListContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 181 "ProjectParser/Parser.fsy"
+# 183 "ProjectParser/Parser.fsy"
                                                                    _2 
                    )
-# 181 "ProjectParser/Parser.fsy"
+# 183 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprList));
-# 1432 "Gen/ProjectParser.fs"
+# 1444 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 183 "ProjectParser/Parser.fsy"
+# 185 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 183 "ProjectParser/Parser.fsy"
+# 185 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprListContent));
-# 1442 "Gen/ProjectParser.fs"
+# 1454 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprListContent in
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 184 "ProjectParser/Parser.fsy"
+# 186 "ProjectParser/Parser.fsy"
                                                   _1 @ [_2] 
                    )
-# 184 "ProjectParser/Parser.fsy"
+# 186 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprListContent));
-# 1454 "Gen/ProjectParser.fs"
+# 1466 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprMapContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 187 "ProjectParser/Parser.fsy"
+# 189 "ProjectParser/Parser.fsy"
                                                           _2 
                    )
-# 187 "ProjectParser/Parser.fsy"
+# 189 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprMap));
-# 1465 "Gen/ProjectParser.fs"
+# 1477 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 189 "ProjectParser/Parser.fsy"
+# 191 "ProjectParser/Parser.fsy"
                                          Map.empty 
                    )
-# 189 "ProjectParser/Parser.fsy"
+# 191 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprMapContent));
-# 1475 "Gen/ProjectParser.fs"
+# 1487 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprMapContent in
             let _2 = parseState.GetInput(2) :?> string in
@@ -1480,112 +1492,112 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 190 "ProjectParser/Parser.fsy"
+# 192 "ProjectParser/Parser.fsy"
                                                      _1.Add (_2, _3) 
                    )
-# 190 "ProjectParser/Parser.fsy"
+# 192 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprMapContent));
-# 1488 "Gen/ProjectParser.fs"
+# 1500 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Strings in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 193 "ProjectParser/Parser.fsy"
+# 195 "ProjectParser/Parser.fsy"
                                                            _2 
                    )
-# 193 "ProjectParser/Parser.fsy"
+# 195 "ProjectParser/Parser.fsy"
                  : 'gentype_ListOfString));
-# 1499 "Gen/ProjectParser.fs"
+# 1511 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 195 "ProjectParser/Parser.fsy"
+# 197 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 195 "ProjectParser/Parser.fsy"
+# 197 "ProjectParser/Parser.fsy"
                  : 'gentype_Strings));
-# 1509 "Gen/ProjectParser.fs"
+# 1521 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Strings in
             let _2 = parseState.GetInput(2) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 196 "ProjectParser/Parser.fsy"
+# 198 "ProjectParser/Parser.fsy"
                                             _1 @ [_2] 
                    )
-# 196 "ProjectParser/Parser.fsy"
+# 198 "ProjectParser/Parser.fsy"
                  : 'gentype_Strings));
-# 1521 "Gen/ProjectParser.fs"
+# 1533 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Identifiers in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 199 "ProjectParser/Parser.fsy"
+# 201 "ProjectParser/Parser.fsy"
                                                                _2 
                    )
-# 199 "ProjectParser/Parser.fsy"
+# 201 "ProjectParser/Parser.fsy"
                  : 'gentype_ListOfIdentifiers));
-# 1532 "Gen/ProjectParser.fs"
+# 1544 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 201 "ProjectParser/Parser.fsy"
+# 203 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 201 "ProjectParser/Parser.fsy"
+# 203 "ProjectParser/Parser.fsy"
                  : 'gentype_Identifiers));
-# 1542 "Gen/ProjectParser.fs"
+# 1554 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Identifiers in
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 202 "ProjectParser/Parser.fsy"
+# 204 "ProjectParser/Parser.fsy"
                                                     _1 @ [_2] 
                    )
-# 202 "ProjectParser/Parser.fsy"
+# 204 "ProjectParser/Parser.fsy"
                  : 'gentype_Identifiers));
-# 1554 "Gen/ProjectParser.fs"
+# 1566 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetIdentifiers in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 205 "ProjectParser/Parser.fsy"
+# 207 "ProjectParser/Parser.fsy"
                                                                      _2 
                    )
-# 205 "ProjectParser/Parser.fsy"
+# 207 "ProjectParser/Parser.fsy"
                  : 'gentype_ListOfTargetIdentifiers));
-# 1565 "Gen/ProjectParser.fs"
+# 1577 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 207 "ProjectParser/Parser.fsy"
+# 209 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 207 "ProjectParser/Parser.fsy"
+# 209 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetIdentifiers));
-# 1575 "Gen/ProjectParser.fs"
+# 1587 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetIdentifiers in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetIdentifier in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 208 "ProjectParser/Parser.fsy"
+# 210 "ProjectParser/Parser.fsy"
                                                                 _1 @ [_2] 
                    )
-# 208 "ProjectParser/Parser.fsy"
+# 210 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetIdentifiers));
 |]
-# 1588 "Gen/ProjectParser.fs"
+# 1600 "Gen/ProjectParser.fs"
 let tables : FSharp.Text.Parsing.Tables<_> = 
   { reductions = _fsyacc_reductions.Value;
     endOfInputTag = _fsyacc_endOfInputTag;

--- a/src/Terrabuild.Configuration/Gen/ProjectParser.fs
+++ b/src/Terrabuild.Configuration/Gen/ProjectParser.fs
@@ -161,6 +161,8 @@ type nonTerminalId =
     | NONTERM_ExprIndex
     | NONTERM_Bool
     | NONTERM_String
+    | NONTERM_ExprTuple
+    | NONTERM_ExprTupleContent
     | NONTERM_ExprList
     | NONTERM_ExprListContent
     | NONTERM_ExprMap
@@ -369,21 +371,24 @@ let prodIdxToNonTerminal (prodIdx:int) =
     | 74 -> NONTERM_Bool 
     | 75 -> NONTERM_Bool 
     | 76 -> NONTERM_String 
-    | 77 -> NONTERM_ExprList 
-    | 78 -> NONTERM_ExprListContent 
-    | 79 -> NONTERM_ExprListContent 
-    | 80 -> NONTERM_ExprMap 
-    | 81 -> NONTERM_ExprMapContent 
-    | 82 -> NONTERM_ExprMapContent 
-    | 83 -> NONTERM_ListOfString 
-    | 84 -> NONTERM_Strings 
-    | 85 -> NONTERM_Strings 
-    | 86 -> NONTERM_ListOfIdentifiers 
-    | 87 -> NONTERM_Identifiers 
-    | 88 -> NONTERM_Identifiers 
-    | 89 -> NONTERM_ListOfTargetIdentifiers 
-    | 90 -> NONTERM_TargetIdentifiers 
-    | 91 -> NONTERM_TargetIdentifiers 
+    | 77 -> NONTERM_ExprTuple 
+    | 78 -> NONTERM_ExprTupleContent 
+    | 79 -> NONTERM_ExprTupleContent 
+    | 80 -> NONTERM_ExprList 
+    | 81 -> NONTERM_ExprListContent 
+    | 82 -> NONTERM_ExprListContent 
+    | 83 -> NONTERM_ExprMap 
+    | 84 -> NONTERM_ExprMapContent 
+    | 85 -> NONTERM_ExprMapContent 
+    | 86 -> NONTERM_ListOfString 
+    | 87 -> NONTERM_Strings 
+    | 88 -> NONTERM_Strings 
+    | 89 -> NONTERM_ListOfIdentifiers 
+    | 90 -> NONTERM_Identifiers 
+    | 91 -> NONTERM_Identifiers 
+    | 92 -> NONTERM_ListOfTargetIdentifiers 
+    | 93 -> NONTERM_TargetIdentifiers 
+    | 94 -> NONTERM_TargetIdentifiers 
     | _ -> failwith "prodIdxToNonTerminal: bad production index"
 
 let _fsyacc_endOfInputTag = 55 
@@ -502,18 +507,18 @@ let _fsyacc_dataOfToken (t:token) =
   | NOTHING  -> (null : System.Object) 
   | TRUE  -> (null : System.Object) 
   | FALSE  -> (null : System.Object) 
-let _fsyacc_gotos = [| 0us;65535us;1us;65535us;0us;1us;1us;65535us;0us;2us;1us;65535us;2us;5us;1us;65535us;9us;10us;1us;65535us;10us;12us;1us;65535us;10us;13us;1us;65535us;10us;14us;1us;65535us;10us;15us;1us;65535us;2us;4us;2us;65535us;29us;30us;33us;34us;2us;65535us;30us;36us;34us;36us;2us;65535us;30us;37us;34us;37us;2us;65535us;30us;38us;34us;38us;2us;65535us;30us;39us;34us;39us;2us;65535us;30us;40us;34us;40us;2us;65535us;30us;41us;34us;41us;1us;65535us;2us;6us;1us;65535us;62us;63us;1us;65535us;63us;65us;1us;65535us;63us;66us;1us;65535us;63us;67us;1us;65535us;63us;68us;20us;65535us;73us;74us;96us;97us;97us;98us;111us;89us;112us;90us;113us;91us;114us;92us;116us;93us;119us;94us;122us;95us;125us;96us;128us;99us;131us;100us;135us;105us;137us;101us;138us;102us;139us;103us;140us;104us;149us;105us;154us;106us;1us;65535us;160us;162us;3us;65535us;7us;8us;28us;32us;63us;78us;2us;65535us;107us;108us;109us;110us;0us;65535us;3us;65535us;17us;18us;23us;24us;156us;158us;20us;65535us;73us;87us;96us;87us;97us;87us;111us;87us;112us;87us;113us;87us;114us;87us;116us;87us;119us;87us;122us;87us;125us;87us;128us;87us;131us;87us;135us;87us;137us;87us;138us;87us;139us;87us;140us;87us;149us;87us;154us;87us;2us;65535us;134us;135us;148us;149us;22us;65535us;26us;27us;73us;88us;79us;80us;96us;88us;97us;88us;111us;88us;112us;88us;113us;88us;114us;88us;116us;88us;119us;88us;122us;88us;125us;88us;128us;88us;131us;88us;135us;88us;137us;88us;138us;88us;139us;88us;140us;88us;149us;88us;154us;88us;1us;65535us;151us;152us;8us;65535us;20us;21us;43us;44us;46us;47us;49us;50us;52us;53us;55us;56us;58us;59us;76us;77us;1us;65535us;155us;156us;0us;65535us;0us;65535us;1us;65535us;70us;71us;1us;65535us;159us;160us;|]
-let _fsyacc_sparseGotoTableRowOffsets = [|0us;1us;3us;5us;7us;9us;11us;13us;15us;17us;19us;22us;25us;28us;31us;34us;37us;40us;42us;44us;46us;48us;50us;52us;73us;75us;79us;82us;83us;87us;108us;111us;134us;136us;145us;147us;148us;149us;151us;|]
-let _fsyacc_stateToProdIdxsTableElements = [| 1us;0us;1us;0us;4us;1us;3us;4us;5us;1us;1us;1us;3us;1us;4us;1us;5us;1us;6us;1us;6us;1us;6us;5us;6us;8us;9us;10us;11us;1us;6us;1us;8us;1us;9us;1us;10us;1us;11us;1us;12us;1us;12us;1us;12us;1us;13us;1us;13us;1us;13us;1us;14us;1us;14us;1us;14us;1us;15us;1us;15us;1us;15us;4us;16us;17us;18us;19us;1us;17us;7us;17us;21us;22us;23us;24us;25us;26us;1us;17us;2us;18us;19us;1us;19us;7us;19us;21us;22us;23us;24us;25us;26us;1us;19us;1us;21us;1us;22us;1us;23us;1us;24us;1us;25us;1us;26us;1us;27us;1us;27us;1us;27us;1us;28us;1us;28us;1us;28us;1us;29us;1us;29us;1us;29us;1us;30us;1us;30us;1us;30us;1us;31us;1us;31us;1us;31us;1us;32us;1us;32us;1us;32us;1us;33us;1us;33us;1us;33us;5us;33us;35us;36us;37us;38us;1us;33us;1us;35us;1us;36us;1us;37us;1us;38us;1us;39us;1us;39us;1us;39us;1us;40us;1us;40us;9us;40us;52us;53us;54us;55us;56us;57us;65us;66us;1us;41us;1us;41us;1us;41us;2us;42us;43us;2us;42us;43us;1us;43us;1us;44us;1us;45us;1us;46us;1us;47us;1us;48us;1us;49us;1us;50us;1us;51us;9us;52us;53us;54us;54us;55us;56us;57us;65us;66us;9us;52us;53us;54us;55us;55us;56us;57us;65us;66us;9us;52us;53us;54us;55us;56us;56us;57us;65us;66us;9us;52us;53us;54us;55us;56us;57us;57us;65us;66us;9us;52us;53us;54us;55us;56us;57us;58us;65us;66us;9us;52us;53us;54us;55us;56us;57us;59us;65us;66us;9us;52us;53us;54us;55us;56us;57us;60us;65us;66us;9us;52us;53us;54us;55us;56us;57us;61us;65us;66us;9us;52us;53us;54us;55us;56us;57us;61us;65us;66us;9us;52us;53us;54us;55us;56us;57us;61us;65us;66us;9us;52us;53us;54us;55us;56us;57us;62us;65us;66us;9us;52us;53us;54us;55us;56us;57us;63us;65us;66us;9us;52us;53us;54us;55us;56us;57us;65us;65us;66us;9us;52us;53us;54us;55us;56us;57us;65us;66us;66us;9us;52us;53us;54us;55us;56us;57us;65us;66us;66us;9us;52us;53us;54us;55us;56us;57us;65us;66us;67us;9us;52us;53us;54us;55us;56us;57us;65us;66us;79us;9us;52us;53us;54us;55us;56us;57us;65us;66us;82us;1us;52us;1us;52us;1us;53us;1us;53us;1us;54us;1us;55us;1us;56us;1us;57us;1us;58us;1us;58us;1us;58us;1us;59us;1us;59us;1us;59us;1us;60us;1us;60us;1us;60us;1us;61us;1us;61us;1us;61us;1us;62us;1us;62us;1us;62us;1us;63us;1us;63us;1us;63us;1us;64us;1us;64us;2us;64us;79us;1us;64us;1us;65us;1us;66us;1us;66us;1us;67us;1us;68us;1us;69us;1us;70us;1us;71us;1us;72us;1us;73us;1us;76us;1us;77us;2us;77us;79us;1us;77us;1us;80us;2us;80us;82us;1us;80us;1us;82us;1us;83us;2us;83us;85us;1us;83us;1us;85us;1us;89us;2us;89us;91us;1us;89us;1us;91us;|]
-let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us;2us;4us;9us;11us;13us;15us;17us;19us;21us;23us;29us;31us;33us;35us;37us;39us;41us;43us;45us;47us;49us;51us;53us;55us;57us;59us;61us;63us;68us;70us;78us;80us;83us;85us;93us;95us;97us;99us;101us;103us;105us;107us;109us;111us;113us;115us;117us;119us;121us;123us;125us;127us;129us;131us;133us;135us;137us;139us;141us;143us;145us;147us;149us;155us;157us;159us;161us;163us;165us;167us;169us;171us;173us;175us;185us;187us;189us;191us;194us;197us;199us;201us;203us;205us;207us;209us;211us;213us;215us;225us;235us;245us;255us;265us;275us;285us;295us;305us;315us;325us;335us;345us;355us;365us;375us;385us;395us;397us;399us;401us;403us;405us;407us;409us;411us;413us;415us;417us;419us;421us;423us;425us;427us;429us;431us;433us;435us;437us;439us;441us;443us;445us;447us;449us;451us;454us;456us;458us;460us;462us;464us;466us;468us;470us;472us;474us;476us;478us;480us;483us;485us;487us;490us;492us;494us;496us;499us;501us;503us;505us;508us;510us;|]
-let _fsyacc_action_rows = 163
-let _fsyacc_actionTableElements = [|0us;16386us;0us;49152us;4us;32768us;14us;28us;15us;7us;16us;60us;17us;3us;0us;16385us;0us;16387us;0us;16388us;0us;16389us;2us;32768us;47us;143us;48us;144us;1us;32768us;41us;9us;0us;16391us;5us;32768us;6us;19us;7us;16us;9us;22us;12us;25us;42us;11us;0us;16390us;0us;16392us;0us;16393us;0us;16394us;0us;16395us;1us;32768us;32us;17us;1us;32768us;49us;147us;0us;16396us;1us;32768us;32us;20us;1us;32768us;39us;155us;0us;16397us;1us;32768us;32us;23us;1us;32768us;49us;147us;0us;16398us;1us;32768us;32us;26us;1us;32768us;41us;151us;0us;16399us;3us;16400us;41us;29us;47us;143us;48us;144us;0us;16404us;7us;32768us;0us;42us;1us;45us;2us;48us;3us;51us;4us;54us;5us;57us;42us;31us;0us;16401us;1us;16402us;41us;33us;0us;16404us;7us;32768us;0us;42us;1us;45us;2us;48us;3us;51us;4us;54us;5us;57us;42us;35us;0us;16403us;0us;16405us;0us;16406us;0us;16407us;0us;16408us;0us;16409us;0us;16410us;1us;32768us;32us;43us;1us;32768us;39us;155us;0us;16411us;1us;32768us;32us;46us;1us;32768us;39us;155us;0us;16412us;1us;32768us;32us;49us;1us;32768us;39us;155us;0us;16413us;1us;32768us;32us;52us;1us;32768us;39us;155us;0us;16414us;1us;32768us;32us;55us;1us;32768us;39us;155us;0us;16415us;1us;32768us;32us;58us;1us;32768us;39us;155us;0us;16416us;1us;32768us;48us;61us;1us;32768us;41us;62us;0us;16418us;6us;32768us;2us;75us;10us;69us;11us;72us;42us;64us;47us;143us;48us;144us;0us;16417us;0us;16419us;0us;16420us;0us;16421us;0us;16422us;1us;32768us;32us;70us;1us;32768us;39us;159us;0us;16423us;1us;32768us;32us;73us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;8us;16424us;18us;137us;19us;138us;29us;114us;30us;113us;33us;111us;34us;112us;37us;107us;38us;109us;1us;32768us;32us;76us;1us;32768us;39us;155us;0us;16425us;1us;32768us;48us;79us;1us;16426us;41us;151us;0us;16427us;0us;16428us;0us;16429us;0us;16430us;0us;16431us;0us;16432us;0us;16433us;0us;16434us;0us;16435us;4us;16438us;29us;114us;30us;113us;37us;107us;38us;109us;4us;16439us;29us;114us;30us;113us;37us;107us;38us;109us;2us;16440us;37us;107us;38us;109us;3us;16441us;30us;113us;37us;107us;38us;109us;9us;32768us;18us;137us;19us;138us;29us;114us;30us;113us;33us;111us;34us;112us;36us;117us;37us;107us;38us;109us;9us;32768us;18us;137us;19us;138us;29us;114us;30us;113us;33us;111us;34us;112us;36us;120us;37us;107us;38us;109us;9us;32768us;18us;137us;19us;138us;29us;114us;30us;113us;33us;111us;34us;112us;36us;123us;37us;107us;38us;109us;24us;32768us;18us;137us;19us;138us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;29us;114us;30us;113us;33us;111us;34us;112us;37us;107us;38us;109us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;24us;32768us;18us;137us;19us;138us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;29us;114us;30us;113us;33us;111us;34us;112us;37us;107us;38us;109us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;9us;32768us;18us;137us;19us;138us;29us;114us;30us;113us;33us;111us;34us;112us;36us;126us;37us;107us;38us;109us;9us;32768us;18us;137us;19us;138us;29us;114us;30us;113us;33us;111us;34us;112us;36us;129us;37us;107us;38us;109us;9us;32768us;18us;137us;19us;138us;29us;114us;30us;113us;33us;111us;34us;112us;36us;132us;37us;107us;38us;109us;6us;16449us;29us;114us;30us;113us;33us;111us;34us;112us;37us;107us;38us;109us;9us;32768us;18us;137us;19us;138us;20us;139us;29us;114us;30us;113us;33us;111us;34us;112us;37us;107us;38us;109us;8us;16450us;18us;137us;19us;138us;29us;114us;30us;113us;33us;111us;34us;112us;37us;107us;38us;109us;0us;16451us;8us;16463us;18us;137us;19us;138us;29us;114us;30us;113us;33us;111us;34us;112us;37us;107us;38us;109us;8us;16466us;18us;137us;19us;138us;29us;114us;30us;113us;33us;111us;34us;112us;37us;107us;38us;109us;2us;32768us;43us;145us;48us;146us;0us;16436us;2us;32768us;43us;145us;48us;146us;0us;16437us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;1us;32768us;35us;116us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16442us;1us;32768us;35us;119us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16443us;1us;32768us;35us;122us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16444us;1us;32768us;35us;125us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16445us;1us;32768us;35us;128us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16446us;1us;32768us;35us;131us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16447us;1us;32768us;35us;134us;0us;16462us;17us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;36us;136us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16448us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16452us;0us;16453us;0us;16454us;0us;16455us;0us;16456us;0us;16457us;0us;16460us;0us;16462us;17us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;40us;150us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16461us;0us;16465us;2us;32768us;42us;153us;44us;154us;0us;16464us;16us;32768us;21us;140us;22us;115us;23us;118us;24us;121us;25us;124us;26us;127us;27us;130us;28us;133us;39us;148us;41us;151us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16468us;2us;32768us;40us;157us;49us;147us;0us;16467us;0us;16469us;0us;16474us;3us;32768us;40us;161us;46us;141us;48us;142us;0us;16473us;0us;16475us;|]
-let _fsyacc_actionTableRowOffsets = [|0us;1us;2us;7us;8us;9us;10us;11us;14us;16us;17us;23us;24us;25us;26us;27us;28us;30us;32us;33us;35us;37us;38us;40us;42us;43us;45us;47us;48us;52us;53us;61us;62us;64us;65us;73us;74us;75us;76us;77us;78us;79us;80us;82us;84us;85us;87us;89us;90us;92us;94us;95us;97us;99us;100us;102us;104us;105us;107us;109us;110us;112us;114us;115us;122us;123us;124us;125us;126us;127us;129us;131us;132us;134us;151us;160us;162us;164us;165us;167us;169us;170us;171us;172us;173us;174us;175us;176us;177us;178us;183us;188us;191us;195us;205us;215us;225us;250us;275us;285us;295us;305us;312us;322us;331us;332us;341us;350us;353us;354us;357us;358us;375us;392us;409us;426us;428us;445us;446us;448us;465us;466us;468us;485us;486us;488us;505us;506us;508us;525us;526us;528us;545us;546us;548us;549us;567us;568us;585us;602us;619us;636us;637us;638us;639us;640us;641us;642us;643us;644us;662us;663us;664us;667us;668us;685us;686us;689us;690us;691us;692us;696us;697us;|]
-let _fsyacc_reductionSymbolCounts = [|1us;2us;0us;2us;2us;2us;5us;0us;2us;2us;2us;2us;3us;3us;3us;3us;1us;4us;2us;5us;0us;2us;2us;2us;2us;2us;2us;3us;3us;3us;3us;3us;3us;5us;0us;2us;2us;2us;2us;3us;3us;3us;2us;3us;1us;1us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;4us;4us;4us;6us;4us;4us;4us;3us;5us;2us;1us;1us;1us;1us;1us;1us;1us;1us;1us;3us;0us;2us;3us;0us;3us;3us;0us;2us;3us;0us;2us;3us;0us;2us;|]
-let _fsyacc_productionToNonTerminalTable = [|0us;1us;2us;2us;2us;2us;3us;4us;4us;4us;4us;4us;5us;6us;7us;8us;9us;9us;9us;9us;10us;10us;10us;10us;10us;10us;10us;11us;12us;13us;14us;15us;16us;17us;18us;18us;18us;18us;18us;19us;20us;21us;22us;22us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;24us;24us;25us;25us;26us;26us;27us;27us;28us;29us;30us;30us;31us;32us;32us;33us;34us;34us;35us;36us;36us;37us;38us;38us;|]
-let _fsyacc_immediateActions = [|65535us;49152us;65535us;16385us;16387us;16388us;16389us;65535us;65535us;65535us;65535us;16390us;16392us;16393us;16394us;16395us;65535us;65535us;16396us;65535us;65535us;16397us;65535us;65535us;16398us;65535us;65535us;16399us;65535us;65535us;65535us;16401us;65535us;65535us;65535us;16403us;16405us;16406us;16407us;16408us;16409us;16410us;65535us;65535us;16411us;65535us;65535us;16412us;65535us;65535us;16413us;65535us;65535us;16414us;65535us;65535us;16415us;65535us;65535us;16416us;65535us;65535us;65535us;65535us;16417us;16419us;16420us;16421us;16422us;65535us;65535us;16423us;65535us;65535us;65535us;65535us;65535us;16425us;65535us;65535us;16427us;16428us;16429us;16430us;16431us;16432us;16433us;16434us;16435us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16436us;65535us;16437us;65535us;65535us;65535us;65535us;65535us;65535us;16442us;65535us;65535us;16443us;65535us;65535us;16444us;65535us;65535us;16445us;65535us;65535us;16446us;65535us;65535us;16447us;65535us;65535us;65535us;16448us;65535us;65535us;65535us;65535us;16452us;16453us;16454us;16455us;16456us;16457us;16460us;65535us;65535us;16461us;65535us;65535us;16464us;65535us;65535us;65535us;16467us;16469us;65535us;65535us;16473us;16475us;|]
+let _fsyacc_gotos = [| 0us;65535us;1us;65535us;0us;1us;1us;65535us;0us;2us;1us;65535us;2us;5us;1us;65535us;9us;10us;1us;65535us;10us;12us;1us;65535us;10us;13us;1us;65535us;10us;14us;1us;65535us;10us;15us;1us;65535us;2us;4us;2us;65535us;29us;30us;33us;34us;2us;65535us;30us;36us;34us;36us;2us;65535us;30us;37us;34us;37us;2us;65535us;30us;38us;34us;38us;2us;65535us;30us;39us;34us;39us;2us;65535us;30us;40us;34us;40us;2us;65535us;30us;41us;34us;41us;1us;65535us;2us;6us;1us;65535us;62us;63us;1us;65535us;63us;65us;1us;65535us;63us;66us;1us;65535us;63us;67us;1us;65535us;63us;68us;12us;65535us;73us;74us;103us;89us;104us;90us;105us;91us;106us;92us;121us;93us;122us;94us;123us;95us;124us;96us;133us;97us;136us;97us;141us;98us;1us;65535us;147us;149us;3us;65535us;7us;8us;28us;32us;63us;78us;2us;65535us;99us;100us;101us;102us;0us;65535us;3us;65535us;17us;18us;23us;24us;143us;145us;7us;65535us;107us;108us;109us;110us;111us;112us;113us;114us;115us;116us;117us;118us;119us;120us;0us;65535us;12us;65535us;73us;87us;103us;87us;104us;87us;105us;87us;106us;87us;121us;87us;122us;87us;123us;87us;124us;87us;133us;87us;136us;87us;141us;87us;2us;65535us;132us;133us;135us;136us;14us;65535us;26us;27us;73us;88us;79us;80us;103us;88us;104us;88us;105us;88us;106us;88us;121us;88us;122us;88us;123us;88us;124us;88us;133us;88us;136us;88us;141us;88us;1us;65535us;138us;139us;8us;65535us;20us;21us;43us;44us;46us;47us;49us;50us;52us;53us;55us;56us;58us;59us;76us;77us;1us;65535us;142us;143us;0us;65535us;0us;65535us;1us;65535us;70us;71us;1us;65535us;146us;147us;|]
+let _fsyacc_sparseGotoTableRowOffsets = [|0us;1us;3us;5us;7us;9us;11us;13us;15us;17us;19us;22us;25us;28us;31us;34us;37us;40us;42us;44us;46us;48us;50us;52us;65us;67us;71us;74us;75us;79us;87us;88us;101us;104us;119us;121us;130us;132us;133us;134us;136us;|]
+let _fsyacc_stateToProdIdxsTableElements = [| 1us;0us;1us;0us;4us;1us;3us;4us;5us;1us;1us;1us;3us;1us;4us;1us;5us;1us;6us;1us;6us;1us;6us;5us;6us;8us;9us;10us;11us;1us;6us;1us;8us;1us;9us;1us;10us;1us;11us;1us;12us;1us;12us;1us;12us;1us;13us;1us;13us;1us;13us;1us;14us;1us;14us;1us;14us;1us;15us;1us;15us;1us;15us;4us;16us;17us;18us;19us;1us;17us;7us;17us;21us;22us;23us;24us;25us;26us;1us;17us;2us;18us;19us;1us;19us;7us;19us;21us;22us;23us;24us;25us;26us;1us;19us;1us;21us;1us;22us;1us;23us;1us;24us;1us;25us;1us;26us;1us;27us;1us;27us;1us;27us;1us;28us;1us;28us;1us;28us;1us;29us;1us;29us;1us;29us;1us;30us;1us;30us;1us;30us;1us;31us;1us;31us;1us;31us;1us;32us;1us;32us;1us;32us;1us;33us;1us;33us;1us;33us;5us;33us;35us;36us;37us;38us;1us;33us;1us;35us;1us;36us;1us;37us;1us;38us;1us;39us;1us;39us;1us;39us;1us;40us;1us;40us;9us;40us;52us;53us;54us;55us;56us;57us;65us;66us;1us;41us;1us;41us;1us;41us;2us;42us;43us;2us;42us;43us;1us;43us;1us;44us;1us;45us;1us;46us;1us;47us;1us;48us;1us;49us;1us;50us;1us;51us;9us;52us;53us;54us;54us;55us;56us;57us;65us;66us;9us;52us;53us;54us;55us;55us;56us;57us;65us;66us;9us;52us;53us;54us;55us;56us;56us;57us;65us;66us;9us;52us;53us;54us;55us;56us;57us;57us;65us;66us;9us;52us;53us;54us;55us;56us;57us;65us;65us;66us;9us;52us;53us;54us;55us;56us;57us;65us;66us;66us;9us;52us;53us;54us;55us;56us;57us;65us;66us;66us;9us;52us;53us;54us;55us;56us;57us;65us;66us;67us;9us;52us;53us;54us;55us;56us;57us;65us;66us;82us;9us;52us;53us;54us;55us;56us;57us;65us;66us;85us;1us;52us;1us;52us;1us;53us;1us;53us;1us;54us;1us;55us;1us;56us;1us;57us;1us;58us;1us;58us;1us;59us;1us;59us;1us;60us;1us;60us;1us;61us;1us;61us;1us;62us;1us;62us;1us;63us;1us;63us;1us;64us;1us;64us;1us;65us;1us;66us;1us;66us;1us;67us;1us;68us;1us;69us;1us;70us;1us;71us;1us;72us;1us;73us;1us;76us;1us;77us;2us;77us;82us;1us;77us;1us;80us;2us;80us;82us;1us;80us;1us;83us;2us;83us;85us;1us;83us;1us;85us;1us;86us;2us;86us;88us;1us;86us;1us;88us;1us;92us;2us;92us;94us;1us;92us;1us;94us;|]
+let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us;2us;4us;9us;11us;13us;15us;17us;19us;21us;23us;29us;31us;33us;35us;37us;39us;41us;43us;45us;47us;49us;51us;53us;55us;57us;59us;61us;63us;68us;70us;78us;80us;83us;85us;93us;95us;97us;99us;101us;103us;105us;107us;109us;111us;113us;115us;117us;119us;121us;123us;125us;127us;129us;131us;133us;135us;137us;139us;141us;143us;145us;147us;149us;155us;157us;159us;161us;163us;165us;167us;169us;171us;173us;175us;185us;187us;189us;191us;194us;197us;199us;201us;203us;205us;207us;209us;211us;213us;215us;225us;235us;245us;255us;265us;275us;285us;295us;305us;315us;317us;319us;321us;323us;325us;327us;329us;331us;333us;335us;337us;339us;341us;343us;345us;347us;349us;351us;353us;355us;357us;359us;361us;363us;365us;367us;369us;371us;373us;375us;377us;379us;381us;383us;386us;388us;390us;393us;395us;397us;400us;402us;404us;406us;409us;411us;413us;415us;418us;420us;|]
+let _fsyacc_action_rows = 150
+let _fsyacc_actionTableElements = [|0us;16386us;0us;49152us;4us;32768us;14us;28us;15us;7us;16us;60us;17us;3us;0us;16385us;0us;16387us;0us;16388us;0us;16389us;2us;32768us;47us;127us;48us;128us;1us;32768us;41us;9us;0us;16391us;5us;32768us;6us;19us;7us;16us;9us;22us;12us;25us;42us;11us;0us;16390us;0us;16392us;0us;16393us;0us;16394us;0us;16395us;1us;32768us;32us;17us;1us;32768us;49us;131us;0us;16396us;1us;32768us;32us;20us;1us;32768us;39us;142us;0us;16397us;1us;32768us;32us;23us;1us;32768us;49us;131us;0us;16398us;1us;32768us;32us;26us;1us;32768us;41us;138us;0us;16399us;3us;16400us;41us;29us;47us;127us;48us;128us;0us;16404us;7us;32768us;0us;42us;1us;45us;2us;48us;3us;51us;4us;54us;5us;57us;42us;31us;0us;16401us;1us;16402us;41us;33us;0us;16404us;7us;32768us;0us;42us;1us;45us;2us;48us;3us;51us;4us;54us;5us;57us;42us;35us;0us;16403us;0us;16405us;0us;16406us;0us;16407us;0us;16408us;0us;16409us;0us;16410us;1us;32768us;32us;43us;1us;32768us;39us;142us;0us;16411us;1us;32768us;32us;46us;1us;32768us;39us;142us;0us;16412us;1us;32768us;32us;49us;1us;32768us;39us;142us;0us;16413us;1us;32768us;32us;52us;1us;32768us;39us;142us;0us;16414us;1us;32768us;32us;55us;1us;32768us;39us;142us;0us;16415us;1us;32768us;32us;58us;1us;32768us;39us;142us;0us;16416us;1us;32768us;48us;61us;1us;32768us;41us;62us;0us;16418us;6us;32768us;2us;75us;10us;69us;11us;72us;42us;64us;47us;127us;48us;128us;0us;16417us;0us;16419us;0us;16420us;0us;16421us;0us;16422us;1us;32768us;32us;70us;1us;32768us;39us;146us;0us;16423us;1us;32768us;32us;73us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;8us;16424us;18us;121us;19us;122us;29us;106us;30us;105us;33us;103us;34us;104us;37us;99us;38us;101us;1us;32768us;32us;76us;1us;32768us;39us;142us;0us;16425us;1us;32768us;48us;79us;1us;16426us;41us;138us;0us;16427us;0us;16428us;0us;16429us;0us;16430us;0us;16431us;0us;16432us;0us;16433us;0us;16434us;0us;16435us;4us;16438us;29us;106us;30us;105us;37us;99us;38us;101us;4us;16439us;29us;106us;30us;105us;37us;99us;38us;101us;2us;16440us;37us;99us;38us;101us;3us;16441us;30us;105us;37us;99us;38us;101us;6us;16449us;29us;106us;30us;105us;33us;103us;34us;104us;37us;99us;38us;101us;9us;32768us;18us;121us;19us;122us;20us;123us;29us;106us;30us;105us;33us;103us;34us;104us;37us;99us;38us;101us;8us;16450us;18us;121us;19us;122us;29us;106us;30us;105us;33us;103us;34us;104us;37us;99us;38us;101us;0us;16451us;8us;16466us;18us;121us;19us;122us;29us;106us;30us;105us;33us;103us;34us;104us;37us;99us;38us;101us;8us;16469us;18us;121us;19us;122us;29us;106us;30us;105us;33us;103us;34us;104us;37us;99us;38us;101us;2us;32768us;43us;129us;48us;130us;0us;16436us;2us;32768us;43us;129us;48us;130us;0us;16437us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;1us;32768us;35us;132us;0us;16442us;1us;32768us;35us;132us;0us;16443us;1us;32768us;35us;132us;0us;16444us;1us;32768us;35us;132us;0us;16445us;1us;32768us;35us;132us;0us;16446us;1us;32768us;35us;132us;0us;16447us;1us;32768us;35us;132us;0us;16448us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16452us;0us;16453us;0us;16454us;0us;16455us;0us;16456us;0us;16457us;0us;16460us;0us;16465us;17us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;36us;134us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16461us;0us;16465us;17us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;40us;137us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16464us;0us;16468us;2us;32768us;42us;140us;44us;141us;0us;16467us;16us;32768us;21us;124us;22us;107us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;39us;135us;41us;138us;43us;85us;45us;86us;49us;84us;50us;81us;51us;82us;52us;83us;0us;16471us;2us;32768us;40us;144us;49us;131us;0us;16470us;0us;16472us;0us;16477us;3us;32768us;40us;148us;46us;125us;48us;126us;0us;16476us;0us;16478us;|]
+let _fsyacc_actionTableRowOffsets = [|0us;1us;2us;7us;8us;9us;10us;11us;14us;16us;17us;23us;24us;25us;26us;27us;28us;30us;32us;33us;35us;37us;38us;40us;42us;43us;45us;47us;48us;52us;53us;61us;62us;64us;65us;73us;74us;75us;76us;77us;78us;79us;80us;82us;84us;85us;87us;89us;90us;92us;94us;95us;97us;99us;100us;102us;104us;105us;107us;109us;110us;112us;114us;115us;122us;123us;124us;125us;126us;127us;129us;131us;132us;134us;151us;160us;162us;164us;165us;167us;169us;170us;171us;172us;173us;174us;175us;176us;177us;178us;183us;188us;191us;195us;202us;212us;221us;222us;231us;240us;243us;244us;247us;248us;265us;282us;299us;316us;318us;319us;321us;322us;324us;325us;327us;328us;330us;331us;333us;334us;336us;337us;354us;371us;388us;405us;406us;407us;408us;409us;410us;411us;412us;413us;431us;432us;433us;451us;452us;453us;456us;457us;474us;475us;478us;479us;480us;481us;485us;486us;|]
+let _fsyacc_reductionSymbolCounts = [|1us;2us;0us;2us;2us;2us;5us;0us;2us;2us;2us;2us;3us;3us;3us;3us;1us;4us;2us;5us;0us;2us;2us;2us;2us;2us;2us;3us;3us;3us;3us;3us;3us;5us;0us;2us;2us;2us;2us;3us;3us;3us;2us;3us;1us;1us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;1us;1us;1us;1us;3us;0us;3us;3us;0us;2us;3us;0us;3us;3us;0us;2us;3us;0us;2us;3us;0us;2us;|]
+let _fsyacc_productionToNonTerminalTable = [|0us;1us;2us;2us;2us;2us;3us;4us;4us;4us;4us;4us;5us;6us;7us;8us;9us;9us;9us;9us;10us;10us;10us;10us;10us;10us;10us;11us;12us;13us;14us;15us;16us;17us;18us;18us;18us;18us;18us;19us;20us;21us;22us;22us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;24us;24us;25us;25us;26us;26us;27us;27us;28us;29us;30us;30us;31us;32us;32us;33us;34us;34us;35us;36us;36us;37us;38us;38us;39us;40us;40us;|]
+let _fsyacc_immediateActions = [|65535us;49152us;65535us;16385us;16387us;16388us;16389us;65535us;65535us;65535us;65535us;16390us;16392us;16393us;16394us;16395us;65535us;65535us;16396us;65535us;65535us;16397us;65535us;65535us;16398us;65535us;65535us;16399us;65535us;65535us;65535us;16401us;65535us;65535us;65535us;16403us;16405us;16406us;16407us;16408us;16409us;16410us;65535us;65535us;16411us;65535us;65535us;16412us;65535us;65535us;16413us;65535us;65535us;16414us;65535us;65535us;16415us;65535us;65535us;16416us;65535us;65535us;65535us;65535us;16417us;16419us;16420us;16421us;16422us;65535us;65535us;16423us;65535us;65535us;65535us;65535us;65535us;16425us;65535us;65535us;16427us;16428us;16429us;16430us;16431us;16432us;16433us;16434us;16435us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16436us;65535us;16437us;65535us;65535us;65535us;65535us;65535us;16442us;65535us;16443us;65535us;16444us;65535us;16445us;65535us;16446us;65535us;16447us;65535us;16448us;65535us;65535us;65535us;65535us;16452us;16453us;16454us;16455us;16456us;16457us;16460us;65535us;65535us;16461us;65535us;65535us;16464us;65535us;65535us;16467us;65535us;65535us;65535us;16470us;16472us;65535us;65535us;16476us;16478us;|]
 let _fsyacc_reductions = lazy [|
-# 516 "Gen/ProjectParser.fs"
+# 521 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Terrabuild.Configuration.Project.AST.ProjectFile in
             Microsoft.FSharp.Core.Operators.box
@@ -522,7 +527,7 @@ let _fsyacc_reductions = lazy [|
                       raise (FSharp.Text.Parsing.Accept(Microsoft.FSharp.Core.Operators.box _1))
                    )
                  : 'gentype__startProjectFile));
-# 525 "Gen/ProjectParser.fs"
+# 530 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             Microsoft.FSharp.Core.Operators.box
@@ -533,7 +538,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 55 "ProjectParser/Parser.fsy"
                  : Terrabuild.Configuration.Project.AST.ProjectFile));
-# 536 "Gen/ProjectParser.fs"
+# 541 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -543,7 +548,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 58 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 546 "Gen/ProjectParser.fs"
+# 551 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Project in
@@ -555,7 +560,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 59 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 558 "Gen/ProjectParser.fs"
+# 563 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Extension in
@@ -567,7 +572,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 60 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 570 "Gen/ProjectParser.fs"
+# 575 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Target in
@@ -579,7 +584,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 61 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 582 "Gen/ProjectParser.fs"
+# 587 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionIdentifier in
             let _4 = parseState.GetInput(4) :?> 'gentype_ExtensionComponents in
@@ -591,7 +596,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 65 "ProjectParser/Parser.fsy"
                  : 'gentype_Extension));
-# 594 "Gen/ProjectParser.fs"
+# 599 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -601,7 +606,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 67 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 604 "Gen/ProjectParser.fs"
+# 609 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionContainer in
@@ -613,7 +618,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 68 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 616 "Gen/ProjectParser.fs"
+# 621 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionVariables in
@@ -625,7 +630,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 69 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 628 "Gen/ProjectParser.fs"
+# 633 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionScript in
@@ -637,7 +642,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 70 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 640 "Gen/ProjectParser.fs"
+# 645 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionDefaults in
@@ -649,7 +654,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 71 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 652 "Gen/ProjectParser.fs"
+# 657 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
@@ -660,7 +665,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 73 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionContainer));
-# 663 "Gen/ProjectParser.fs"
+# 668 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
@@ -671,7 +676,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 75 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionVariables));
-# 674 "Gen/ProjectParser.fs"
+# 679 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
@@ -682,7 +687,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 77 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionScript));
-# 685 "Gen/ProjectParser.fs"
+# 690 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprMap in
             Microsoft.FSharp.Core.Operators.box
@@ -693,7 +698,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 79 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionDefaults));
-# 696 "Gen/ProjectParser.fs"
+# 701 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -703,7 +708,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 83 "ProjectParser/Parser.fsy"
                  : 'gentype_Project));
-# 706 "Gen/ProjectParser.fs"
+# 711 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ProjectComponents in
             Microsoft.FSharp.Core.Operators.box
@@ -714,7 +719,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 84 "ProjectParser/Parser.fsy"
                  : 'gentype_Project));
-# 717 "Gen/ProjectParser.fs"
+# 722 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionIdentifier in
             Microsoft.FSharp.Core.Operators.box
@@ -725,7 +730,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 85 "ProjectParser/Parser.fsy"
                  : 'gentype_Project));
-# 728 "Gen/ProjectParser.fs"
+# 733 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionIdentifier in
             let _4 = parseState.GetInput(4) :?> 'gentype_ProjectComponents in
@@ -737,7 +742,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 86 "ProjectParser/Parser.fsy"
                  : 'gentype_Project));
-# 740 "Gen/ProjectParser.fs"
+# 745 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -747,7 +752,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 88 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 750 "Gen/ProjectParser.fs"
+# 755 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectDependencies in
@@ -759,7 +764,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 89 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 762 "Gen/ProjectParser.fs"
+# 767 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectLinks in
@@ -771,7 +776,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 90 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 774 "Gen/ProjectParser.fs"
+# 779 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectOutputs in
@@ -783,7 +788,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 91 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 786 "Gen/ProjectParser.fs"
+# 791 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectIgnores in
@@ -795,7 +800,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 92 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 798 "Gen/ProjectParser.fs"
+# 803 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectIncludes in
@@ -807,7 +812,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 93 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 810 "Gen/ProjectParser.fs"
+# 815 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectLabels in
@@ -819,7 +824,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 94 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 822 "Gen/ProjectParser.fs"
+# 827 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
@@ -830,7 +835,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 96 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectDependencies));
-# 833 "Gen/ProjectParser.fs"
+# 838 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
@@ -841,7 +846,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 98 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectLinks));
-# 844 "Gen/ProjectParser.fs"
+# 849 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
@@ -852,7 +857,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 100 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectOutputs));
-# 855 "Gen/ProjectParser.fs"
+# 860 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
@@ -863,7 +868,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 102 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectIgnores));
-# 866 "Gen/ProjectParser.fs"
+# 871 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
@@ -874,7 +879,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 104 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectIncludes));
-# 877 "Gen/ProjectParser.fs"
+# 882 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
@@ -885,7 +890,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 106 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectLabels));
-# 888 "Gen/ProjectParser.fs"
+# 893 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             let _4 = parseState.GetInput(4) :?> 'gentype_TargetComponents in
@@ -897,7 +902,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 109 "ProjectParser/Parser.fsy"
                  : 'gentype_Target));
-# 900 "Gen/ProjectParser.fs"
+# 905 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -907,7 +912,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 111 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 910 "Gen/ProjectParser.fs"
+# 915 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetDependsOn in
@@ -919,7 +924,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 112 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 922 "Gen/ProjectParser.fs"
+# 927 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetRebuild in
@@ -931,7 +936,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 113 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 934 "Gen/ProjectParser.fs"
+# 939 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetOutputs in
@@ -943,7 +948,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 114 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 946 "Gen/ProjectParser.fs"
+# 951 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetStep in
@@ -955,7 +960,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 115 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 958 "Gen/ProjectParser.fs"
+# 963 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfTargetIdentifiers in
             Microsoft.FSharp.Core.Operators.box
@@ -966,7 +971,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 117 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetDependsOn));
-# 969 "Gen/ProjectParser.fs"
+# 974 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
@@ -977,7 +982,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 119 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetRebuild));
-# 980 "Gen/ProjectParser.fs"
+# 985 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
@@ -988,7 +993,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 121 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetOutputs));
-# 991 "Gen/ProjectParser.fs"
+# 996 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionIdentifier in
             let _2 = parseState.GetInput(2) :?> string in
@@ -1000,7 +1005,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 123 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetStep));
-# 1003 "Gen/ProjectParser.fs"
+# 1008 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionIdentifier in
             let _2 = parseState.GetInput(2) :?> string in
@@ -1013,7 +1018,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 124 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetStep));
-# 1016 "Gen/ProjectParser.fs"
+# 1021 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -1023,7 +1028,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 128 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1026 "Gen/ProjectParser.fs"
+# 1031 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -1033,7 +1038,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 129 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1036 "Gen/ProjectParser.fs"
+# 1041 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -1043,7 +1048,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 130 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1046 "Gen/ProjectParser.fs"
+# 1051 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1054,7 +1059,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 131 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1057 "Gen/ProjectParser.fs"
+# 1062 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
@@ -1065,7 +1070,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 132 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1068 "Gen/ProjectParser.fs"
+# 1073 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1076,7 +1081,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 133 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1079 "Gen/ProjectParser.fs"
+# 1084 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprList in
             Microsoft.FSharp.Core.Operators.box
@@ -1087,7 +1092,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 135 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1090 "Gen/ProjectParser.fs"
+# 1095 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprMap in
             Microsoft.FSharp.Core.Operators.box
@@ -1098,7 +1103,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 136 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1101 "Gen/ProjectParser.fs"
+# 1106 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
@@ -1110,7 +1115,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 138 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1113 "Gen/ProjectParser.fs"
+# 1118 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
@@ -1122,7 +1127,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 139 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1125 "Gen/ProjectParser.fs"
+# 1130 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1134,7 +1139,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 140 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1137 "Gen/ProjectParser.fs"
+# 1142 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1146,7 +1151,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 141 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1149 "Gen/ProjectParser.fs"
+# 1154 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1158,7 +1163,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 142 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1161 "Gen/ProjectParser.fs"
+# 1166 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1170,86 +1175,84 @@ let _fsyacc_reductions = lazy [|
                    )
 # 143 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1173 "Gen/ProjectParser.fs"
+# 1178 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 144 "ProjectParser/Parser.fsy"
-                                                     Expr.Function (Function.Trim, [_3]) 
+                                            Expr.Function (Function.Trim, _2) 
                    )
 # 144 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1184 "Gen/ProjectParser.fs"
+# 1189 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 145 "ProjectParser/Parser.fsy"
-                                                      Expr.Function (Function.Upper, [_3]) 
+                                             Expr.Function (Function.Upper, _2) 
                    )
 # 145 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1195 "Gen/ProjectParser.fs"
+# 1200 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 146 "ProjectParser/Parser.fsy"
-                                                      Expr.Function (Function.Lower, [_3]) 
+                                             Expr.Function (Function.Lower, _2) 
                    )
 # 146 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1206 "Gen/ProjectParser.fs"
+# 1211 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
-            let _4 = parseState.GetInput(4) :?> 'gentype_Expr in
-            let _5 = parseState.GetInput(5) :?> 'gentype_Expr in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 147 "ProjectParser/Parser.fsy"
-                                                                  Expr.Function (Function.Replace, [_3; _4; _5]) 
+                                               Expr.Function (Function.Replace, _2) 
                    )
 # 147 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1219 "Gen/ProjectParser.fs"
+# 1222 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 148 "ProjectParser/Parser.fsy"
-                                                      Expr.Function (Function.Count, [_3])
+                                             Expr.Function (Function.Count, _2)
                    )
 # 148 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1230 "Gen/ProjectParser.fs"
+# 1233 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 149 "ProjectParser/Parser.fsy"
-                                                        Expr.Function (Function.Version, [_3]) 
+                                               Expr.Function (Function.Version, _2) 
                    )
 # 149 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1241 "Gen/ProjectParser.fs"
+# 1244 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_ExprListContent in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 150 "ProjectParser/Parser.fsy"
-                                                                  Expr.Function (Function.Format, _3) 
+                                              Expr.Function (Function.Format, _2) 
                    )
 # 150 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1252 "Gen/ProjectParser.fs"
+# 1255 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1261,7 +1264,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 151 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1264 "Gen/ProjectParser.fs"
+# 1267 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1274,7 +1277,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 152 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1277 "Gen/ProjectParser.fs"
+# 1280 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
@@ -1285,7 +1288,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 153 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1288 "Gen/ProjectParser.fs"
+# 1291 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1296,7 +1299,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 156 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetIdentifier));
-# 1299 "Gen/ProjectParser.fs"
+# 1302 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1307,7 +1310,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 157 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetIdentifier));
-# 1310 "Gen/ProjectParser.fs"
+# 1313 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1318,7 +1321,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 160 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionIdentifier));
-# 1321 "Gen/ProjectParser.fs"
+# 1324 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1329,7 +1332,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 161 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionIdentifier));
-# 1332 "Gen/ProjectParser.fs"
+# 1335 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
@@ -1340,7 +1343,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 164 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprIndex));
-# 1343 "Gen/ProjectParser.fs"
+# 1346 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1351,7 +1354,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 165 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprIndex));
-# 1354 "Gen/ProjectParser.fs"
+# 1357 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -1361,7 +1364,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 168 "ProjectParser/Parser.fsy"
                  : 'gentype_Bool));
-# 1364 "Gen/ProjectParser.fs"
+# 1367 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -1371,7 +1374,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 169 "ProjectParser/Parser.fsy"
                  : 'gentype_Bool));
-# 1374 "Gen/ProjectParser.fs"
+# 1377 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1382,18 +1385,18 @@ let _fsyacc_reductions = lazy [|
                    )
 # 172 "ProjectParser/Parser.fsy"
                  : 'gentype_String));
-# 1385 "Gen/ProjectParser.fs"
+# 1388 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprListContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 175 "ProjectParser/Parser.fsy"
-                                                                   _2 
+                                                           _2 
                    )
 # 175 "ProjectParser/Parser.fsy"
-                 : 'gentype_ExprList));
-# 1396 "Gen/ProjectParser.fs"
+                 : 'gentype_ExprTuple));
+# 1399 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -1402,41 +1405,74 @@ let _fsyacc_reductions = lazy [|
                                          [] 
                    )
 # 177 "ProjectParser/Parser.fsy"
+                 : 'gentype_ExprTupleContent));
+# 1409 "Gen/ProjectParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            let _1 = parseState.GetInput(1) :?> 'gentype_ExprListContent in
+            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 178 "ProjectParser/Parser.fsy"
+                                                        _1 @ [_3] 
+                   )
+# 178 "ProjectParser/Parser.fsy"
+                 : 'gentype_ExprTupleContent));
+# 1421 "Gen/ProjectParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprListContent in
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 181 "ProjectParser/Parser.fsy"
+                                                                   _2 
+                   )
+# 181 "ProjectParser/Parser.fsy"
+                 : 'gentype_ExprList));
+# 1432 "Gen/ProjectParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 183 "ProjectParser/Parser.fsy"
+                                         [] 
+                   )
+# 183 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprListContent));
-# 1406 "Gen/ProjectParser.fs"
+# 1442 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprListContent in
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 178 "ProjectParser/Parser.fsy"
+# 184 "ProjectParser/Parser.fsy"
                                                   _1 @ [_2] 
                    )
-# 178 "ProjectParser/Parser.fsy"
+# 184 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprListContent));
-# 1418 "Gen/ProjectParser.fs"
+# 1454 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprMapContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 181 "ProjectParser/Parser.fsy"
+# 187 "ProjectParser/Parser.fsy"
                                                           _2 
                    )
-# 181 "ProjectParser/Parser.fsy"
+# 187 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprMap));
-# 1429 "Gen/ProjectParser.fs"
+# 1465 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 183 "ProjectParser/Parser.fsy"
+# 189 "ProjectParser/Parser.fsy"
                                          Map.empty 
                    )
-# 183 "ProjectParser/Parser.fsy"
+# 189 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprMapContent));
-# 1439 "Gen/ProjectParser.fs"
+# 1475 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprMapContent in
             let _2 = parseState.GetInput(2) :?> string in
@@ -1444,112 +1480,112 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 184 "ProjectParser/Parser.fsy"
+# 190 "ProjectParser/Parser.fsy"
                                                      _1.Add (_2, _3) 
                    )
-# 184 "ProjectParser/Parser.fsy"
+# 190 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprMapContent));
-# 1452 "Gen/ProjectParser.fs"
+# 1488 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Strings in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 187 "ProjectParser/Parser.fsy"
+# 193 "ProjectParser/Parser.fsy"
                                                            _2 
                    )
-# 187 "ProjectParser/Parser.fsy"
+# 193 "ProjectParser/Parser.fsy"
                  : 'gentype_ListOfString));
-# 1463 "Gen/ProjectParser.fs"
+# 1499 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 189 "ProjectParser/Parser.fsy"
+# 195 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 189 "ProjectParser/Parser.fsy"
+# 195 "ProjectParser/Parser.fsy"
                  : 'gentype_Strings));
-# 1473 "Gen/ProjectParser.fs"
+# 1509 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Strings in
             let _2 = parseState.GetInput(2) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 190 "ProjectParser/Parser.fsy"
+# 196 "ProjectParser/Parser.fsy"
                                             _1 @ [_2] 
                    )
-# 190 "ProjectParser/Parser.fsy"
+# 196 "ProjectParser/Parser.fsy"
                  : 'gentype_Strings));
-# 1485 "Gen/ProjectParser.fs"
+# 1521 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Identifiers in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 193 "ProjectParser/Parser.fsy"
+# 199 "ProjectParser/Parser.fsy"
                                                                _2 
                    )
-# 193 "ProjectParser/Parser.fsy"
+# 199 "ProjectParser/Parser.fsy"
                  : 'gentype_ListOfIdentifiers));
-# 1496 "Gen/ProjectParser.fs"
+# 1532 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 195 "ProjectParser/Parser.fsy"
+# 201 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 195 "ProjectParser/Parser.fsy"
+# 201 "ProjectParser/Parser.fsy"
                  : 'gentype_Identifiers));
-# 1506 "Gen/ProjectParser.fs"
+# 1542 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Identifiers in
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 196 "ProjectParser/Parser.fsy"
+# 202 "ProjectParser/Parser.fsy"
                                                     _1 @ [_2] 
                    )
-# 196 "ProjectParser/Parser.fsy"
+# 202 "ProjectParser/Parser.fsy"
                  : 'gentype_Identifiers));
-# 1518 "Gen/ProjectParser.fs"
+# 1554 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetIdentifiers in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 199 "ProjectParser/Parser.fsy"
+# 205 "ProjectParser/Parser.fsy"
                                                                      _2 
                    )
-# 199 "ProjectParser/Parser.fsy"
+# 205 "ProjectParser/Parser.fsy"
                  : 'gentype_ListOfTargetIdentifiers));
-# 1529 "Gen/ProjectParser.fs"
+# 1565 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 201 "ProjectParser/Parser.fsy"
+# 207 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 201 "ProjectParser/Parser.fsy"
+# 207 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetIdentifiers));
-# 1539 "Gen/ProjectParser.fs"
+# 1575 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetIdentifiers in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetIdentifier in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 202 "ProjectParser/Parser.fsy"
+# 208 "ProjectParser/Parser.fsy"
                                                                 _1 @ [_2] 
                    )
-# 202 "ProjectParser/Parser.fsy"
+# 208 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetIdentifiers));
 |]
-# 1552 "Gen/ProjectParser.fs"
+# 1588 "Gen/ProjectParser.fs"
 let tables : FSharp.Text.Parsing.Tables<_> = 
   { reductions = _fsyacc_reductions.Value;
     endOfInputTag = _fsyacc_endOfInputTag;

--- a/src/Terrabuild.Configuration/Gen/ProjectParser.fsi
+++ b/src/Terrabuild.Configuration/Gen/ProjectParser.fsi
@@ -140,6 +140,8 @@ type nonTerminalId =
     | NONTERM_ExprIndex
     | NONTERM_Bool
     | NONTERM_String
+    | NONTERM_ExprTuple
+    | NONTERM_ExprTupleContent
     | NONTERM_ExprList
     | NONTERM_ExprListContent
     | NONTERM_ExprMap

--- a/src/Terrabuild.Configuration/Gen/WorkspaceParser.fs
+++ b/src/Terrabuild.Configuration/Gen/WorkspaceParser.fs
@@ -346,18 +346,19 @@ let prodIdxToNonTerminal (prodIdx:int) =
     | 67 -> NONTERM_ExprTuple 
     | 68 -> NONTERM_ExprTupleContent 
     | 69 -> NONTERM_ExprTupleContent 
-    | 70 -> NONTERM_ExprList 
-    | 71 -> NONTERM_ExprListContent 
+    | 70 -> NONTERM_ExprTupleContent 
+    | 71 -> NONTERM_ExprList 
     | 72 -> NONTERM_ExprListContent 
-    | 73 -> NONTERM_ExprMap 
-    | 74 -> NONTERM_ExprMapContent 
+    | 73 -> NONTERM_ExprListContent 
+    | 74 -> NONTERM_ExprMap 
     | 75 -> NONTERM_ExprMapContent 
-    | 76 -> NONTERM_ListOfString 
-    | 77 -> NONTERM_Strings 
+    | 76 -> NONTERM_ExprMapContent 
+    | 77 -> NONTERM_ListOfString 
     | 78 -> NONTERM_Strings 
-    | 79 -> NONTERM_ListOfTargetIdentifiers 
-    | 80 -> NONTERM_TargetIdentifiers 
+    | 79 -> NONTERM_Strings 
+    | 80 -> NONTERM_ListOfTargetIdentifiers 
     | 81 -> NONTERM_TargetIdentifiers 
+    | 82 -> NONTERM_TargetIdentifiers 
     | _ -> failwith "prodIdxToNonTerminal: bad production index"
 
 let _fsyacc_endOfInputTag = 52 
@@ -470,18 +471,18 @@ let _fsyacc_dataOfToken (t:token) =
   | NOTHING  -> (null : System.Object) 
   | TRUE  -> (null : System.Object) 
   | FALSE  -> (null : System.Object) 
-let _fsyacc_gotos = [| 0us;65535us;1us;65535us;0us;1us;1us;65535us;0us;2us;1us;65535us;2us;4us;1us;65535us;9us;10us;1us;65535us;10us;12us;1us;65535us;2us;5us;1us;65535us;18us;19us;1us;65535us;19us;21us;1us;65535us;19us;22us;1us;65535us;2us;6us;2us;65535us;31us;32us;34us;35us;2us;65535us;32us;37us;35us;37us;1us;65535us;2us;7us;1us;65535us;43us;44us;1us;65535us;44us;46us;1us;65535us;44us;47us;1us;65535us;44us;48us;1us;65535us;44us;49us;12us;65535us;27us;28us;84us;70us;85us;71us;86us;72us;87us;73us;102us;74us;103us;75us;104us;76us;105us;77us;114us;78us;117us;78us;122us;79us;1us;65535us;128us;130us;1us;65535us;41us;42us;2us;65535us;80us;81us;82us;83us;0us;65535us;4us;65535us;14us;15us;51us;52us;57us;58us;124us;126us;7us;65535us;88us;89us;90us;91us;92us;93us;94us;95us;96us;97us;98us;99us;100us;101us;0us;65535us;12us;65535us;27us;68us;84us;68us;85us;68us;86us;68us;87us;68us;102us;68us;103us;68us;104us;68us;105us;68us;114us;68us;117us;68us;122us;68us;2us;65535us;113us;114us;116us;117us;14us;65535us;27us;69us;39us;40us;60us;61us;84us;69us;85us;69us;86us;69us;87us;69us;102us;69us;103us;69us;104us;69us;105us;69us;114us;69us;117us;69us;122us;69us;1us;65535us;119us;120us;1us;65535us;54us;55us;1us;65535us;123us;124us;1us;65535us;24us;25us;1us;65535us;127us;128us;|]
-let _fsyacc_sparseGotoTableRowOffsets = [|0us;1us;3us;5us;7us;9us;11us;13us;15us;17us;19us;21us;24us;27us;29us;31us;33us;35us;37us;39us;52us;54us;56us;59us;60us;65us;73us;74us;87us;90us;105us;107us;109us;111us;113us;|]
-let _fsyacc_stateToProdIdxsTableElements = [| 1us;0us;1us;0us;5us;1us;3us;4us;5us;6us;1us;1us;1us;3us;1us;4us;1us;5us;1us;6us;1us;7us;1us;7us;2us;7us;9us;1us;7us;1us;9us;1us;10us;1us;10us;1us;10us;2us;11us;12us;2us;11us;12us;1us;12us;3us;12us;14us;15us;1us;12us;1us;14us;1us;15us;1us;16us;1us;16us;1us;16us;1us;17us;1us;17us;9us;17us;42us;43us;44us;45us;46us;47us;55us;56us;3us;18us;19us;20us;2us;18us;20us;1us;19us;2us;19us;22us;1us;19us;1us;20us;2us;20us;22us;1us;20us;1us;22us;1us;23us;1us;23us;1us;23us;1us;24us;1us;24us;1us;24us;5us;24us;26us;27us;28us;29us;1us;24us;1us;26us;1us;27us;1us;28us;1us;29us;1us;30us;1us;30us;1us;30us;1us;31us;1us;31us;1us;31us;1us;32us;1us;32us;1us;32us;1us;33us;1us;33us;1us;33us;1us;34us;1us;35us;1us;36us;1us;37us;1us;38us;1us;39us;1us;40us;1us;41us;9us;42us;43us;44us;44us;45us;46us;47us;55us;56us;9us;42us;43us;44us;45us;45us;46us;47us;55us;56us;9us;42us;43us;44us;45us;46us;46us;47us;55us;56us;9us;42us;43us;44us;45us;46us;47us;47us;55us;56us;9us;42us;43us;44us;45us;46us;47us;55us;55us;56us;9us;42us;43us;44us;45us;46us;47us;55us;56us;56us;9us;42us;43us;44us;45us;46us;47us;55us;56us;56us;9us;42us;43us;44us;45us;46us;47us;55us;56us;57us;9us;42us;43us;44us;45us;46us;47us;55us;56us;72us;9us;42us;43us;44us;45us;46us;47us;55us;56us;75us;1us;42us;1us;42us;1us;43us;1us;43us;1us;44us;1us;45us;1us;46us;1us;47us;1us;48us;1us;48us;1us;49us;1us;49us;1us;50us;1us;50us;1us;51us;1us;51us;1us;52us;1us;52us;1us;53us;1us;53us;1us;54us;1us;54us;1us;55us;1us;56us;1us;56us;1us;57us;1us;58us;1us;59us;1us;60us;1us;61us;1us;62us;1us;63us;1us;66us;1us;67us;2us;67us;72us;1us;67us;1us;70us;2us;70us;72us;1us;70us;1us;73us;2us;73us;75us;1us;73us;1us;75us;1us;76us;2us;76us;78us;1us;76us;1us;78us;1us;79us;2us;79us;81us;1us;79us;1us;81us;|]
-let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us;2us;4us;10us;12us;14us;16us;18us;20us;22us;24us;27us;29us;31us;33us;35us;37us;40us;43us;45us;49us;51us;53us;55us;57us;59us;61us;63us;65us;75us;79us;82us;84us;87us;89us;91us;94us;96us;98us;100us;102us;104us;106us;108us;110us;116us;118us;120us;122us;124us;126us;128us;130us;132us;134us;136us;138us;140us;142us;144us;146us;148us;150us;152us;154us;156us;158us;160us;162us;164us;166us;176us;186us;196us;206us;216us;226us;236us;246us;256us;266us;268us;270us;272us;274us;276us;278us;280us;282us;284us;286us;288us;290us;292us;294us;296us;298us;300us;302us;304us;306us;308us;310us;312us;314us;316us;318us;320us;322us;324us;326us;328us;330us;332us;334us;337us;339us;341us;344us;346us;348us;351us;353us;355us;357us;360us;362us;364us;366us;369us;371us;|]
-let _fsyacc_action_rows = 131
-let _fsyacc_actionTableElements = [|0us;16386us;0us;49152us;5us;32768us;10us;8us;11us;16us;12us;29us;13us;41us;14us;3us;0us;16385us;0us;16387us;0us;16388us;0us;16389us;0us;16390us;1us;32768us;38us;9us;0us;16392us;2us;32768us;1us;13us;39us;11us;0us;16391us;0us;16393us;1us;32768us;29us;14us;1us;32768us;46us;112us;0us;16394us;1us;32768us;45us;17us;1us;16395us;38us;18us;0us;16397us;3us;32768us;2us;23us;3us;26us;39us;20us;0us;16396us;0us;16398us;0us;16399us;1us;32768us;29us;24us;1us;32768us;36us;127us;0us;16400us;1us;32768us;29us;27us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;8us;16401us;15us;102us;16us;103us;26us;87us;27us;86us;30us;84us;31us;85us;34us;80us;35us;82us;2us;32768us;38us;31us;45us;30us;1us;16402us;38us;34us;0us;16405us;2us;32768us;4us;38us;39us;33us;0us;16403us;0us;16405us;2us;32768us;4us;38us;39us;36us;0us;16404us;0us;16406us;1us;32768us;29us;39us;1us;32768us;38us;119us;0us;16407us;2us;32768us;44us;108us;45us;109us;1us;32768us;38us;43us;0us;16409us;5us;32768us;4us;53us;5us;50us;7us;56us;8us;59us;39us;45us;0us;16408us;0us;16410us;0us;16411us;0us;16412us;0us;16413us;1us;32768us;29us;51us;1us;32768us;46us;112us;0us;16414us;1us;32768us;29us;54us;1us;32768us;36us;123us;0us;16415us;1us;32768us;29us;57us;1us;32768us;46us;112us;0us;16416us;1us;32768us;29us;60us;1us;32768us;38us;119us;0us;16417us;0us;16418us;0us;16419us;0us;16420us;0us;16421us;0us;16422us;0us;16423us;0us;16424us;0us;16425us;4us;16428us;26us;87us;27us;86us;34us;80us;35us;82us;4us;16429us;26us;87us;27us;86us;34us;80us;35us;82us;2us;16430us;34us;80us;35us;82us;3us;16431us;27us;86us;34us;80us;35us;82us;6us;16439us;26us;87us;27us;86us;30us;84us;31us;85us;34us;80us;35us;82us;9us;32768us;15us;102us;16us;103us;17us;104us;26us;87us;27us;86us;30us;84us;31us;85us;34us;80us;35us;82us;8us;16440us;15us;102us;16us;103us;26us;87us;27us;86us;30us;84us;31us;85us;34us;80us;35us;82us;0us;16441us;8us;16456us;15us;102us;16us;103us;26us;87us;27us;86us;30us;84us;31us;85us;34us;80us;35us;82us;8us;16459us;15us;102us;16us;103us;26us;87us;27us;86us;30us;84us;31us;85us;34us;80us;35us;82us;2us;32768us;40us;110us;45us;111us;0us;16426us;2us;32768us;40us;110us;45us;111us;0us;16427us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;1us;32768us;32us;113us;0us;16432us;1us;32768us;32us;113us;0us;16433us;1us;32768us;32us;113us;0us;16434us;1us;32768us;32us;113us;0us;16435us;1us;32768us;32us;113us;0us;16436us;1us;32768us;32us;113us;0us;16437us;1us;32768us;32us;113us;0us;16438us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16442us;0us;16443us;0us;16444us;0us;16445us;0us;16446us;0us;16447us;0us;16450us;0us;16455us;17us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;33us;115us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16451us;0us;16455us;17us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;37us;118us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16454us;0us;16458us;2us;32768us;39us;121us;41us;122us;0us;16457us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16461us;2us;32768us;37us;125us;46us;112us;0us;16460us;0us;16462us;0us;16464us;3us;32768us;37us;129us;43us;106us;45us;107us;0us;16463us;0us;16465us;|]
-let _fsyacc_actionTableRowOffsets = [|0us;1us;2us;8us;9us;10us;11us;12us;13us;15us;16us;19us;20us;21us;23us;25us;26us;28us;30us;31us;35us;36us;37us;38us;40us;42us;43us;45us;62us;71us;74us;76us;77us;80us;81us;82us;85us;86us;87us;89us;91us;92us;95us;97us;98us;104us;105us;106us;107us;108us;109us;111us;113us;114us;116us;118us;119us;121us;123us;124us;126us;128us;129us;130us;131us;132us;133us;134us;135us;136us;137us;142us;147us;150us;154us;161us;171us;180us;181us;190us;199us;202us;203us;206us;207us;224us;241us;258us;275us;277us;278us;280us;281us;283us;284us;286us;287us;289us;290us;292us;293us;295us;296us;313us;330us;347us;364us;365us;366us;367us;368us;369us;370us;371us;372us;390us;391us;392us;410us;411us;412us;415us;416us;433us;434us;437us;438us;439us;440us;444us;445us;|]
-let _fsyacc_reductionSymbolCounts = [|1us;2us;0us;2us;2us;2us;2us;4us;0us;2us;3us;2us;5us;0us;2us;2us;3us;3us;2us;4us;5us;0us;2us;3us;5us;0us;2us;2us;2us;2us;3us;3us;3us;3us;1us;1us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;1us;1us;1us;1us;3us;0us;3us;3us;0us;2us;3us;0us;3us;3us;0us;2us;3us;0us;2us;|]
-let _fsyacc_productionToNonTerminalTable = [|0us;1us;2us;2us;2us;2us;2us;3us;4us;4us;5us;6us;6us;7us;7us;7us;8us;9us;10us;10us;10us;11us;11us;12us;13us;14us;14us;14us;14us;14us;15us;16us;17us;18us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;20us;20us;21us;21us;22us;22us;23us;23us;24us;25us;26us;26us;27us;28us;28us;29us;30us;30us;31us;32us;32us;33us;34us;34us;|]
-let _fsyacc_immediateActions = [|65535us;49152us;65535us;16385us;16387us;16388us;16389us;16390us;65535us;65535us;65535us;16391us;16393us;65535us;65535us;16394us;65535us;65535us;65535us;65535us;16396us;16398us;16399us;65535us;65535us;16400us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16403us;65535us;65535us;16404us;16406us;65535us;65535us;16407us;65535us;65535us;65535us;65535us;16408us;16410us;16411us;16412us;16413us;65535us;65535us;16414us;65535us;65535us;16415us;65535us;65535us;16416us;65535us;65535us;16417us;16418us;16419us;16420us;16421us;16422us;16423us;16424us;16425us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16426us;65535us;16427us;65535us;65535us;65535us;65535us;65535us;16432us;65535us;16433us;65535us;16434us;65535us;16435us;65535us;16436us;65535us;16437us;65535us;16438us;65535us;65535us;65535us;65535us;16442us;16443us;16444us;16445us;16446us;16447us;16450us;65535us;65535us;16451us;65535us;65535us;16454us;65535us;65535us;16457us;65535us;65535us;65535us;16460us;16462us;65535us;65535us;16463us;16465us;|]
+let _fsyacc_gotos = [| 0us;65535us;1us;65535us;0us;1us;1us;65535us;0us;2us;1us;65535us;2us;4us;1us;65535us;9us;10us;1us;65535us;10us;12us;1us;65535us;2us;5us;1us;65535us;18us;19us;1us;65535us;19us;21us;1us;65535us;19us;22us;1us;65535us;2us;6us;2us;65535us;31us;32us;34us;35us;2us;65535us;32us;37us;35us;37us;1us;65535us;2us;7us;1us;65535us;43us;44us;1us;65535us;44us;46us;1us;65535us;44us;47us;1us;65535us;44us;48us;1us;65535us;44us;49us;13us;65535us;27us;28us;86us;70us;87us;71us;88us;72us;89us;73us;104us;74us;105us;75us;106us;76us;107us;77us;115us;78us;118us;79us;120us;80us;125us;81us;1us;65535us;131us;133us;1us;65535us;41us;42us;2us;65535us;82us;83us;84us;85us;0us;65535us;4us;65535us;14us;15us;51us;52us;57us;58us;127us;129us;7us;65535us;90us;91us;92us;93us;94us;95us;96us;97us;98us;99us;100us;101us;102us;103us;1us;65535us;115us;116us;13us;65535us;27us;68us;86us;68us;87us;68us;88us;68us;89us;68us;104us;68us;105us;68us;106us;68us;107us;68us;115us;68us;118us;68us;120us;68us;125us;68us;1us;65535us;119us;120us;15us;65535us;27us;69us;39us;40us;60us;61us;86us;69us;87us;69us;88us;69us;89us;69us;104us;69us;105us;69us;106us;69us;107us;69us;115us;69us;118us;69us;120us;69us;125us;69us;1us;65535us;122us;123us;1us;65535us;54us;55us;1us;65535us;126us;127us;1us;65535us;24us;25us;1us;65535us;130us;131us;|]
+let _fsyacc_sparseGotoTableRowOffsets = [|0us;1us;3us;5us;7us;9us;11us;13us;15us;17us;19us;21us;24us;27us;29us;31us;33us;35us;37us;39us;53us;55us;57us;60us;61us;66us;74us;76us;90us;92us;108us;110us;112us;114us;116us;|]
+let _fsyacc_stateToProdIdxsTableElements = [| 1us;0us;1us;0us;5us;1us;3us;4us;5us;6us;1us;1us;1us;3us;1us;4us;1us;5us;1us;6us;1us;7us;1us;7us;2us;7us;9us;1us;7us;1us;9us;1us;10us;1us;10us;1us;10us;2us;11us;12us;2us;11us;12us;1us;12us;3us;12us;14us;15us;1us;12us;1us;14us;1us;15us;1us;16us;1us;16us;1us;16us;1us;17us;1us;17us;9us;17us;42us;43us;44us;45us;46us;47us;55us;56us;3us;18us;19us;20us;2us;18us;20us;1us;19us;2us;19us;22us;1us;19us;1us;20us;2us;20us;22us;1us;20us;1us;22us;1us;23us;1us;23us;1us;23us;1us;24us;1us;24us;1us;24us;5us;24us;26us;27us;28us;29us;1us;24us;1us;26us;1us;27us;1us;28us;1us;29us;1us;30us;1us;30us;1us;30us;1us;31us;1us;31us;1us;31us;1us;32us;1us;32us;1us;32us;1us;33us;1us;33us;1us;33us;1us;34us;1us;35us;1us;36us;1us;37us;1us;38us;1us;39us;1us;40us;1us;41us;9us;42us;43us;44us;44us;45us;46us;47us;55us;56us;9us;42us;43us;44us;45us;45us;46us;47us;55us;56us;9us;42us;43us;44us;45us;46us;46us;47us;55us;56us;9us;42us;43us;44us;45us;46us;47us;47us;55us;56us;9us;42us;43us;44us;45us;46us;47us;55us;55us;56us;9us;42us;43us;44us;45us;46us;47us;55us;56us;56us;9us;42us;43us;44us;45us;46us;47us;55us;56us;56us;9us;42us;43us;44us;45us;46us;47us;55us;56us;57us;9us;42us;43us;44us;45us;46us;47us;55us;56us;69us;9us;42us;43us;44us;45us;46us;47us;55us;56us;70us;9us;42us;43us;44us;45us;46us;47us;55us;56us;73us;9us;42us;43us;44us;45us;46us;47us;55us;56us;76us;1us;42us;1us;42us;1us;43us;1us;43us;1us;44us;1us;45us;1us;46us;1us;47us;1us;48us;1us;48us;1us;49us;1us;49us;1us;50us;1us;50us;1us;51us;1us;51us;1us;52us;1us;52us;1us;53us;1us;53us;1us;54us;1us;54us;1us;55us;1us;56us;1us;56us;1us;57us;1us;58us;1us;59us;1us;60us;1us;61us;1us;62us;1us;63us;1us;66us;1us;67us;2us;67us;70us;1us;67us;1us;70us;1us;71us;2us;71us;73us;1us;71us;1us;74us;2us;74us;76us;1us;74us;1us;76us;1us;77us;2us;77us;79us;1us;77us;1us;79us;1us;80us;2us;80us;82us;1us;80us;1us;82us;|]
+let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us;2us;4us;10us;12us;14us;16us;18us;20us;22us;24us;27us;29us;31us;33us;35us;37us;40us;43us;45us;49us;51us;53us;55us;57us;59us;61us;63us;65us;75us;79us;82us;84us;87us;89us;91us;94us;96us;98us;100us;102us;104us;106us;108us;110us;116us;118us;120us;122us;124us;126us;128us;130us;132us;134us;136us;138us;140us;142us;144us;146us;148us;150us;152us;154us;156us;158us;160us;162us;164us;166us;176us;186us;196us;206us;216us;226us;236us;246us;256us;266us;276us;286us;288us;290us;292us;294us;296us;298us;300us;302us;304us;306us;308us;310us;312us;314us;316us;318us;320us;322us;324us;326us;328us;330us;332us;334us;336us;338us;340us;342us;344us;346us;348us;350us;352us;354us;357us;359us;361us;363us;366us;368us;370us;373us;375us;377us;379us;382us;384us;386us;388us;391us;393us;|]
+let _fsyacc_action_rows = 134
+let _fsyacc_actionTableElements = [|0us;16386us;0us;49152us;5us;32768us;10us;8us;11us;16us;12us;29us;13us;41us;14us;3us;0us;16385us;0us;16387us;0us;16388us;0us;16389us;0us;16390us;1us;32768us;38us;9us;0us;16392us;2us;32768us;1us;13us;39us;11us;0us;16391us;0us;16393us;1us;32768us;29us;14us;1us;32768us;46us;114us;0us;16394us;1us;32768us;45us;17us;1us;16395us;38us;18us;0us;16397us;3us;32768us;2us;23us;3us;26us;39us;20us;0us;16396us;0us;16398us;0us;16399us;1us;32768us;29us;24us;1us;32768us;36us;130us;0us;16400us;1us;32768us;29us;27us;16us;32768us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;8us;16401us;15us;104us;16us;105us;26us;89us;27us;88us;30us;86us;31us;87us;34us;82us;35us;84us;2us;32768us;38us;31us;45us;30us;1us;16402us;38us;34us;0us;16405us;2us;32768us;4us;38us;39us;33us;0us;16403us;0us;16405us;2us;32768us;4us;38us;39us;36us;0us;16404us;0us;16406us;1us;32768us;29us;39us;1us;32768us;38us;122us;0us;16407us;2us;32768us;44us;110us;45us;111us;1us;32768us;38us;43us;0us;16409us;5us;32768us;4us;53us;5us;50us;7us;56us;8us;59us;39us;45us;0us;16408us;0us;16410us;0us;16411us;0us;16412us;0us;16413us;1us;32768us;29us;51us;1us;32768us;46us;114us;0us;16414us;1us;32768us;29us;54us;1us;32768us;36us;126us;0us;16415us;1us;32768us;29us;57us;1us;32768us;46us;114us;0us;16416us;1us;32768us;29us;60us;1us;32768us;38us;122us;0us;16417us;0us;16418us;0us;16419us;0us;16420us;0us;16421us;0us;16422us;0us;16423us;0us;16424us;0us;16425us;4us;16428us;26us;89us;27us;88us;34us;82us;35us;84us;4us;16429us;26us;89us;27us;88us;34us;82us;35us;84us;2us;16430us;34us;82us;35us;84us;3us;16431us;27us;88us;34us;82us;35us;84us;6us;16439us;26us;89us;27us;88us;30us;86us;31us;87us;34us;82us;35us;84us;9us;32768us;15us;104us;16us;105us;17us;106us;26us;89us;27us;88us;30us;86us;31us;87us;34us;82us;35us;84us;8us;16440us;15us;104us;16us;105us;26us;89us;27us;88us;30us;86us;31us;87us;34us;82us;35us;84us;0us;16441us;8us;16453us;15us;104us;16us;105us;26us;89us;27us;88us;30us;86us;31us;87us;34us;82us;35us;84us;8us;16454us;15us;104us;16us;105us;26us;89us;27us;88us;30us;86us;31us;87us;34us;82us;35us;84us;8us;16457us;15us;104us;16us;105us;26us;89us;27us;88us;30us;86us;31us;87us;34us;82us;35us;84us;8us;16460us;15us;104us;16us;105us;26us;89us;27us;88us;30us;86us;31us;87us;34us;82us;35us;84us;2us;32768us;40us;112us;45us;113us;0us;16426us;2us;32768us;40us;112us;45us;113us;0us;16427us;16us;32768us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;1us;32768us;32us;115us;0us;16432us;1us;32768us;32us;115us;0us;16433us;1us;32768us;32us;115us;0us;16434us;1us;32768us;32us;115us;0us;16435us;1us;32768us;32us;115us;0us;16436us;1us;32768us;32us;115us;0us;16437us;1us;32768us;32us;115us;0us;16438us;16us;32768us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16442us;0us;16443us;0us;16444us;0us;16445us;0us;16446us;0us;16447us;0us;16450us;16us;16452us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;2us;32768us;28us;118us;33us;117us;0us;16451us;16us;32768us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16456us;17us;32768us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;37us;121us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16455us;0us;16459us;2us;32768us;39us;124us;41us;125us;0us;16458us;16us;32768us;18us;107us;19us;90us;20us;92us;21us;94us;22us;96us;23us;98us;24us;100us;25us;102us;36us;119us;38us;122us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16462us;2us;32768us;37us;128us;46us;114us;0us;16461us;0us;16463us;0us;16465us;3us;32768us;37us;132us;43us;108us;45us;109us;0us;16464us;0us;16466us;|]
+let _fsyacc_actionTableRowOffsets = [|0us;1us;2us;8us;9us;10us;11us;12us;13us;15us;16us;19us;20us;21us;23us;25us;26us;28us;30us;31us;35us;36us;37us;38us;40us;42us;43us;45us;62us;71us;74us;76us;77us;80us;81us;82us;85us;86us;87us;89us;91us;92us;95us;97us;98us;104us;105us;106us;107us;108us;109us;111us;113us;114us;116us;118us;119us;121us;123us;124us;126us;128us;129us;130us;131us;132us;133us;134us;135us;136us;137us;142us;147us;150us;154us;161us;171us;180us;181us;190us;199us;208us;217us;220us;221us;224us;225us;242us;259us;276us;293us;295us;296us;298us;299us;301us;302us;304us;305us;307us;308us;310us;311us;313us;314us;331us;348us;365us;382us;383us;384us;385us;386us;387us;388us;389us;406us;409us;410us;427us;428us;446us;447us;448us;451us;452us;469us;470us;473us;474us;475us;476us;480us;481us;|]
+let _fsyacc_reductionSymbolCounts = [|1us;2us;0us;2us;2us;2us;2us;4us;0us;2us;3us;2us;5us;0us;2us;2us;3us;3us;2us;4us;5us;0us;2us;3us;5us;0us;2us;2us;2us;2us;3us;3us;3us;3us;1us;1us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;1us;1us;1us;1us;3us;0us;1us;3us;3us;0us;2us;3us;0us;3us;3us;0us;2us;3us;0us;2us;|]
+let _fsyacc_productionToNonTerminalTable = [|0us;1us;2us;2us;2us;2us;2us;3us;4us;4us;5us;6us;6us;7us;7us;7us;8us;9us;10us;10us;10us;11us;11us;12us;13us;14us;14us;14us;14us;14us;15us;16us;17us;18us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;20us;20us;21us;21us;22us;22us;23us;23us;24us;25us;26us;26us;26us;27us;28us;28us;29us;30us;30us;31us;32us;32us;33us;34us;34us;|]
+let _fsyacc_immediateActions = [|65535us;49152us;65535us;16385us;16387us;16388us;16389us;16390us;65535us;65535us;65535us;16391us;16393us;65535us;65535us;16394us;65535us;65535us;65535us;65535us;16396us;16398us;16399us;65535us;65535us;16400us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16403us;65535us;65535us;16404us;16406us;65535us;65535us;16407us;65535us;65535us;65535us;65535us;16408us;16410us;16411us;16412us;16413us;65535us;65535us;16414us;65535us;65535us;16415us;65535us;65535us;16416us;65535us;65535us;16417us;16418us;16419us;16420us;16421us;16422us;16423us;16424us;16425us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16426us;65535us;16427us;65535us;65535us;65535us;65535us;65535us;16432us;65535us;16433us;65535us;16434us;65535us;16435us;65535us;16436us;65535us;16437us;65535us;16438us;65535us;65535us;65535us;65535us;16442us;16443us;16444us;16445us;16446us;16447us;16450us;65535us;65535us;16451us;65535us;65535us;65535us;16455us;65535us;65535us;16458us;65535us;65535us;65535us;16461us;16463us;65535us;65535us;16464us;16466us;|]
 let _fsyacc_reductions = lazy [|
-# 484 "Gen/WorkspaceParser.fs"
+# 485 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Terrabuild.Configuration.Workspace.AST.WorkspaceFile in
             Microsoft.FSharp.Core.Operators.box
@@ -490,626 +491,626 @@ let _fsyacc_reductions = lazy [|
                       raise (FSharp.Text.Parsing.Accept(Microsoft.FSharp.Core.Operators.box _1))
                    )
                  : 'gentype__startWorkspaceFile));
-# 493 "Gen/WorkspaceParser.fs"
+# 494 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 55 "WorkspaceParser/Parser.fsy"
+# 56 "WorkspaceParser/Parser.fsy"
                                                          WorkspaceFile.Build _1 
                    )
-# 55 "WorkspaceParser/Parser.fsy"
+# 56 "WorkspaceParser/Parser.fsy"
                  : Terrabuild.Configuration.Workspace.AST.WorkspaceFile));
-# 504 "Gen/WorkspaceParser.fs"
+# 505 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 58 "WorkspaceParser/Parser.fsy"
+# 59 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 58 "WorkspaceParser/Parser.fsy"
+# 59 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 514 "Gen/WorkspaceParser.fs"
+# 515 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Workspace in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 59 "WorkspaceParser/Parser.fsy"
+# 60 "WorkspaceParser/Parser.fsy"
                                                                _1 @ [_2] 
                    )
-# 59 "WorkspaceParser/Parser.fsy"
+# 60 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 526 "Gen/WorkspaceParser.fs"
+# 527 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Target in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 60 "WorkspaceParser/Parser.fsy"
+# 61 "WorkspaceParser/Parser.fsy"
                                                             _1 @ [_2] 
                    )
-# 60 "WorkspaceParser/Parser.fsy"
+# 61 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 538 "Gen/WorkspaceParser.fs"
+# 539 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Configuration in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 61 "WorkspaceParser/Parser.fsy"
+# 62 "WorkspaceParser/Parser.fsy"
                                                                    _1 @ [_2] 
                    )
-# 61 "WorkspaceParser/Parser.fsy"
+# 62 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 550 "Gen/WorkspaceParser.fs"
+# 551 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Extension in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 62 "WorkspaceParser/Parser.fsy"
+# 63 "WorkspaceParser/Parser.fsy"
                                                                _1 @ [_2] 
                    )
-# 62 "WorkspaceParser/Parser.fsy"
+# 63 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 562 "Gen/WorkspaceParser.fs"
+# 563 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_WorkspaceComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 65 "WorkspaceParser/Parser.fsy"
+# 66 "WorkspaceParser/Parser.fsy"
                                                                          Workspace.Build _3 |> WorkspaceFileComponents.Workspace 
                    )
-# 65 "WorkspaceParser/Parser.fsy"
+# 66 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Workspace));
-# 573 "Gen/WorkspaceParser.fs"
+# 574 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 67 "WorkspaceParser/Parser.fsy"
+# 68 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 67 "WorkspaceParser/Parser.fsy"
+# 68 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceComponents));
-# 583 "Gen/WorkspaceParser.fs"
+# 584 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_WorkspaceSpace in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 68 "WorkspaceParser/Parser.fsy"
+# 69 "WorkspaceParser/Parser.fsy"
                                                                 _1 @ [_2] 
                    )
-# 68 "WorkspaceParser/Parser.fsy"
+# 69 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceComponents));
-# 595 "Gen/WorkspaceParser.fs"
+# 596 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 70 "WorkspaceParser/Parser.fsy"
+# 71 "WorkspaceParser/Parser.fsy"
                                                 WorkspaceComponents.Space _3 
                    )
-# 70 "WorkspaceParser/Parser.fsy"
+# 71 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceSpace));
-# 606 "Gen/WorkspaceParser.fs"
+# 607 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 73 "WorkspaceParser/Parser.fsy"
+# 74 "WorkspaceParser/Parser.fsy"
                                                Target.Build _2 [] |> WorkspaceFileComponents.Target 
                    )
-# 73 "WorkspaceParser/Parser.fsy"
+# 74 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Target));
-# 617 "Gen/WorkspaceParser.fs"
+# 618 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             let _4 = parseState.GetInput(4) :?> 'gentype_TargetComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 74 "WorkspaceParser/Parser.fsy"
+# 75 "WorkspaceParser/Parser.fsy"
                                                                               Target.Build _2 _4 |>  WorkspaceFileComponents.Target 
                    )
-# 74 "WorkspaceParser/Parser.fsy"
+# 75 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Target));
-# 629 "Gen/WorkspaceParser.fs"
+# 630 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 76 "WorkspaceParser/Parser.fsy"
+# 77 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 76 "WorkspaceParser/Parser.fsy"
+# 77 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 639 "Gen/WorkspaceParser.fs"
+# 640 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetDependsOn in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 77 "WorkspaceParser/Parser.fsy"
+# 78 "WorkspaceParser/Parser.fsy"
                                                               _1 @ [_2] 
                    )
-# 77 "WorkspaceParser/Parser.fsy"
+# 78 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 651 "Gen/WorkspaceParser.fs"
+# 652 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetRebuild in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 78 "WorkspaceParser/Parser.fsy"
+# 79 "WorkspaceParser/Parser.fsy"
                                                             _1 @ [_2] 
                    )
-# 78 "WorkspaceParser/Parser.fsy"
+# 79 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 663 "Gen/WorkspaceParser.fs"
+# 664 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfTargetIdentifiers in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 80 "WorkspaceParser/Parser.fsy"
+# 81 "WorkspaceParser/Parser.fsy"
                                                                       TargetComponents.DependsOn _3 
                    )
-# 80 "WorkspaceParser/Parser.fsy"
+# 81 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetDependsOn));
-# 674 "Gen/WorkspaceParser.fs"
+# 675 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 82 "WorkspaceParser/Parser.fsy"
+# 83 "WorkspaceParser/Parser.fsy"
                                                 TargetComponents.Rebuild _3 
                    )
-# 82 "WorkspaceParser/Parser.fsy"
+# 83 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetRebuild));
-# 685 "Gen/WorkspaceParser.fs"
+# 686 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 85 "WorkspaceParser/Parser.fsy"
+# 86 "WorkspaceParser/Parser.fsy"
                                                       Configuration.Build _2 [] |> WorkspaceFileComponents.Configuration 
                    )
-# 85 "WorkspaceParser/Parser.fsy"
+# 86 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Configuration));
-# 696 "Gen/WorkspaceParser.fs"
+# 697 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ConfigurationComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 86 "WorkspaceParser/Parser.fsy"
+# 87 "WorkspaceParser/Parser.fsy"
                                                                                  Configuration.Build "default" _3 |> WorkspaceFileComponents.Configuration 
                    )
-# 86 "WorkspaceParser/Parser.fsy"
+# 87 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Configuration));
-# 707 "Gen/WorkspaceParser.fs"
+# 708 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             let _4 = parseState.GetInput(4) :?> 'gentype_ConfigurationComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 87 "WorkspaceParser/Parser.fsy"
+# 88 "WorkspaceParser/Parser.fsy"
                                                                                             Configuration.Build _2 _4 |> WorkspaceFileComponents.Configuration 
                    )
-# 87 "WorkspaceParser/Parser.fsy"
+# 88 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Configuration));
-# 719 "Gen/WorkspaceParser.fs"
+# 720 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 89 "WorkspaceParser/Parser.fsy"
+# 90 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 89 "WorkspaceParser/Parser.fsy"
+# 90 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ConfigurationComponents));
-# 729 "Gen/WorkspaceParser.fs"
+# 730 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ConfigurationComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ConfigurationVariables in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 90 "WorkspaceParser/Parser.fsy"
+# 91 "WorkspaceParser/Parser.fsy"
                                                                             _1 @ [_2] 
                    )
-# 90 "WorkspaceParser/Parser.fsy"
+# 91 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ConfigurationComponents));
-# 741 "Gen/WorkspaceParser.fs"
+# 742 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprMap in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 92 "WorkspaceParser/Parser.fsy"
+# 93 "WorkspaceParser/Parser.fsy"
                                                      ConfigurationComponents.Variables _3 
                    )
-# 92 "WorkspaceParser/Parser.fsy"
+# 93 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ConfigurationVariables));
-# 752 "Gen/WorkspaceParser.fs"
+# 753 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionIdentifier in
             let _4 = parseState.GetInput(4) :?> 'gentype_ExtensionComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 95 "WorkspaceParser/Parser.fsy"
+# 96 "WorkspaceParser/Parser.fsy"
                                                                                              Extension.Build _2 _4 |> WorkspaceFileComponents.Extension 
                    )
-# 95 "WorkspaceParser/Parser.fsy"
+# 96 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Extension));
-# 764 "Gen/WorkspaceParser.fs"
+# 765 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 97 "WorkspaceParser/Parser.fsy"
+# 98 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 97 "WorkspaceParser/Parser.fsy"
+# 98 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 774 "Gen/WorkspaceParser.fs"
+# 775 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionContainer in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 98 "WorkspaceParser/Parser.fsy"
+# 99 "WorkspaceParser/Parser.fsy"
                                                                     _1 @ [_2] 
                    )
-# 98 "WorkspaceParser/Parser.fsy"
+# 99 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 786 "Gen/WorkspaceParser.fs"
+# 787 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionVariables in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 99 "WorkspaceParser/Parser.fsy"
+# 100 "WorkspaceParser/Parser.fsy"
                                                                     _1 @ [_2] 
                    )
-# 99 "WorkspaceParser/Parser.fsy"
+# 100 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 798 "Gen/WorkspaceParser.fs"
+# 799 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionScript in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 100 "WorkspaceParser/Parser.fsy"
+# 101 "WorkspaceParser/Parser.fsy"
                                                                  _1 @ [_2] 
                    )
-# 100 "WorkspaceParser/Parser.fsy"
+# 101 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 810 "Gen/WorkspaceParser.fs"
+# 811 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionDefaults in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 101 "WorkspaceParser/Parser.fsy"
+# 102 "WorkspaceParser/Parser.fsy"
                                                                    _1 @ [_2] 
                    )
-# 101 "WorkspaceParser/Parser.fsy"
+# 102 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 822 "Gen/WorkspaceParser.fs"
+# 823 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 103 "WorkspaceParser/Parser.fsy"
+# 104 "WorkspaceParser/Parser.fsy"
                                                     ExtensionComponents.Container _3 
                    )
-# 103 "WorkspaceParser/Parser.fsy"
+# 104 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionContainer));
-# 833 "Gen/WorkspaceParser.fs"
+# 834 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 105 "WorkspaceParser/Parser.fsy"
+# 106 "WorkspaceParser/Parser.fsy"
                                                           ExtensionComponents.Variables _3 
                    )
-# 105 "WorkspaceParser/Parser.fsy"
+# 106 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionVariables));
-# 844 "Gen/WorkspaceParser.fs"
+# 845 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 107 "WorkspaceParser/Parser.fsy"
+# 108 "WorkspaceParser/Parser.fsy"
                                                  ExtensionComponents.Script _3 
                    )
-# 107 "WorkspaceParser/Parser.fsy"
+# 108 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionScript));
-# 855 "Gen/WorkspaceParser.fs"
+# 856 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprMap in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 109 "WorkspaceParser/Parser.fsy"
+# 110 "WorkspaceParser/Parser.fsy"
                                                     ExtensionComponents.Defaults _3 
                    )
-# 109 "WorkspaceParser/Parser.fsy"
+# 110 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionDefaults));
-# 866 "Gen/WorkspaceParser.fs"
+# 867 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 113 "WorkspaceParser/Parser.fsy"
+# 114 "WorkspaceParser/Parser.fsy"
                                      Expr.Nothing 
                    )
-# 113 "WorkspaceParser/Parser.fsy"
+# 114 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 876 "Gen/WorkspaceParser.fs"
+# 877 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 114 "WorkspaceParser/Parser.fsy"
+# 115 "WorkspaceParser/Parser.fsy"
                                   Expr.Bool true 
                    )
-# 114 "WorkspaceParser/Parser.fsy"
+# 115 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 886 "Gen/WorkspaceParser.fs"
+# 887 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 115 "WorkspaceParser/Parser.fsy"
+# 116 "WorkspaceParser/Parser.fsy"
                                    Expr.Bool false 
                    )
-# 115 "WorkspaceParser/Parser.fsy"
+# 116 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 896 "Gen/WorkspaceParser.fs"
+# 897 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 116 "WorkspaceParser/Parser.fsy"
+# 117 "WorkspaceParser/Parser.fsy"
                                     Expr.String _1 
                    )
-# 116 "WorkspaceParser/Parser.fsy"
+# 117 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 907 "Gen/WorkspaceParser.fs"
+# 908 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 117 "WorkspaceParser/Parser.fsy"
+# 118 "WorkspaceParser/Parser.fsy"
                                     Expr.Number _1 
                    )
-# 117 "WorkspaceParser/Parser.fsy"
+# 118 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 918 "Gen/WorkspaceParser.fs"
+# 919 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 118 "WorkspaceParser/Parser.fsy"
+# 119 "WorkspaceParser/Parser.fsy"
                                       Expr.Variable _1 
                    )
-# 118 "WorkspaceParser/Parser.fsy"
+# 119 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 929 "Gen/WorkspaceParser.fs"
+# 930 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprList in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 120 "WorkspaceParser/Parser.fsy"
+# 121 "WorkspaceParser/Parser.fsy"
                                       Expr.List _1 
                    )
-# 120 "WorkspaceParser/Parser.fsy"
+# 121 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 940 "Gen/WorkspaceParser.fs"
+# 941 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprMap in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 121 "WorkspaceParser/Parser.fsy"
+# 122 "WorkspaceParser/Parser.fsy"
                                      Expr.Map _1 
                    )
-# 121 "WorkspaceParser/Parser.fsy"
+# 122 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 951 "Gen/WorkspaceParser.fs"
+# 952 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 123 "WorkspaceParser/Parser.fsy"
+# 124 "WorkspaceParser/Parser.fsy"
                                                 Expr.Function (Function.Item, [_1;  _3]) 
                    )
-# 123 "WorkspaceParser/Parser.fsy"
+# 124 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 963 "Gen/WorkspaceParser.fs"
+# 964 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 124 "WorkspaceParser/Parser.fsy"
+# 125 "WorkspaceParser/Parser.fsy"
                                                          Expr.Function (Function.TryItem, [_1; _3]) 
                    )
-# 124 "WorkspaceParser/Parser.fsy"
+# 125 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 975 "Gen/WorkspaceParser.fs"
+# 976 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 125 "WorkspaceParser/Parser.fsy"
+# 126 "WorkspaceParser/Parser.fsy"
                                                     Expr.Function (Function.Equal, [_1; _3]) 
                    )
-# 125 "WorkspaceParser/Parser.fsy"
+# 126 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 987 "Gen/WorkspaceParser.fs"
+# 988 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 126 "WorkspaceParser/Parser.fsy"
+# 127 "WorkspaceParser/Parser.fsy"
                                                  Expr.Function (Function.NotEqual, [_1; _3]) 
                    )
-# 126 "WorkspaceParser/Parser.fsy"
+# 127 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 999 "Gen/WorkspaceParser.fs"
+# 1000 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 127 "WorkspaceParser/Parser.fsy"
+# 128 "WorkspaceParser/Parser.fsy"
                                             Expr.Function (Function.Plus, [_1; _3]) 
                    )
-# 127 "WorkspaceParser/Parser.fsy"
+# 128 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1011 "Gen/WorkspaceParser.fs"
+# 1012 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 128 "WorkspaceParser/Parser.fsy"
+# 129 "WorkspaceParser/Parser.fsy"
                                              Expr.Function (Function.Minus, [_1; _3]) 
                    )
-# 128 "WorkspaceParser/Parser.fsy"
+# 129 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1023 "Gen/WorkspaceParser.fs"
+# 1024 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 129 "WorkspaceParser/Parser.fsy"
+# 130 "WorkspaceParser/Parser.fsy"
                                             Expr.Function (Function.Trim, _2) 
                    )
-# 129 "WorkspaceParser/Parser.fsy"
+# 130 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1034 "Gen/WorkspaceParser.fs"
+# 1035 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 130 "WorkspaceParser/Parser.fsy"
+# 131 "WorkspaceParser/Parser.fsy"
                                              Expr.Function (Function.Upper, _2) 
                    )
-# 130 "WorkspaceParser/Parser.fsy"
+# 131 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1045 "Gen/WorkspaceParser.fs"
+# 1046 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 131 "WorkspaceParser/Parser.fsy"
+# 132 "WorkspaceParser/Parser.fsy"
                                              Expr.Function (Function.Lower, _2) 
                    )
-# 131 "WorkspaceParser/Parser.fsy"
+# 132 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1056 "Gen/WorkspaceParser.fs"
+# 1057 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 132 "WorkspaceParser/Parser.fsy"
+# 133 "WorkspaceParser/Parser.fsy"
                                                Expr.Function (Function.Replace, _2) 
                    )
-# 132 "WorkspaceParser/Parser.fsy"
+# 133 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1067 "Gen/WorkspaceParser.fs"
+# 1068 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 133 "WorkspaceParser/Parser.fsy"
+# 134 "WorkspaceParser/Parser.fsy"
                                              Expr.Function (Function.Count, _2)
                    )
-# 133 "WorkspaceParser/Parser.fsy"
+# 134 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1078 "Gen/WorkspaceParser.fs"
+# 1079 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 134 "WorkspaceParser/Parser.fsy"
+# 135 "WorkspaceParser/Parser.fsy"
                                                Expr.Function (Function.Version, _2) 
                    )
-# 134 "WorkspaceParser/Parser.fsy"
+# 135 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1089 "Gen/WorkspaceParser.fs"
+# 1090 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 135 "WorkspaceParser/Parser.fsy"
+# 136 "WorkspaceParser/Parser.fsy"
                                               Expr.Function (Function.Format, _2) 
                    )
-# 135 "WorkspaceParser/Parser.fsy"
+# 136 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1100 "Gen/WorkspaceParser.fs"
+# 1101 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 136 "WorkspaceParser/Parser.fsy"
+# 137 "WorkspaceParser/Parser.fsy"
                                                        Expr.Function (Function.Coalesce, [_1; _3]) 
                    )
-# 136 "WorkspaceParser/Parser.fsy"
+# 137 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1112 "Gen/WorkspaceParser.fs"
+# 1113 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1117,207 +1118,218 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 137 "WorkspaceParser/Parser.fsy"
+# 138 "WorkspaceParser/Parser.fsy"
                                                            Expr.Function (Function.Ternary, [_1; _3; _5] ) 
                    )
-# 137 "WorkspaceParser/Parser.fsy"
+# 138 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1125 "Gen/WorkspaceParser.fs"
+# 1126 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 138 "WorkspaceParser/Parser.fsy"
+# 139 "WorkspaceParser/Parser.fsy"
                                        Expr.Function (Function.Not, [_2]) 
                    )
-# 138 "WorkspaceParser/Parser.fsy"
+# 139 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1136 "Gen/WorkspaceParser.fs"
+# 1137 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 141 "WorkspaceParser/Parser.fsy"
+# 142 "WorkspaceParser/Parser.fsy"
                                                _1 
                    )
-# 141 "WorkspaceParser/Parser.fsy"
+# 142 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetIdentifier));
-# 1147 "Gen/WorkspaceParser.fs"
+# 1148 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 142 "WorkspaceParser/Parser.fsy"
+# 143 "WorkspaceParser/Parser.fsy"
                                         _1 
                    )
-# 142 "WorkspaceParser/Parser.fsy"
+# 143 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetIdentifier));
-# 1158 "Gen/WorkspaceParser.fs"
+# 1159 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 145 "WorkspaceParser/Parser.fsy"
+# 146 "WorkspaceParser/Parser.fsy"
                                                   _1 
                    )
-# 145 "WorkspaceParser/Parser.fsy"
+# 146 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionIdentifier));
-# 1169 "Gen/WorkspaceParser.fs"
+# 1170 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 146 "WorkspaceParser/Parser.fsy"
+# 147 "WorkspaceParser/Parser.fsy"
                                         _1 
                    )
-# 146 "WorkspaceParser/Parser.fsy"
+# 147 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionIdentifier));
-# 1180 "Gen/WorkspaceParser.fs"
+# 1181 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 149 "WorkspaceParser/Parser.fsy"
+# 150 "WorkspaceParser/Parser.fsy"
                                     Expr.Number _1 
                    )
-# 149 "WorkspaceParser/Parser.fsy"
+# 150 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprIndex));
-# 1191 "Gen/WorkspaceParser.fs"
+# 1192 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 150 "WorkspaceParser/Parser.fsy"
+# 151 "WorkspaceParser/Parser.fsy"
                                         Expr.String _1 
                    )
-# 150 "WorkspaceParser/Parser.fsy"
+# 151 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprIndex));
-# 1202 "Gen/WorkspaceParser.fs"
+# 1203 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 153 "WorkspaceParser/Parser.fsy"
+# 154 "WorkspaceParser/Parser.fsy"
                                   true 
                    )
-# 153 "WorkspaceParser/Parser.fsy"
+# 154 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Bool));
-# 1212 "Gen/WorkspaceParser.fs"
+# 1213 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 154 "WorkspaceParser/Parser.fsy"
+# 155 "WorkspaceParser/Parser.fsy"
                                    false 
                    )
-# 154 "WorkspaceParser/Parser.fsy"
+# 155 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Bool));
-# 1222 "Gen/WorkspaceParser.fs"
+# 1223 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 157 "WorkspaceParser/Parser.fsy"
+# 158 "WorkspaceParser/Parser.fsy"
                                     _1 
                    )
-# 157 "WorkspaceParser/Parser.fsy"
+# 158 "WorkspaceParser/Parser.fsy"
                  : 'gentype_String));
-# 1233 "Gen/WorkspaceParser.fs"
+# 1234 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _2 = parseState.GetInput(2) :?> 'gentype_ExprListContent in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTupleContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 160 "WorkspaceParser/Parser.fsy"
-                                                           _2 
+# 161 "WorkspaceParser/Parser.fsy"
+                                                            _2 
                    )
-# 160 "WorkspaceParser/Parser.fsy"
+# 161 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprTuple));
-# 1244 "Gen/WorkspaceParser.fs"
+# 1245 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 162 "WorkspaceParser/Parser.fsy"
+# 163 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 162 "WorkspaceParser/Parser.fsy"
+# 163 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprTupleContent));
-# 1254 "Gen/WorkspaceParser.fs"
+# 1255 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _1 = parseState.GetInput(1) :?> 'gentype_ExprListContent in
+            let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 164 "WorkspaceParser/Parser.fsy"
+                                  [_1] 
+                   )
+# 164 "WorkspaceParser/Parser.fsy"
+                 : 'gentype_ExprTupleContent));
+# 1266 "Gen/WorkspaceParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            let _1 = parseState.GetInput(1) :?> 'gentype_ExprTupleContent in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 163 "WorkspaceParser/Parser.fsy"
-                                                        _1 @ [_3] 
+# 165 "WorkspaceParser/Parser.fsy"
+                                                         _1 @ [_3] 
                    )
-# 163 "WorkspaceParser/Parser.fsy"
+# 165 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprTupleContent));
-# 1266 "Gen/WorkspaceParser.fs"
+# 1278 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprListContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 166 "WorkspaceParser/Parser.fsy"
+# 168 "WorkspaceParser/Parser.fsy"
                                                                    _2 
                    )
-# 166 "WorkspaceParser/Parser.fsy"
+# 168 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprList));
-# 1277 "Gen/WorkspaceParser.fs"
+# 1289 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 168 "WorkspaceParser/Parser.fsy"
+# 170 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 168 "WorkspaceParser/Parser.fsy"
+# 170 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprListContent));
-# 1287 "Gen/WorkspaceParser.fs"
+# 1299 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprListContent in
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 169 "WorkspaceParser/Parser.fsy"
+# 171 "WorkspaceParser/Parser.fsy"
                                                   _1 @ [_2] 
                    )
-# 169 "WorkspaceParser/Parser.fsy"
+# 171 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprListContent));
-# 1299 "Gen/WorkspaceParser.fs"
+# 1311 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprMapContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 172 "WorkspaceParser/Parser.fsy"
+# 174 "WorkspaceParser/Parser.fsy"
                                                           _2 
                    )
-# 172 "WorkspaceParser/Parser.fsy"
+# 174 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprMap));
-# 1310 "Gen/WorkspaceParser.fs"
+# 1322 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 174 "WorkspaceParser/Parser.fsy"
+# 176 "WorkspaceParser/Parser.fsy"
                                          Map.empty 
                    )
-# 174 "WorkspaceParser/Parser.fsy"
+# 176 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprMapContent));
-# 1320 "Gen/WorkspaceParser.fs"
+# 1332 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprMapContent in
             let _2 = parseState.GetInput(2) :?> string in
@@ -1325,79 +1337,79 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 175 "WorkspaceParser/Parser.fsy"
+# 177 "WorkspaceParser/Parser.fsy"
                                                      _1.Add (_2, _3) 
                    )
-# 175 "WorkspaceParser/Parser.fsy"
+# 177 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprMapContent));
-# 1333 "Gen/WorkspaceParser.fs"
+# 1345 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Strings in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 178 "WorkspaceParser/Parser.fsy"
+# 180 "WorkspaceParser/Parser.fsy"
                                                            _2 
                    )
-# 178 "WorkspaceParser/Parser.fsy"
+# 180 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ListOfString));
-# 1344 "Gen/WorkspaceParser.fs"
+# 1356 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 180 "WorkspaceParser/Parser.fsy"
+# 182 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 180 "WorkspaceParser/Parser.fsy"
+# 182 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Strings));
-# 1354 "Gen/WorkspaceParser.fs"
+# 1366 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Strings in
             let _2 = parseState.GetInput(2) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 181 "WorkspaceParser/Parser.fsy"
+# 183 "WorkspaceParser/Parser.fsy"
                                             _1 @ [_2] 
                    )
-# 181 "WorkspaceParser/Parser.fsy"
+# 183 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Strings));
-# 1366 "Gen/WorkspaceParser.fs"
+# 1378 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetIdentifiers in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 184 "WorkspaceParser/Parser.fsy"
+# 186 "WorkspaceParser/Parser.fsy"
                                                                      _2 
                    )
-# 184 "WorkspaceParser/Parser.fsy"
+# 186 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ListOfTargetIdentifiers));
-# 1377 "Gen/WorkspaceParser.fs"
+# 1389 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 186 "WorkspaceParser/Parser.fsy"
+# 188 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 186 "WorkspaceParser/Parser.fsy"
+# 188 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetIdentifiers));
-# 1387 "Gen/WorkspaceParser.fs"
+# 1399 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetIdentifiers in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetIdentifier in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 187 "WorkspaceParser/Parser.fsy"
+# 189 "WorkspaceParser/Parser.fsy"
                                                                 _1 @ [_2] 
                    )
-# 187 "WorkspaceParser/Parser.fsy"
+# 189 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetIdentifiers));
 |]
-# 1400 "Gen/WorkspaceParser.fs"
+# 1412 "Gen/WorkspaceParser.fs"
 let tables : FSharp.Text.Parsing.Tables<_> = 
   { reductions = _fsyacc_reductions.Value;
     endOfInputTag = _fsyacc_endOfInputTag;

--- a/src/Terrabuild.Configuration/Gen/WorkspaceParser.fs
+++ b/src/Terrabuild.Configuration/Gen/WorkspaceParser.fs
@@ -151,6 +151,8 @@ type nonTerminalId =
     | NONTERM_ExprIndex
     | NONTERM_Bool
     | NONTERM_String
+    | NONTERM_ExprTuple
+    | NONTERM_ExprTupleContent
     | NONTERM_ExprList
     | NONTERM_ExprListContent
     | NONTERM_ExprMap
@@ -341,18 +343,21 @@ let prodIdxToNonTerminal (prodIdx:int) =
     | 64 -> NONTERM_Bool 
     | 65 -> NONTERM_Bool 
     | 66 -> NONTERM_String 
-    | 67 -> NONTERM_ExprList 
-    | 68 -> NONTERM_ExprListContent 
-    | 69 -> NONTERM_ExprListContent 
-    | 70 -> NONTERM_ExprMap 
-    | 71 -> NONTERM_ExprMapContent 
-    | 72 -> NONTERM_ExprMapContent 
-    | 73 -> NONTERM_ListOfString 
-    | 74 -> NONTERM_Strings 
-    | 75 -> NONTERM_Strings 
-    | 76 -> NONTERM_ListOfTargetIdentifiers 
-    | 77 -> NONTERM_TargetIdentifiers 
-    | 78 -> NONTERM_TargetIdentifiers 
+    | 67 -> NONTERM_ExprTuple 
+    | 68 -> NONTERM_ExprTupleContent 
+    | 69 -> NONTERM_ExprTupleContent 
+    | 70 -> NONTERM_ExprList 
+    | 71 -> NONTERM_ExprListContent 
+    | 72 -> NONTERM_ExprListContent 
+    | 73 -> NONTERM_ExprMap 
+    | 74 -> NONTERM_ExprMapContent 
+    | 75 -> NONTERM_ExprMapContent 
+    | 76 -> NONTERM_ListOfString 
+    | 77 -> NONTERM_Strings 
+    | 78 -> NONTERM_Strings 
+    | 79 -> NONTERM_ListOfTargetIdentifiers 
+    | 80 -> NONTERM_TargetIdentifiers 
+    | 81 -> NONTERM_TargetIdentifiers 
     | _ -> failwith "prodIdxToNonTerminal: bad production index"
 
 let _fsyacc_endOfInputTag = 52 
@@ -465,18 +470,18 @@ let _fsyacc_dataOfToken (t:token) =
   | NOTHING  -> (null : System.Object) 
   | TRUE  -> (null : System.Object) 
   | FALSE  -> (null : System.Object) 
-let _fsyacc_gotos = [| 0us;65535us;1us;65535us;0us;1us;1us;65535us;0us;2us;1us;65535us;2us;4us;1us;65535us;9us;10us;1us;65535us;10us;12us;1us;65535us;2us;5us;1us;65535us;18us;19us;1us;65535us;19us;21us;1us;65535us;19us;22us;1us;65535us;2us;6us;2us;65535us;31us;32us;34us;35us;2us;65535us;32us;37us;35us;37us;1us;65535us;2us;7us;1us;65535us;43us;44us;1us;65535us;44us;46us;1us;65535us;44us;47us;1us;65535us;44us;48us;1us;65535us;44us;49us;20us;65535us;27us;28us;77us;78us;78us;79us;92us;70us;93us;71us;94us;72us;95us;73us;97us;74us;100us;75us;103us;76us;106us;77us;109us;80us;112us;81us;116us;86us;118us;82us;119us;83us;120us;84us;121us;85us;130us;86us;135us;87us;1us;65535us;141us;143us;1us;65535us;41us;42us;2us;65535us;88us;89us;90us;91us;0us;65535us;4us;65535us;14us;15us;51us;52us;57us;58us;137us;139us;20us;65535us;27us;68us;77us;68us;78us;68us;92us;68us;93us;68us;94us;68us;95us;68us;97us;68us;100us;68us;103us;68us;106us;68us;109us;68us;112us;68us;116us;68us;118us;68us;119us;68us;120us;68us;121us;68us;130us;68us;135us;68us;2us;65535us;115us;116us;129us;130us;22us;65535us;27us;69us;39us;40us;60us;61us;77us;69us;78us;69us;92us;69us;93us;69us;94us;69us;95us;69us;97us;69us;100us;69us;103us;69us;106us;69us;109us;69us;112us;69us;116us;69us;118us;69us;119us;69us;120us;69us;121us;69us;130us;69us;135us;69us;1us;65535us;132us;133us;1us;65535us;54us;55us;1us;65535us;136us;137us;1us;65535us;24us;25us;1us;65535us;140us;141us;|]
-let _fsyacc_sparseGotoTableRowOffsets = [|0us;1us;3us;5us;7us;9us;11us;13us;15us;17us;19us;21us;24us;27us;29us;31us;33us;35us;37us;39us;60us;62us;64us;67us;68us;73us;94us;97us;120us;122us;124us;126us;128us;|]
-let _fsyacc_stateToProdIdxsTableElements = [| 1us;0us;1us;0us;5us;1us;3us;4us;5us;6us;1us;1us;1us;3us;1us;4us;1us;5us;1us;6us;1us;7us;1us;7us;2us;7us;9us;1us;7us;1us;9us;1us;10us;1us;10us;1us;10us;2us;11us;12us;2us;11us;12us;1us;12us;3us;12us;14us;15us;1us;12us;1us;14us;1us;15us;1us;16us;1us;16us;1us;16us;1us;17us;1us;17us;9us;17us;42us;43us;44us;45us;46us;47us;55us;56us;3us;18us;19us;20us;2us;18us;20us;1us;19us;2us;19us;22us;1us;19us;1us;20us;2us;20us;22us;1us;20us;1us;22us;1us;23us;1us;23us;1us;23us;1us;24us;1us;24us;1us;24us;5us;24us;26us;27us;28us;29us;1us;24us;1us;26us;1us;27us;1us;28us;1us;29us;1us;30us;1us;30us;1us;30us;1us;31us;1us;31us;1us;31us;1us;32us;1us;32us;1us;32us;1us;33us;1us;33us;1us;33us;1us;34us;1us;35us;1us;36us;1us;37us;1us;38us;1us;39us;1us;40us;1us;41us;9us;42us;43us;44us;44us;45us;46us;47us;55us;56us;9us;42us;43us;44us;45us;45us;46us;47us;55us;56us;9us;42us;43us;44us;45us;46us;46us;47us;55us;56us;9us;42us;43us;44us;45us;46us;47us;47us;55us;56us;9us;42us;43us;44us;45us;46us;47us;48us;55us;56us;9us;42us;43us;44us;45us;46us;47us;49us;55us;56us;9us;42us;43us;44us;45us;46us;47us;50us;55us;56us;9us;42us;43us;44us;45us;46us;47us;51us;55us;56us;9us;42us;43us;44us;45us;46us;47us;51us;55us;56us;9us;42us;43us;44us;45us;46us;47us;51us;55us;56us;9us;42us;43us;44us;45us;46us;47us;52us;55us;56us;9us;42us;43us;44us;45us;46us;47us;53us;55us;56us;9us;42us;43us;44us;45us;46us;47us;55us;55us;56us;9us;42us;43us;44us;45us;46us;47us;55us;56us;56us;9us;42us;43us;44us;45us;46us;47us;55us;56us;56us;9us;42us;43us;44us;45us;46us;47us;55us;56us;57us;9us;42us;43us;44us;45us;46us;47us;55us;56us;69us;9us;42us;43us;44us;45us;46us;47us;55us;56us;72us;1us;42us;1us;42us;1us;43us;1us;43us;1us;44us;1us;45us;1us;46us;1us;47us;1us;48us;1us;48us;1us;48us;1us;49us;1us;49us;1us;49us;1us;50us;1us;50us;1us;50us;1us;51us;1us;51us;1us;51us;1us;52us;1us;52us;1us;52us;1us;53us;1us;53us;1us;53us;1us;54us;1us;54us;2us;54us;69us;1us;54us;1us;55us;1us;56us;1us;56us;1us;57us;1us;58us;1us;59us;1us;60us;1us;61us;1us;62us;1us;63us;1us;66us;1us;67us;2us;67us;69us;1us;67us;1us;70us;2us;70us;72us;1us;70us;1us;72us;1us;73us;2us;73us;75us;1us;73us;1us;75us;1us;76us;2us;76us;78us;1us;76us;1us;78us;|]
-let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us;2us;4us;10us;12us;14us;16us;18us;20us;22us;24us;27us;29us;31us;33us;35us;37us;40us;43us;45us;49us;51us;53us;55us;57us;59us;61us;63us;65us;75us;79us;82us;84us;87us;89us;91us;94us;96us;98us;100us;102us;104us;106us;108us;110us;116us;118us;120us;122us;124us;126us;128us;130us;132us;134us;136us;138us;140us;142us;144us;146us;148us;150us;152us;154us;156us;158us;160us;162us;164us;166us;176us;186us;196us;206us;216us;226us;236us;246us;256us;266us;276us;286us;296us;306us;316us;326us;336us;346us;348us;350us;352us;354us;356us;358us;360us;362us;364us;366us;368us;370us;372us;374us;376us;378us;380us;382us;384us;386us;388us;390us;392us;394us;396us;398us;400us;402us;405us;407us;409us;411us;413us;415us;417us;419us;421us;423us;425us;427us;429us;431us;434us;436us;438us;441us;443us;445us;447us;450us;452us;454us;456us;459us;461us;|]
-let _fsyacc_action_rows = 144
-let _fsyacc_actionTableElements = [|0us;16386us;0us;49152us;5us;32768us;10us;8us;11us;16us;12us;29us;13us;41us;14us;3us;0us;16385us;0us;16387us;0us;16388us;0us;16389us;0us;16390us;1us;32768us;38us;9us;0us;16392us;2us;32768us;1us;13us;39us;11us;0us;16391us;0us;16393us;1us;32768us;29us;14us;1us;32768us;46us;128us;0us;16394us;1us;32768us;45us;17us;1us;16395us;38us;18us;0us;16397us;3us;32768us;2us;23us;3us;26us;39us;20us;0us;16396us;0us;16398us;0us;16399us;1us;32768us;29us;24us;1us;32768us;36us;140us;0us;16400us;1us;32768us;29us;27us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;8us;16401us;15us;118us;16us;119us;26us;95us;27us;94us;30us;92us;31us;93us;34us;88us;35us;90us;2us;32768us;38us;31us;45us;30us;1us;16402us;38us;34us;0us;16405us;2us;32768us;4us;38us;39us;33us;0us;16403us;0us;16405us;2us;32768us;4us;38us;39us;36us;0us;16404us;0us;16406us;1us;32768us;29us;39us;1us;32768us;38us;132us;0us;16407us;2us;32768us;44us;124us;45us;125us;1us;32768us;38us;43us;0us;16409us;5us;32768us;4us;53us;5us;50us;7us;56us;8us;59us;39us;45us;0us;16408us;0us;16410us;0us;16411us;0us;16412us;0us;16413us;1us;32768us;29us;51us;1us;32768us;46us;128us;0us;16414us;1us;32768us;29us;54us;1us;32768us;36us;136us;0us;16415us;1us;32768us;29us;57us;1us;32768us;46us;128us;0us;16416us;1us;32768us;29us;60us;1us;32768us;38us;132us;0us;16417us;0us;16418us;0us;16419us;0us;16420us;0us;16421us;0us;16422us;0us;16423us;0us;16424us;0us;16425us;4us;16428us;26us;95us;27us;94us;34us;88us;35us;90us;4us;16429us;26us;95us;27us;94us;34us;88us;35us;90us;2us;16430us;34us;88us;35us;90us;3us;16431us;27us;94us;34us;88us;35us;90us;9us;32768us;15us;118us;16us;119us;26us;95us;27us;94us;30us;92us;31us;93us;33us;98us;34us;88us;35us;90us;9us;32768us;15us;118us;16us;119us;26us;95us;27us;94us;30us;92us;31us;93us;33us;101us;34us;88us;35us;90us;9us;32768us;15us;118us;16us;119us;26us;95us;27us;94us;30us;92us;31us;93us;33us;104us;34us;88us;35us;90us;24us;32768us;15us;118us;16us;119us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;26us;95us;27us;94us;30us;92us;31us;93us;34us;88us;35us;90us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;24us;32768us;15us;118us;16us;119us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;26us;95us;27us;94us;30us;92us;31us;93us;34us;88us;35us;90us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;9us;32768us;15us;118us;16us;119us;26us;95us;27us;94us;30us;92us;31us;93us;33us;107us;34us;88us;35us;90us;9us;32768us;15us;118us;16us;119us;26us;95us;27us;94us;30us;92us;31us;93us;33us;110us;34us;88us;35us;90us;9us;32768us;15us;118us;16us;119us;26us;95us;27us;94us;30us;92us;31us;93us;33us;113us;34us;88us;35us;90us;6us;16439us;26us;95us;27us;94us;30us;92us;31us;93us;34us;88us;35us;90us;9us;32768us;15us;118us;16us;119us;17us;120us;26us;95us;27us;94us;30us;92us;31us;93us;34us;88us;35us;90us;8us;16440us;15us;118us;16us;119us;26us;95us;27us;94us;30us;92us;31us;93us;34us;88us;35us;90us;0us;16441us;8us;16453us;15us;118us;16us;119us;26us;95us;27us;94us;30us;92us;31us;93us;34us;88us;35us;90us;8us;16456us;15us;118us;16us;119us;26us;95us;27us;94us;30us;92us;31us;93us;34us;88us;35us;90us;2us;32768us;40us;126us;45us;127us;0us;16426us;2us;32768us;40us;126us;45us;127us;0us;16427us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;1us;32768us;32us;97us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16432us;1us;32768us;32us;100us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16433us;1us;32768us;32us;103us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16434us;1us;32768us;32us;106us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16435us;1us;32768us;32us;109us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16436us;1us;32768us;32us;112us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16437us;1us;32768us;32us;115us;0us;16452us;17us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;33us;117us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16438us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16442us;0us;16443us;0us;16444us;0us;16445us;0us;16446us;0us;16447us;0us;16450us;0us;16452us;17us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;37us;131us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16451us;0us;16455us;2us;32768us;39us;134us;41us;135us;0us;16454us;16us;32768us;18us;121us;19us;96us;20us;99us;21us;102us;22us;105us;23us;108us;24us;111us;25us;114us;36us;129us;38us;132us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16458us;2us;32768us;37us;138us;46us;128us;0us;16457us;0us;16459us;0us;16461us;3us;32768us;37us;142us;43us;122us;45us;123us;0us;16460us;0us;16462us;|]
-let _fsyacc_actionTableRowOffsets = [|0us;1us;2us;8us;9us;10us;11us;12us;13us;15us;16us;19us;20us;21us;23us;25us;26us;28us;30us;31us;35us;36us;37us;38us;40us;42us;43us;45us;62us;71us;74us;76us;77us;80us;81us;82us;85us;86us;87us;89us;91us;92us;95us;97us;98us;104us;105us;106us;107us;108us;109us;111us;113us;114us;116us;118us;119us;121us;123us;124us;126us;128us;129us;130us;131us;132us;133us;134us;135us;136us;137us;142us;147us;150us;154us;164us;174us;184us;209us;234us;244us;254us;264us;271us;281us;290us;291us;300us;309us;312us;313us;316us;317us;334us;351us;368us;385us;387us;404us;405us;407us;424us;425us;427us;444us;445us;447us;464us;465us;467us;484us;485us;487us;504us;505us;507us;508us;526us;527us;544us;561us;578us;595us;596us;597us;598us;599us;600us;601us;602us;603us;621us;622us;623us;626us;627us;644us;645us;648us;649us;650us;651us;655us;656us;|]
-let _fsyacc_reductionSymbolCounts = [|1us;2us;0us;2us;2us;2us;2us;4us;0us;2us;3us;2us;5us;0us;2us;2us;3us;3us;2us;4us;5us;0us;2us;3us;5us;0us;2us;2us;2us;2us;3us;3us;3us;3us;1us;1us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;4us;4us;4us;6us;4us;4us;4us;3us;5us;2us;1us;1us;1us;1us;1us;1us;1us;1us;1us;3us;0us;2us;3us;0us;3us;3us;0us;2us;3us;0us;2us;|]
-let _fsyacc_productionToNonTerminalTable = [|0us;1us;2us;2us;2us;2us;2us;3us;4us;4us;5us;6us;6us;7us;7us;7us;8us;9us;10us;10us;10us;11us;11us;12us;13us;14us;14us;14us;14us;14us;15us;16us;17us;18us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;20us;20us;21us;21us;22us;22us;23us;23us;24us;25us;26us;26us;27us;28us;28us;29us;30us;30us;31us;32us;32us;|]
-let _fsyacc_immediateActions = [|65535us;49152us;65535us;16385us;16387us;16388us;16389us;16390us;65535us;65535us;65535us;16391us;16393us;65535us;65535us;16394us;65535us;65535us;65535us;65535us;16396us;16398us;16399us;65535us;65535us;16400us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16403us;65535us;65535us;16404us;16406us;65535us;65535us;16407us;65535us;65535us;65535us;65535us;16408us;16410us;16411us;16412us;16413us;65535us;65535us;16414us;65535us;65535us;16415us;65535us;65535us;16416us;65535us;65535us;16417us;16418us;16419us;16420us;16421us;16422us;16423us;16424us;16425us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16426us;65535us;16427us;65535us;65535us;65535us;65535us;65535us;65535us;16432us;65535us;65535us;16433us;65535us;65535us;16434us;65535us;65535us;16435us;65535us;65535us;16436us;65535us;65535us;16437us;65535us;65535us;65535us;16438us;65535us;65535us;65535us;65535us;16442us;16443us;16444us;16445us;16446us;16447us;16450us;65535us;65535us;16451us;65535us;65535us;16454us;65535us;65535us;65535us;16457us;16459us;65535us;65535us;16460us;16462us;|]
+let _fsyacc_gotos = [| 0us;65535us;1us;65535us;0us;1us;1us;65535us;0us;2us;1us;65535us;2us;4us;1us;65535us;9us;10us;1us;65535us;10us;12us;1us;65535us;2us;5us;1us;65535us;18us;19us;1us;65535us;19us;21us;1us;65535us;19us;22us;1us;65535us;2us;6us;2us;65535us;31us;32us;34us;35us;2us;65535us;32us;37us;35us;37us;1us;65535us;2us;7us;1us;65535us;43us;44us;1us;65535us;44us;46us;1us;65535us;44us;47us;1us;65535us;44us;48us;1us;65535us;44us;49us;12us;65535us;27us;28us;84us;70us;85us;71us;86us;72us;87us;73us;102us;74us;103us;75us;104us;76us;105us;77us;114us;78us;117us;78us;122us;79us;1us;65535us;128us;130us;1us;65535us;41us;42us;2us;65535us;80us;81us;82us;83us;0us;65535us;4us;65535us;14us;15us;51us;52us;57us;58us;124us;126us;7us;65535us;88us;89us;90us;91us;92us;93us;94us;95us;96us;97us;98us;99us;100us;101us;0us;65535us;12us;65535us;27us;68us;84us;68us;85us;68us;86us;68us;87us;68us;102us;68us;103us;68us;104us;68us;105us;68us;114us;68us;117us;68us;122us;68us;2us;65535us;113us;114us;116us;117us;14us;65535us;27us;69us;39us;40us;60us;61us;84us;69us;85us;69us;86us;69us;87us;69us;102us;69us;103us;69us;104us;69us;105us;69us;114us;69us;117us;69us;122us;69us;1us;65535us;119us;120us;1us;65535us;54us;55us;1us;65535us;123us;124us;1us;65535us;24us;25us;1us;65535us;127us;128us;|]
+let _fsyacc_sparseGotoTableRowOffsets = [|0us;1us;3us;5us;7us;9us;11us;13us;15us;17us;19us;21us;24us;27us;29us;31us;33us;35us;37us;39us;52us;54us;56us;59us;60us;65us;73us;74us;87us;90us;105us;107us;109us;111us;113us;|]
+let _fsyacc_stateToProdIdxsTableElements = [| 1us;0us;1us;0us;5us;1us;3us;4us;5us;6us;1us;1us;1us;3us;1us;4us;1us;5us;1us;6us;1us;7us;1us;7us;2us;7us;9us;1us;7us;1us;9us;1us;10us;1us;10us;1us;10us;2us;11us;12us;2us;11us;12us;1us;12us;3us;12us;14us;15us;1us;12us;1us;14us;1us;15us;1us;16us;1us;16us;1us;16us;1us;17us;1us;17us;9us;17us;42us;43us;44us;45us;46us;47us;55us;56us;3us;18us;19us;20us;2us;18us;20us;1us;19us;2us;19us;22us;1us;19us;1us;20us;2us;20us;22us;1us;20us;1us;22us;1us;23us;1us;23us;1us;23us;1us;24us;1us;24us;1us;24us;5us;24us;26us;27us;28us;29us;1us;24us;1us;26us;1us;27us;1us;28us;1us;29us;1us;30us;1us;30us;1us;30us;1us;31us;1us;31us;1us;31us;1us;32us;1us;32us;1us;32us;1us;33us;1us;33us;1us;33us;1us;34us;1us;35us;1us;36us;1us;37us;1us;38us;1us;39us;1us;40us;1us;41us;9us;42us;43us;44us;44us;45us;46us;47us;55us;56us;9us;42us;43us;44us;45us;45us;46us;47us;55us;56us;9us;42us;43us;44us;45us;46us;46us;47us;55us;56us;9us;42us;43us;44us;45us;46us;47us;47us;55us;56us;9us;42us;43us;44us;45us;46us;47us;55us;55us;56us;9us;42us;43us;44us;45us;46us;47us;55us;56us;56us;9us;42us;43us;44us;45us;46us;47us;55us;56us;56us;9us;42us;43us;44us;45us;46us;47us;55us;56us;57us;9us;42us;43us;44us;45us;46us;47us;55us;56us;72us;9us;42us;43us;44us;45us;46us;47us;55us;56us;75us;1us;42us;1us;42us;1us;43us;1us;43us;1us;44us;1us;45us;1us;46us;1us;47us;1us;48us;1us;48us;1us;49us;1us;49us;1us;50us;1us;50us;1us;51us;1us;51us;1us;52us;1us;52us;1us;53us;1us;53us;1us;54us;1us;54us;1us;55us;1us;56us;1us;56us;1us;57us;1us;58us;1us;59us;1us;60us;1us;61us;1us;62us;1us;63us;1us;66us;1us;67us;2us;67us;72us;1us;67us;1us;70us;2us;70us;72us;1us;70us;1us;73us;2us;73us;75us;1us;73us;1us;75us;1us;76us;2us;76us;78us;1us;76us;1us;78us;1us;79us;2us;79us;81us;1us;79us;1us;81us;|]
+let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us;2us;4us;10us;12us;14us;16us;18us;20us;22us;24us;27us;29us;31us;33us;35us;37us;40us;43us;45us;49us;51us;53us;55us;57us;59us;61us;63us;65us;75us;79us;82us;84us;87us;89us;91us;94us;96us;98us;100us;102us;104us;106us;108us;110us;116us;118us;120us;122us;124us;126us;128us;130us;132us;134us;136us;138us;140us;142us;144us;146us;148us;150us;152us;154us;156us;158us;160us;162us;164us;166us;176us;186us;196us;206us;216us;226us;236us;246us;256us;266us;268us;270us;272us;274us;276us;278us;280us;282us;284us;286us;288us;290us;292us;294us;296us;298us;300us;302us;304us;306us;308us;310us;312us;314us;316us;318us;320us;322us;324us;326us;328us;330us;332us;334us;337us;339us;341us;344us;346us;348us;351us;353us;355us;357us;360us;362us;364us;366us;369us;371us;|]
+let _fsyacc_action_rows = 131
+let _fsyacc_actionTableElements = [|0us;16386us;0us;49152us;5us;32768us;10us;8us;11us;16us;12us;29us;13us;41us;14us;3us;0us;16385us;0us;16387us;0us;16388us;0us;16389us;0us;16390us;1us;32768us;38us;9us;0us;16392us;2us;32768us;1us;13us;39us;11us;0us;16391us;0us;16393us;1us;32768us;29us;14us;1us;32768us;46us;112us;0us;16394us;1us;32768us;45us;17us;1us;16395us;38us;18us;0us;16397us;3us;32768us;2us;23us;3us;26us;39us;20us;0us;16396us;0us;16398us;0us;16399us;1us;32768us;29us;24us;1us;32768us;36us;127us;0us;16400us;1us;32768us;29us;27us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;8us;16401us;15us;102us;16us;103us;26us;87us;27us;86us;30us;84us;31us;85us;34us;80us;35us;82us;2us;32768us;38us;31us;45us;30us;1us;16402us;38us;34us;0us;16405us;2us;32768us;4us;38us;39us;33us;0us;16403us;0us;16405us;2us;32768us;4us;38us;39us;36us;0us;16404us;0us;16406us;1us;32768us;29us;39us;1us;32768us;38us;119us;0us;16407us;2us;32768us;44us;108us;45us;109us;1us;32768us;38us;43us;0us;16409us;5us;32768us;4us;53us;5us;50us;7us;56us;8us;59us;39us;45us;0us;16408us;0us;16410us;0us;16411us;0us;16412us;0us;16413us;1us;32768us;29us;51us;1us;32768us;46us;112us;0us;16414us;1us;32768us;29us;54us;1us;32768us;36us;123us;0us;16415us;1us;32768us;29us;57us;1us;32768us;46us;112us;0us;16416us;1us;32768us;29us;60us;1us;32768us;38us;119us;0us;16417us;0us;16418us;0us;16419us;0us;16420us;0us;16421us;0us;16422us;0us;16423us;0us;16424us;0us;16425us;4us;16428us;26us;87us;27us;86us;34us;80us;35us;82us;4us;16429us;26us;87us;27us;86us;34us;80us;35us;82us;2us;16430us;34us;80us;35us;82us;3us;16431us;27us;86us;34us;80us;35us;82us;6us;16439us;26us;87us;27us;86us;30us;84us;31us;85us;34us;80us;35us;82us;9us;32768us;15us;102us;16us;103us;17us;104us;26us;87us;27us;86us;30us;84us;31us;85us;34us;80us;35us;82us;8us;16440us;15us;102us;16us;103us;26us;87us;27us;86us;30us;84us;31us;85us;34us;80us;35us;82us;0us;16441us;8us;16456us;15us;102us;16us;103us;26us;87us;27us;86us;30us;84us;31us;85us;34us;80us;35us;82us;8us;16459us;15us;102us;16us;103us;26us;87us;27us;86us;30us;84us;31us;85us;34us;80us;35us;82us;2us;32768us;40us;110us;45us;111us;0us;16426us;2us;32768us;40us;110us;45us;111us;0us;16427us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;1us;32768us;32us;113us;0us;16432us;1us;32768us;32us;113us;0us;16433us;1us;32768us;32us;113us;0us;16434us;1us;32768us;32us;113us;0us;16435us;1us;32768us;32us;113us;0us;16436us;1us;32768us;32us;113us;0us;16437us;1us;32768us;32us;113us;0us;16438us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16442us;0us;16443us;0us;16444us;0us;16445us;0us;16446us;0us;16447us;0us;16450us;0us;16455us;17us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;33us;115us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16451us;0us;16455us;17us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;37us;118us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16454us;0us;16458us;2us;32768us;39us;121us;41us;122us;0us;16457us;16us;32768us;18us;105us;19us;88us;20us;90us;21us;92us;22us;94us;23us;96us;24us;98us;25us;100us;36us;116us;38us;119us;40us;66us;42us;67us;46us;65us;47us;62us;48us;63us;49us;64us;0us;16461us;2us;32768us;37us;125us;46us;112us;0us;16460us;0us;16462us;0us;16464us;3us;32768us;37us;129us;43us;106us;45us;107us;0us;16463us;0us;16465us;|]
+let _fsyacc_actionTableRowOffsets = [|0us;1us;2us;8us;9us;10us;11us;12us;13us;15us;16us;19us;20us;21us;23us;25us;26us;28us;30us;31us;35us;36us;37us;38us;40us;42us;43us;45us;62us;71us;74us;76us;77us;80us;81us;82us;85us;86us;87us;89us;91us;92us;95us;97us;98us;104us;105us;106us;107us;108us;109us;111us;113us;114us;116us;118us;119us;121us;123us;124us;126us;128us;129us;130us;131us;132us;133us;134us;135us;136us;137us;142us;147us;150us;154us;161us;171us;180us;181us;190us;199us;202us;203us;206us;207us;224us;241us;258us;275us;277us;278us;280us;281us;283us;284us;286us;287us;289us;290us;292us;293us;295us;296us;313us;330us;347us;364us;365us;366us;367us;368us;369us;370us;371us;372us;390us;391us;392us;410us;411us;412us;415us;416us;433us;434us;437us;438us;439us;440us;444us;445us;|]
+let _fsyacc_reductionSymbolCounts = [|1us;2us;0us;2us;2us;2us;2us;4us;0us;2us;3us;2us;5us;0us;2us;2us;3us;3us;2us;4us;5us;0us;2us;3us;5us;0us;2us;2us;2us;2us;3us;3us;3us;3us;1us;1us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;1us;1us;1us;1us;3us;0us;3us;3us;0us;2us;3us;0us;3us;3us;0us;2us;3us;0us;2us;|]
+let _fsyacc_productionToNonTerminalTable = [|0us;1us;2us;2us;2us;2us;2us;3us;4us;4us;5us;6us;6us;7us;7us;7us;8us;9us;10us;10us;10us;11us;11us;12us;13us;14us;14us;14us;14us;14us;15us;16us;17us;18us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;19us;20us;20us;21us;21us;22us;22us;23us;23us;24us;25us;26us;26us;27us;28us;28us;29us;30us;30us;31us;32us;32us;33us;34us;34us;|]
+let _fsyacc_immediateActions = [|65535us;49152us;65535us;16385us;16387us;16388us;16389us;16390us;65535us;65535us;65535us;16391us;16393us;65535us;65535us;16394us;65535us;65535us;65535us;65535us;16396us;16398us;16399us;65535us;65535us;16400us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16403us;65535us;65535us;16404us;16406us;65535us;65535us;16407us;65535us;65535us;65535us;65535us;16408us;16410us;16411us;16412us;16413us;65535us;65535us;16414us;65535us;65535us;16415us;65535us;65535us;16416us;65535us;65535us;16417us;16418us;16419us;16420us;16421us;16422us;16423us;16424us;16425us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16426us;65535us;16427us;65535us;65535us;65535us;65535us;65535us;16432us;65535us;16433us;65535us;16434us;65535us;16435us;65535us;16436us;65535us;16437us;65535us;16438us;65535us;65535us;65535us;65535us;16442us;16443us;16444us;16445us;16446us;16447us;16450us;65535us;65535us;16451us;65535us;65535us;16454us;65535us;65535us;16457us;65535us;65535us;65535us;16460us;16462us;65535us;65535us;16463us;16465us;|]
 let _fsyacc_reductions = lazy [|
-# 479 "Gen/WorkspaceParser.fs"
+# 484 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Terrabuild.Configuration.Workspace.AST.WorkspaceFile in
             Microsoft.FSharp.Core.Operators.box
@@ -485,7 +490,7 @@ let _fsyacc_reductions = lazy [|
                       raise (FSharp.Text.Parsing.Accept(Microsoft.FSharp.Core.Operators.box _1))
                    )
                  : 'gentype__startWorkspaceFile));
-# 488 "Gen/WorkspaceParser.fs"
+# 493 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             Microsoft.FSharp.Core.Operators.box
@@ -496,7 +501,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 55 "WorkspaceParser/Parser.fsy"
                  : Terrabuild.Configuration.Workspace.AST.WorkspaceFile));
-# 499 "Gen/WorkspaceParser.fs"
+# 504 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -506,7 +511,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 58 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 509 "Gen/WorkspaceParser.fs"
+# 514 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Workspace in
@@ -518,7 +523,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 59 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 521 "Gen/WorkspaceParser.fs"
+# 526 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Target in
@@ -530,7 +535,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 60 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 533 "Gen/WorkspaceParser.fs"
+# 538 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Configuration in
@@ -542,7 +547,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 61 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 545 "Gen/WorkspaceParser.fs"
+# 550 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Extension in
@@ -554,7 +559,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 62 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 557 "Gen/WorkspaceParser.fs"
+# 562 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_WorkspaceComponents in
             Microsoft.FSharp.Core.Operators.box
@@ -565,7 +570,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 65 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Workspace));
-# 568 "Gen/WorkspaceParser.fs"
+# 573 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -575,7 +580,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 67 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceComponents));
-# 578 "Gen/WorkspaceParser.fs"
+# 583 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_WorkspaceSpace in
@@ -587,7 +592,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 68 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceComponents));
-# 590 "Gen/WorkspaceParser.fs"
+# 595 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
@@ -598,7 +603,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 70 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceSpace));
-# 601 "Gen/WorkspaceParser.fs"
+# 606 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -609,7 +614,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 73 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Target));
-# 612 "Gen/WorkspaceParser.fs"
+# 617 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             let _4 = parseState.GetInput(4) :?> 'gentype_TargetComponents in
@@ -621,7 +626,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 74 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Target));
-# 624 "Gen/WorkspaceParser.fs"
+# 629 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -631,7 +636,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 76 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 634 "Gen/WorkspaceParser.fs"
+# 639 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetDependsOn in
@@ -643,7 +648,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 77 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 646 "Gen/WorkspaceParser.fs"
+# 651 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetRebuild in
@@ -655,7 +660,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 78 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 658 "Gen/WorkspaceParser.fs"
+# 663 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfTargetIdentifiers in
             Microsoft.FSharp.Core.Operators.box
@@ -666,7 +671,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 80 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetDependsOn));
-# 669 "Gen/WorkspaceParser.fs"
+# 674 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
@@ -677,7 +682,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 82 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetRebuild));
-# 680 "Gen/WorkspaceParser.fs"
+# 685 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -688,7 +693,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 85 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Configuration));
-# 691 "Gen/WorkspaceParser.fs"
+# 696 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ConfigurationComponents in
             Microsoft.FSharp.Core.Operators.box
@@ -699,7 +704,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 86 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Configuration));
-# 702 "Gen/WorkspaceParser.fs"
+# 707 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             let _4 = parseState.GetInput(4) :?> 'gentype_ConfigurationComponents in
@@ -711,7 +716,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 87 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Configuration));
-# 714 "Gen/WorkspaceParser.fs"
+# 719 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -721,7 +726,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 89 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ConfigurationComponents));
-# 724 "Gen/WorkspaceParser.fs"
+# 729 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ConfigurationComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ConfigurationVariables in
@@ -733,7 +738,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 90 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ConfigurationComponents));
-# 736 "Gen/WorkspaceParser.fs"
+# 741 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprMap in
             Microsoft.FSharp.Core.Operators.box
@@ -744,7 +749,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 92 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ConfigurationVariables));
-# 747 "Gen/WorkspaceParser.fs"
+# 752 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionIdentifier in
             let _4 = parseState.GetInput(4) :?> 'gentype_ExtensionComponents in
@@ -756,7 +761,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 95 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Extension));
-# 759 "Gen/WorkspaceParser.fs"
+# 764 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -766,7 +771,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 97 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 769 "Gen/WorkspaceParser.fs"
+# 774 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionContainer in
@@ -778,7 +783,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 98 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 781 "Gen/WorkspaceParser.fs"
+# 786 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionVariables in
@@ -790,7 +795,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 99 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 793 "Gen/WorkspaceParser.fs"
+# 798 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionScript in
@@ -802,7 +807,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 100 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 805 "Gen/WorkspaceParser.fs"
+# 810 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionDefaults in
@@ -814,7 +819,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 101 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 817 "Gen/WorkspaceParser.fs"
+# 822 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
@@ -825,7 +830,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 103 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionContainer));
-# 828 "Gen/WorkspaceParser.fs"
+# 833 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
@@ -836,7 +841,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 105 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionVariables));
-# 839 "Gen/WorkspaceParser.fs"
+# 844 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
@@ -847,7 +852,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 107 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionScript));
-# 850 "Gen/WorkspaceParser.fs"
+# 855 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprMap in
             Microsoft.FSharp.Core.Operators.box
@@ -858,7 +863,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 109 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionDefaults));
-# 861 "Gen/WorkspaceParser.fs"
+# 866 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -868,7 +873,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 113 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 871 "Gen/WorkspaceParser.fs"
+# 876 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -878,7 +883,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 114 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 881 "Gen/WorkspaceParser.fs"
+# 886 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -888,7 +893,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 115 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 891 "Gen/WorkspaceParser.fs"
+# 896 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -899,7 +904,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 116 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 902 "Gen/WorkspaceParser.fs"
+# 907 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
@@ -910,7 +915,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 117 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 913 "Gen/WorkspaceParser.fs"
+# 918 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -921,7 +926,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 118 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 924 "Gen/WorkspaceParser.fs"
+# 929 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprList in
             Microsoft.FSharp.Core.Operators.box
@@ -932,7 +937,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 120 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 935 "Gen/WorkspaceParser.fs"
+# 940 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprMap in
             Microsoft.FSharp.Core.Operators.box
@@ -943,7 +948,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 121 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 946 "Gen/WorkspaceParser.fs"
+# 951 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
@@ -955,7 +960,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 123 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 958 "Gen/WorkspaceParser.fs"
+# 963 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
@@ -967,7 +972,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 124 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 970 "Gen/WorkspaceParser.fs"
+# 975 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -979,7 +984,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 125 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 982 "Gen/WorkspaceParser.fs"
+# 987 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -991,7 +996,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 126 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 994 "Gen/WorkspaceParser.fs"
+# 999 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1003,7 +1008,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 127 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1006 "Gen/WorkspaceParser.fs"
+# 1011 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1015,86 +1020,84 @@ let _fsyacc_reductions = lazy [|
                    )
 # 128 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1018 "Gen/WorkspaceParser.fs"
+# 1023 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 129 "WorkspaceParser/Parser.fsy"
-                                                     Expr.Function (Function.Trim, [_3]) 
+                                            Expr.Function (Function.Trim, _2) 
                    )
 # 129 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1029 "Gen/WorkspaceParser.fs"
+# 1034 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 130 "WorkspaceParser/Parser.fsy"
-                                                      Expr.Function (Function.Upper, [_3]) 
+                                             Expr.Function (Function.Upper, _2) 
                    )
 # 130 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1040 "Gen/WorkspaceParser.fs"
+# 1045 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 131 "WorkspaceParser/Parser.fsy"
-                                                      Expr.Function (Function.Lower, [_3]) 
+                                             Expr.Function (Function.Lower, _2) 
                    )
 # 131 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1051 "Gen/WorkspaceParser.fs"
+# 1056 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
-            let _4 = parseState.GetInput(4) :?> 'gentype_Expr in
-            let _5 = parseState.GetInput(5) :?> 'gentype_Expr in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 132 "WorkspaceParser/Parser.fsy"
-                                                                  Expr.Function (Function.Replace, [_3; _4; _5]) 
+                                               Expr.Function (Function.Replace, _2) 
                    )
 # 132 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1064 "Gen/WorkspaceParser.fs"
+# 1067 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 133 "WorkspaceParser/Parser.fsy"
-                                                      Expr.Function (Function.Count, [_3])
+                                             Expr.Function (Function.Count, _2)
                    )
 # 133 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1075 "Gen/WorkspaceParser.fs"
+# 1078 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 134 "WorkspaceParser/Parser.fsy"
-                                                        Expr.Function (Function.Version, [_3]) 
+                                               Expr.Function (Function.Version, _2) 
                    )
 # 134 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1086 "Gen/WorkspaceParser.fs"
+# 1089 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_ExprListContent in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 135 "WorkspaceParser/Parser.fsy"
-                                                                  Expr.Function (Function.Format, _3) 
+                                              Expr.Function (Function.Format, _2) 
                    )
 # 135 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1097 "Gen/WorkspaceParser.fs"
+# 1100 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1106,7 +1109,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 136 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1109 "Gen/WorkspaceParser.fs"
+# 1112 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1119,7 +1122,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 137 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1122 "Gen/WorkspaceParser.fs"
+# 1125 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
@@ -1130,7 +1133,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 138 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1133 "Gen/WorkspaceParser.fs"
+# 1136 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1141,7 +1144,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 141 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetIdentifier));
-# 1144 "Gen/WorkspaceParser.fs"
+# 1147 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1152,7 +1155,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 142 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetIdentifier));
-# 1155 "Gen/WorkspaceParser.fs"
+# 1158 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1163,7 +1166,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 145 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionIdentifier));
-# 1166 "Gen/WorkspaceParser.fs"
+# 1169 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1174,7 +1177,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 146 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionIdentifier));
-# 1177 "Gen/WorkspaceParser.fs"
+# 1180 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
@@ -1185,7 +1188,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 149 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprIndex));
-# 1188 "Gen/WorkspaceParser.fs"
+# 1191 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1196,7 +1199,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 150 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprIndex));
-# 1199 "Gen/WorkspaceParser.fs"
+# 1202 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -1206,7 +1209,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 153 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Bool));
-# 1209 "Gen/WorkspaceParser.fs"
+# 1212 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -1216,7 +1219,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 154 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Bool));
-# 1219 "Gen/WorkspaceParser.fs"
+# 1222 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -1227,18 +1230,18 @@ let _fsyacc_reductions = lazy [|
                    )
 # 157 "WorkspaceParser/Parser.fsy"
                  : 'gentype_String));
-# 1230 "Gen/WorkspaceParser.fs"
+# 1233 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprListContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 160 "WorkspaceParser/Parser.fsy"
-                                                                   _2 
+                                                           _2 
                    )
 # 160 "WorkspaceParser/Parser.fsy"
-                 : 'gentype_ExprList));
-# 1241 "Gen/WorkspaceParser.fs"
+                 : 'gentype_ExprTuple));
+# 1244 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -1247,41 +1250,74 @@ let _fsyacc_reductions = lazy [|
                                          [] 
                    )
 # 162 "WorkspaceParser/Parser.fsy"
+                 : 'gentype_ExprTupleContent));
+# 1254 "Gen/WorkspaceParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            let _1 = parseState.GetInput(1) :?> 'gentype_ExprListContent in
+            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 163 "WorkspaceParser/Parser.fsy"
+                                                        _1 @ [_3] 
+                   )
+# 163 "WorkspaceParser/Parser.fsy"
+                 : 'gentype_ExprTupleContent));
+# 1266 "Gen/WorkspaceParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExprListContent in
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 166 "WorkspaceParser/Parser.fsy"
+                                                                   _2 
+                   )
+# 166 "WorkspaceParser/Parser.fsy"
+                 : 'gentype_ExprList));
+# 1277 "Gen/WorkspaceParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 168 "WorkspaceParser/Parser.fsy"
+                                         [] 
+                   )
+# 168 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprListContent));
-# 1251 "Gen/WorkspaceParser.fs"
+# 1287 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprListContent in
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 163 "WorkspaceParser/Parser.fsy"
+# 169 "WorkspaceParser/Parser.fsy"
                                                   _1 @ [_2] 
                    )
-# 163 "WorkspaceParser/Parser.fsy"
+# 169 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprListContent));
-# 1263 "Gen/WorkspaceParser.fs"
+# 1299 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprMapContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 166 "WorkspaceParser/Parser.fsy"
+# 172 "WorkspaceParser/Parser.fsy"
                                                           _2 
                    )
-# 166 "WorkspaceParser/Parser.fsy"
+# 172 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprMap));
-# 1274 "Gen/WorkspaceParser.fs"
+# 1310 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 168 "WorkspaceParser/Parser.fsy"
+# 174 "WorkspaceParser/Parser.fsy"
                                          Map.empty 
                    )
-# 168 "WorkspaceParser/Parser.fsy"
+# 174 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprMapContent));
-# 1284 "Gen/WorkspaceParser.fs"
+# 1320 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprMapContent in
             let _2 = parseState.GetInput(2) :?> string in
@@ -1289,79 +1325,79 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 169 "WorkspaceParser/Parser.fsy"
+# 175 "WorkspaceParser/Parser.fsy"
                                                      _1.Add (_2, _3) 
                    )
-# 169 "WorkspaceParser/Parser.fsy"
+# 175 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprMapContent));
-# 1297 "Gen/WorkspaceParser.fs"
+# 1333 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Strings in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 172 "WorkspaceParser/Parser.fsy"
+# 178 "WorkspaceParser/Parser.fsy"
                                                            _2 
                    )
-# 172 "WorkspaceParser/Parser.fsy"
+# 178 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ListOfString));
-# 1308 "Gen/WorkspaceParser.fs"
+# 1344 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 174 "WorkspaceParser/Parser.fsy"
+# 180 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 174 "WorkspaceParser/Parser.fsy"
+# 180 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Strings));
-# 1318 "Gen/WorkspaceParser.fs"
+# 1354 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Strings in
             let _2 = parseState.GetInput(2) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 175 "WorkspaceParser/Parser.fsy"
+# 181 "WorkspaceParser/Parser.fsy"
                                             _1 @ [_2] 
                    )
-# 175 "WorkspaceParser/Parser.fsy"
+# 181 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Strings));
-# 1330 "Gen/WorkspaceParser.fs"
+# 1366 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetIdentifiers in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 178 "WorkspaceParser/Parser.fsy"
+# 184 "WorkspaceParser/Parser.fsy"
                                                                      _2 
                    )
-# 178 "WorkspaceParser/Parser.fsy"
+# 184 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ListOfTargetIdentifiers));
-# 1341 "Gen/WorkspaceParser.fs"
+# 1377 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 180 "WorkspaceParser/Parser.fsy"
+# 186 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 180 "WorkspaceParser/Parser.fsy"
+# 186 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetIdentifiers));
-# 1351 "Gen/WorkspaceParser.fs"
+# 1387 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetIdentifiers in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetIdentifier in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 181 "WorkspaceParser/Parser.fsy"
+# 187 "WorkspaceParser/Parser.fsy"
                                                                 _1 @ [_2] 
                    )
-# 181 "WorkspaceParser/Parser.fsy"
+# 187 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetIdentifiers));
 |]
-# 1364 "Gen/WorkspaceParser.fs"
+# 1400 "Gen/WorkspaceParser.fs"
 let tables : FSharp.Text.Parsing.Tables<_> = 
   { reductions = _fsyacc_reductions.Value;
     endOfInputTag = _fsyacc_endOfInputTag;

--- a/src/Terrabuild.Configuration/Gen/WorkspaceParser.fsi
+++ b/src/Terrabuild.Configuration/Gen/WorkspaceParser.fsi
@@ -130,6 +130,8 @@ type nonTerminalId =
     | NONTERM_ExprIndex
     | NONTERM_Bool
     | NONTERM_String
+    | NONTERM_ExprTuple
+    | NONTERM_ExprTupleContent
     | NONTERM_ExprList
     | NONTERM_ExprListContent
     | NONTERM_ExprMap

--- a/src/Terrabuild.Configuration/ProjectParser/Parser.fsy
+++ b/src/Terrabuild.Configuration/ProjectParser/Parser.fsy
@@ -47,6 +47,7 @@ let debugPrint s = ignore s
 %left PLUS
 %left DOT DOT_QUESTION
 %right BANG
+%left COMMA
 
 %type <Terrabuild.Configuration.Project.AST.ProjectFile> ProjectFile
 %% 
@@ -172,10 +173,11 @@ String:
     | STRING { $1 }
 
 ExprTuple:
-    | LPAREN ExprListContent RPAREN { $2 }
+    | LPAREN ExprTupleContent RPAREN { $2 }
 ExprTupleContent:
     | /* empty */ { [] }
-    | ExprListContent COMMA Expr { $1 @ [$3] }
+    | Expr { [$1] }
+    | ExprTupleContent COMMA Expr { $1 @ [$3] }
 
 ExprList:
     | LSQBRACKET ExprListContent RSQBRACKET { $2 }

--- a/src/Terrabuild.Configuration/ProjectParser/Parser.fsy
+++ b/src/Terrabuild.Configuration/ProjectParser/Parser.fsy
@@ -141,13 +141,13 @@ Expr:
     | Expr NOT_EQUAL Expr { Expr.Function (Function.NotEqual, [$1; $3]) }
     | Expr PLUS Expr { Expr.Function (Function.Plus, [$1; $3]) }
     | Expr MINUS Expr { Expr.Function (Function.Minus, [$1; $3]) }
-    | TRIM LPAREN Expr RPAREN { Expr.Function (Function.Trim, [$3]) }
-    | UPPER LPAREN Expr RPAREN { Expr.Function (Function.Upper, [$3]) }
-    | LOWER LPAREN Expr RPAREN { Expr.Function (Function.Lower, [$3]) }
-    | REPLACE LPAREN Expr Expr Expr RPAREN { Expr.Function (Function.Replace, [$3; $4; $5]) }
-    | COUNT LPAREN Expr RPAREN { Expr.Function (Function.Count, [$3])}
-    | VERSION LPAREN Expr RPAREN { Expr.Function (Function.Version, [$3]) }
-    | FORMAT LPAREN ExprListContent RPAREN { Expr.Function (Function.Format, $3) }
+    | TRIM ExprTuple { Expr.Function (Function.Trim, $2) }
+    | UPPER ExprTuple { Expr.Function (Function.Upper, $2) }
+    | LOWER ExprTuple { Expr.Function (Function.Lower, $2) }
+    | REPLACE ExprTuple { Expr.Function (Function.Replace, $2) }
+    | COUNT ExprTuple { Expr.Function (Function.Count, $2)}
+    | VERSION ExprTuple { Expr.Function (Function.Version, $2) }
+    | FORMAT ExprTuple { Expr.Function (Function.Format, $2) }
     | Expr DOUBLE_QUESTION Expr { Expr.Function (Function.Coalesce, [$1; $3]) }
     | Expr QUESTION Expr COLON Expr { Expr.Function (Function.Ternary, [$1; $3; $5] ) }
     | BANG Expr { Expr.Function (Function.Not, [$2]) }
@@ -170,6 +170,12 @@ Bool:
 
 String:
     | STRING { $1 }
+
+ExprTuple:
+    | LPAREN ExprListContent RPAREN { $2 }
+ExprTupleContent:
+    | /* empty */ { [] }
+    | ExprListContent COMMA Expr { $1 @ [$3] }
 
 ExprList:
     | LSQBRACKET ExprListContent RSQBRACKET { $2 }

--- a/src/Terrabuild.Configuration/WorkspaceParser/Parser.fsy
+++ b/src/Terrabuild.Configuration/WorkspaceParser/Parser.fsy
@@ -47,6 +47,7 @@ let debugPrint s = ignore s
 %left PLUS
 %left DOT DOT_QUESTION
 %right BANG
+%left COMMA
 
 %type <Terrabuild.Configuration.Workspace.AST.WorkspaceFile> WorkspaceFile
 %% 
@@ -157,10 +158,11 @@ String:
     | STRING { $1 }
 
 ExprTuple:
-    | LPAREN ExprListContent RPAREN { $2 }
+    | LPAREN ExprTupleContent RPAREN { $2 }
 ExprTupleContent:
     | /* empty */ { [] }
-    | ExprListContent COMMA Expr { $1 @ [$3] }
+    | Expr { [$1] }
+    | ExprTupleContent COMMA Expr { $1 @ [$3] }
 
 ExprList:
     | LSQBRACKET ExprListContent RSQBRACKET { $2 }

--- a/src/Terrabuild.Configuration/WorkspaceParser/Parser.fsy
+++ b/src/Terrabuild.Configuration/WorkspaceParser/Parser.fsy
@@ -126,13 +126,13 @@ Expr:
     | Expr NOT_EQUAL Expr { Expr.Function (Function.NotEqual, [$1; $3]) }
     | Expr PLUS Expr { Expr.Function (Function.Plus, [$1; $3]) }
     | Expr MINUS Expr { Expr.Function (Function.Minus, [$1; $3]) }
-    | TRIM LPAREN Expr RPAREN { Expr.Function (Function.Trim, [$3]) }
-    | UPPER LPAREN Expr RPAREN { Expr.Function (Function.Upper, [$3]) }
-    | LOWER LPAREN Expr RPAREN { Expr.Function (Function.Lower, [$3]) }
-    | REPLACE LPAREN Expr Expr Expr RPAREN { Expr.Function (Function.Replace, [$3; $4; $5]) }
-    | COUNT LPAREN Expr RPAREN { Expr.Function (Function.Count, [$3])}
-    | VERSION LPAREN Expr RPAREN { Expr.Function (Function.Version, [$3]) }
-    | FORMAT LPAREN ExprListContent RPAREN { Expr.Function (Function.Format, $3) }
+    | TRIM ExprTuple { Expr.Function (Function.Trim, $2) }
+    | UPPER ExprTuple { Expr.Function (Function.Upper, $2) }
+    | LOWER ExprTuple { Expr.Function (Function.Lower, $2) }
+    | REPLACE ExprTuple { Expr.Function (Function.Replace, $2) }
+    | COUNT ExprTuple { Expr.Function (Function.Count, $2)}
+    | VERSION ExprTuple { Expr.Function (Function.Version, $2) }
+    | FORMAT ExprTuple { Expr.Function (Function.Format, $2) }
     | Expr DOUBLE_QUESTION Expr { Expr.Function (Function.Coalesce, [$1; $3]) }
     | Expr QUESTION Expr COLON Expr { Expr.Function (Function.Ternary, [$1; $3; $5] ) }
     | BANG Expr { Expr.Function (Function.Not, [$2]) }
@@ -155,6 +155,12 @@ Bool:
 
 String:
     | STRING { $1 }
+
+ExprTuple:
+    | LPAREN ExprListContent RPAREN { $2 }
+ExprTupleContent:
+    | /* empty */ { [] }
+    | ExprListContent COMMA Expr { $1 @ [$3] }
 
 ExprList:
     | LSQBRACKET ExprListContent RSQBRACKET { $2 }

--- a/src/Terrabuild.Expressions/Eval.fs
+++ b/src/Terrabuild.Expressions/Eval.fs
@@ -76,7 +76,7 @@ let rec eval (context: EvaluationContext) (expr: Expr) =
                         | Value.Bool b -> if b then "true" else "false"
                         | Value.Number n -> $"{n}"
                         | Value.String s -> s
-                        | _ -> TerrabuildException.Raise($"Unsupported type for format")
+                        | _ -> TerrabuildException.Raise($"Unsupported type for format {v}")
 
                     values
                     |> List.fold (fun acc value -> $"{acc}{formatValue value}") ""


### PR DESCRIPTION
Breaking change for function call, now use tuple syntax (comma separated): `format("toto" 42)` → `format("toto", 42)` 