### PR TITLE
Eager evaluation to avoid circular dependencies

### DIFF
--- a/src/Terrabuild.Expressions.Tests/Eval.fs
+++ b/src/Terrabuild.Expressions.Tests/Eval.fs
@@ -9,7 +9,7 @@ let mkVar value =
 
 let private evaluationContext = {
     Eval.EvaluationContext.WorkspaceDir = TestContext.CurrentContext.WorkDirectory
-    Eval.EvaluationContext.ProjectDir = TestContext.CurrentContext.TestDirectory
+    Eval.EvaluationContext.ProjectDir = Some TestContext.CurrentContext.TestDirectory
     Eval.EvaluationContext.Variables = Map.empty
     Eval.EvaluationContext.Versions = Map.empty
 }

--- a/src/Terrabuild.Expressions.Tests/Eval.fs
+++ b/src/Terrabuild.Expressions.Tests/Eval.fs
@@ -3,6 +3,7 @@ module Terrabuild.Expressions.Tests
 open NUnit.Framework
 open FsUnit
 open Eval
+open Errors
 
 let private evaluationContext = {
     Eval.EvaluationContext.WorkspaceDir = TestContext.CurrentContext.WorkDirectory
@@ -47,6 +48,14 @@ let valueVariable() =
     let varUsed, result = eval context (Expr.Variable "toto")
     varUsed |> should equal expectedUsedVars
     result |> should equal expected
+
+[<Test>]
+let valueVariableCircular() =
+    let context = { evaluationContext with Variables = Map ["toto", Expr.Variable "titi"
+                                                            "titi", Expr.Variable "toto"] }
+    
+    (fun () -> eval context (Expr.Variable "toto") |> ignore)
+    |> should (throwWithMessage "Variable toto has circular definition") typeof<TerrabuildException>
 
 [<Test>]
 let concatString() =

--- a/src/Terrabuild.Expressions/Eval.fs
+++ b/src/Terrabuild.Expressions/Eval.fs
@@ -19,6 +19,7 @@ let rec eval (context: EvaluationContext) (expr: Expr) =
         | Expr.Number num -> varUsed, Value.Number num
         | Expr.Object obj -> varUsed, Value.Object obj
         | Expr.Variable var ->
+            if varUsed |> Set.contains var then TerrabuildException.Raise($"Variable {var} has circular definition")
             match context.Variables |> Map.tryFind var with
             | None -> TerrabuildException.Raise($"Variable '{var}' is not defined")
             | Some value -> eval (varUsed |> Set.add var) value

--- a/src/Terrabuild.Expressions/Eval.fs
+++ b/src/Terrabuild.Expressions/Eval.fs
@@ -22,7 +22,7 @@ let rec eval (context: EvaluationContext) (expr: Expr) =
             // if varUsed |> Set.contains var then TerrabuildException.Raise($"Variable {var} has circular definition")
             match context.Variables |> Map.tryFind var with
             | None -> TerrabuildException.Raise($"Variable '{var}' is not defined")
-            | Some (value, varUsed) -> value, (varUsed + Set.singleton var)
+            | Some (value, varUsed) -> value, (varUsed |> Set.add var)
         | Expr.Map map ->
             let values, varUsed = map |> Map.fold (fun (map, varUsed) k v ->
                 let mv, mvu = eval v

--- a/src/Terrabuild.Expressions/Eval.fs
+++ b/src/Terrabuild.Expressions/Eval.fs
@@ -7,36 +7,36 @@ type EvaluationContext = {
     WorkspaceDir: string
     ProjectDir: string
     Versions: Map<string, string>
-    Variables: Map<string, Expr>
+    Variables: Map<string, Value * Set<string>>
 }
 
 let rec eval (context: EvaluationContext) (expr: Expr) =
     let rec eval (varUsed: Set<string>) (expr: Expr) =
         match expr with
-        | Expr.Nothing -> varUsed, Value.Nothing
-        | Expr.Bool bool -> varUsed, Value.Bool bool
-        | Expr.String str -> varUsed, Value.String str
-        | Expr.Number num -> varUsed, Value.Number num
-        | Expr.Object obj -> varUsed, Value.Object obj
+        | Expr.Nothing -> Value.Nothing, varUsed
+        | Expr.Bool bool -> Value.Bool bool, varUsed
+        | Expr.String str -> Value.String str, varUsed
+        | Expr.Number num -> Value.Number num, varUsed
+        | Expr.Object obj -> Value.Object obj, varUsed
         | Expr.Variable var ->
             if varUsed |> Set.contains var then TerrabuildException.Raise($"Variable {var} has circular definition")
             match context.Variables |> Map.tryFind var with
             | None -> TerrabuildException.Raise($"Variable '{var}' is not defined")
-            | Some value -> eval (varUsed |> Set.add var) value
+            | Some value -> value
         | Expr.Map map ->
-            let varUsed, values = map |> Map.fold (fun (varUsed, map) k v ->
-                let mvu, mv = eval varUsed v
-                varUsed+mvu, map |> Map.add k mv) (varUsed, Map.empty)
-            varUsed, Value.Map values
+            let values, varUsed = map |> Map.fold (fun (map, varUsed) k v ->
+                let mv, mvu = eval varUsed v
+                map |> Map.add k mv, varUsed+mvu) (Map.empty, varUsed)
+            Value.Map values, varUsed
         | Expr.List list ->
-            let varUsed, values = list |> List.fold (fun (varUsed, list) v ->
-                let mvu, mv = eval varUsed v
-                varUsed+mvu, list @ [mv]) (varUsed, [])
-            varUsed, Value.List values
+            let values, varUsed = list |> List.fold (fun (list, varUsed) v ->
+                let mv, mvu = eval varUsed v
+                list @ [mv], varUsed+mvu) ([], varUsed)
+            Value.List values, varUsed
         | Expr.Function (f, exprs) ->
-            let varUsed, values = exprs |> List.fold (fun (varUsed, exprs) expr ->
-                let vu, e = eval varUsed expr
-                varUsed+vu, (exprs @ [e])) (varUsed, [])
+            let values, varUsed = exprs |> List.fold (fun (exprs, varUsed) expr ->
+                let e, vu = eval varUsed expr
+                (exprs @ [e], varUsed+vu)) ([], varUsed)
             let res =
                 match f, values with
                 | Function.Plus, [Value.String left; Value.String right] -> Value.String (left + right)
@@ -131,6 +131,6 @@ let rec eval (context: EvaluationContext) (expr: Expr) =
 
                     let prms = prms |> List.map (getParamType) |> String.join "*"
                     TerrabuildException.Raise($"Invalid arguments for function {f} with parameters ({prms})")
-            varUsed, res
+            res, varUsed
 
     eval Set.empty expr

--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -152,8 +152,8 @@ let read (options: ConfigOptions.Options) =
             | Some value -> convertToVarType key (expr |> fst) value, Set.empty
             | _ -> expr)
 
-    // let branchOrTag = options.BranchOrTag
-    // let headCommit = options.HeadCommit
+    let evaluationContext = { evaluationContext
+                              with Eval.Variables = evaluationContext.Variables |> Map.addMap buildVariables }
 
     let extensions = 
         Extensions.systemExtensions

--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -286,37 +286,37 @@ let read (options: ConfigOptions.Options) =
             projectDef.Targets
             |> Map.map (fun targetName target ->
 
-                let tagValue = 
-                    match options.Tag with
-                    | Some tag -> Value.String tag
-                    | _ -> Value.Nothing
+                let evaluationContext =
+                    let actionVariables =
+                        let tagValue = 
+                            match options.Tag with
+                            | Some tag -> Value.String tag
+                            | _ -> Value.Nothing
 
-                let noteValue =
-                    match options.Note with
-                    | Some note -> Value.String note
-                    | _ -> Value.Nothing
+                        let noteValue =
+                            match options.Note with
+                            | Some note -> Value.String note
+                            | _ -> Value.Nothing
 
-                let actionVariables = Map [
-                    "terrabuild_project", (Value.String projectId, Set.empty)
-                    "terrabuild_target", (Value.String targetName, Set.empty)
-                    "terrabuild_hash", (Value.String projectHash, Set.empty)
-                    "terrabuild_configuration", (Value.String options.Configuration, Set.empty)
-                    "terrabuild_branch_or_tag", (Value.String options.BranchOrTag, Set.empty)
-                    "terrabuild_head_commit", (Value.String options.HeadCommit, Set.empty)
-                    "terrabuild_retry", (Value.Bool options.Retry, Set.empty)
-                    "terrabuild_force", (Value.Bool options.Force, Set.empty)
-                    "terrabuild_ci", (Value.Bool options.CI.IsSome, Set.empty)
-                    "terrabuild_debug", (Value.Bool options.Debug, Set.empty)
-                    "terrabuild_tag", (tagValue, Set.empty)
-                    "terrabuild_note", (noteValue, Set.empty)
-                ]
+                        [ "terrabuild_project", Value.String projectId
+                          "terrabuild_target" , Value.String targetName
+                          "terrabuild_hash", Value.String projectHash 
+                          "terrabuild_configuration", Value.String options.Configuration
+                          "terrabuild_branch_or_tag", Value.String options.BranchOrTag 
+                          "terrabuild_head_commit", Value.String options.HeadCommit 
+                          "terrabuild_retry", Value.Bool options.Retry 
+                          "terrabuild_force", Value.Bool options.Force 
+                          "terrabuild_ci", Value.Bool options.CI.IsSome 
+                          "terrabuild_debug", Value.Bool options.Debug 
+                          "terrabuild_tag", tagValue 
+                          "terrabuild_note", noteValue ]
+                        |> Seq.map (fun (name, value) -> name, (value, Set.empty))
+                        |> Map.ofSeq
 
-                let evaluationContext = {
-                    evaluationContext with
+                    { evaluationContext with
                         Eval.ProjectDir = Some projectDir
                         Eval.Versions = versions
-                        Eval.Variables = evaluationContext.Variables |> Map.addMap actionVariables
-                }
+                        Eval.Variables = evaluationContext.Variables |> Map.addMap actionVariables }
 
                 // use value from project target
                 // otherwise use workspace target

--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -361,7 +361,7 @@ let read (options: ConfigOptions.Options) =
                                 |> Seq.sort
                                 |> Seq.choose (fun key ->
                                     match buildVariables |> Map.tryFind key with
-                                    | Some value -> Some $"{key} = {value}"
+                                    | Some (value, _) -> Some $"{key} = {value}"
                                     | _ -> None)
                                 |> List.ofSeq
 


### PR DESCRIPTION
Goal is to be clearer when evaluating variables. Before, variables could be overridden leading to difficulties to understand evaluation - even leading to wrong evaluation.

Now, variables are evaluated eagerly and this way:
- use `default` configuration and evaluate
- apply environment/command line variable overrides and evaluate
- apply target configuration and evaluate
- evaluate each steps with `terrabuild_xxx` vars
