### PR TITLE
.terrabuild is no more required

### DIFF
--- a/src/Terrabuild/Core/Scaffold.fs
+++ b/src/Terrabuild/Core/Scaffold.fs
@@ -252,10 +252,3 @@ let scaffold workspaceDir force =
     let workspaceFile = FS.combinePath workspaceDir "WORKSPACE"
     let workspaceContent = genWorkspace extensions
     File.WriteAllLines(workspaceFile, workspaceContent)
-
-    // exclude terrabuild temp folder
-    let terrabuildLines = [ "# Terrabuild temporary folder"; ".terrabuild" ]
-    match FS.combinePath workspaceDir ".gitignore" with
-    | FS.File file -> File.AppendAllLines(file, terrabuildLines)
-    | FS.None file -> File.WriteAllLines(file, terrabuildLines)
-    | _ -> ()

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -90,9 +90,6 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         Log.Debug("Changing current directory to {directory}", options.Workspace)
         Log.Debug("ProcessorCount = {procCount}", Environment.ProcessorCount)
 
-        // create temporary folder so extensions can expose files to docker containers (folder must within workspaceDir hierarchy)
-        IO.createDirectory ".terrabuild"
-
         let sourceControl = SourceControls.Factory.create()
 
         let options = {


### PR DESCRIPTION
Remove the now useless `.terrabuild` folder at the root of workspace.