### PR TITLE
fix circular variable evaluation

### DIFF
--- a/src/Terrabuild.Expressions.Tests/Eval.fs
+++ b/src/Terrabuild.Expressions.Tests/Eval.fs
@@ -3,6 +3,7 @@ module Terrabuild.Expressions.Tests
 open NUnit.Framework
 open FsUnit
 open Eval
+open Errors
 
 let private evaluationContext = {
     Eval.EvaluationContext.WorkspaceDir = TestContext.CurrentContext.WorkDirectory
@@ -47,6 +48,14 @@ let valueVariable() =
     let varUsed, result = eval context (Expr.Variable "toto")
     varUsed |> should equal expectedUsedVars
     result |> should equal expected
+
+[<Test>]
+let valueVariableCircular() =
+    let context = { evaluationContext with Variables = Map ["toto", Expr.Variable "titi"
+                                                            "titi", Expr.Variable "toto"] }
+    
+    (fun () -> eval context (Expr.Variable "toto") |> ignore)
+    |> should (throwWithMessage "Variable toto has circular definition") typeof<TerrabuildException>
 
 [<Test>]
 let concatString() =

--- a/src/Terrabuild.Expressions/Eval.fs
+++ b/src/Terrabuild.Expressions/Eval.fs
@@ -19,6 +19,7 @@ let rec eval (context: EvaluationContext) (expr: Expr) =
         | Expr.Number num -> varUsed, Value.Number num
         | Expr.Object obj -> varUsed, Value.Object obj
         | Expr.Variable var ->
+            if varUsed |> Set.contains var then TerrabuildException.Raise($"Variable {var} has circular definition")
             match context.Variables |> Map.tryFind var with
             | None -> TerrabuildException.Raise($"Variable '{var}' is not defined")
             | Some value -> eval (varUsed |> Set.add var) value


### PR DESCRIPTION
Variable evaluation can lead to infinite recursive evaluation. Evaluation must fail if circular evaluation is detected.
