### PR TITLE
remove --check-state

### DIFF
--- a/src/Terrabuild.Extensibility/Extensions.fs
+++ b/src/Terrabuild.Extensibility/Extensions.fs
@@ -34,16 +34,9 @@ type ActionContext = {
 }
 
 [<RequireQualifiedAccess>]
-type StatusCode =
-    | SuccessUpdate
-    | Success
-    | Error of exitCode:int
-
-[<RequireQualifiedAccess>]
 type ShellOperation = {
     Command: string
     Arguments: string
-    ExitCodes: Map<int, StatusCode>
 }
 
 [<Flags>]
@@ -52,7 +45,6 @@ type Cacheability =
     | Local = 1
     | Remote = 2
     | Always = 3 // Local + Remote
-    | External = 4 // NOTE: mutually exclusive with Local or Remote
 
 type ShellOperations = ShellOperation list
 
@@ -63,18 +55,9 @@ type ActionExecutionRequest = {
 }
 
 
-
-let defaultExitCodes = Map [ 0, StatusCode.SuccessUpdate ]
-
 let shellOp cmd args = 
     { ShellOperation.Command = cmd
-      ShellOperation.Arguments = args
-      ShellOperation.ExitCodes = defaultExitCodes }
-
-let checkOp cmd args exitCodes = 
-    { ShellOperation.Command = cmd
-      ShellOperation.Arguments = args
-      ShellOperation.ExitCodes = exitCodes }
+      ShellOperation.Arguments = args }
 
 let execRequest cache ops =
     { ActionExecutionRequest.Cache = cache 

--- a/src/Terrabuild.Extensions/Terraform.fs
+++ b/src/Terrabuild.Extensions/Terraform.fs
@@ -85,11 +85,9 @@ type Terraform() =
             | Some workspace -> shellOp "terraform" $"workspace select {workspace}"
             | _ -> ()
 
-            let statusCode = Map [ 0, StatusCode.Success
-                                   2, StatusCode.SuccessUpdate ]
-            checkOp "terraform" $"plan -detailed-exitcode -out=terrabuild.planfile{vars}" statusCode
+            shellOp "terraform" $"plan -out=terrabuild.planfile{vars}"
         ]
-        execRequest Cacheability.External ops
+        execRequest Cacheability.Always ops
   
 
     /// <summary weight="4" title="Apply plan file.">

--- a/src/Terrabuild/CLI.fs
+++ b/src/Terrabuild/CLI.fs
@@ -46,7 +46,6 @@ type RunArgs =
     | [<Unique; AltCommandLine("-f")>] Force
     | [<Unique; AltCommandLine("-r")>] Retry
     | [<Unique; AltCommandLine("-lo")>] Local_Only
-    | [<Unique; AltCommandLine("-cs")>] Check_State
     | [<Unique; AltCommandLine("-n")>] Note of note:string
     | [<Unique; AltCommandLine("-t")>] Tag of tag:string
     | [<Unique; AltCommandLine("-ct")>] Container_Tool of tool:ContainerTool
@@ -65,7 +64,6 @@ with
             | Force -> "Ignore cache when building target."
             | Retry -> "Retry failed task."
             | Local_Only -> "Use local cache only."
-            | Check_State -> "Ensure external state is valid."
             | Note _ -> "Note for the build."
             | Logs -> "Output logs for impacted projects."
             | Tag _ -> "Tag for build."

--- a/src/Terrabuild/Contracts/ConfigOptions.fs
+++ b/src/Terrabuild/Contracts/ConfigOptions.fs
@@ -11,7 +11,6 @@ type Options = {
     Force: bool
     Retry: bool
     LocalOnly: bool
-    CheckState: bool
     StartedAt: DateTime
     Targets: string set
     CI: string option

--- a/src/Terrabuild/Core/Builder.fs
+++ b/src/Terrabuild/Core/Builder.fs
@@ -111,12 +111,9 @@ let build (options: ConfigOptions.Options) (configuration: Configuration.Workspa
                                 ContaineredShellOperation.ContainerVariables = operation.ContainerVariables
                                 ContaineredShellOperation.MetaCommand = $"{operation.Extension} {operation.Command}"
                                 ContaineredShellOperation.Command = shellOperation.Command
-                                ContaineredShellOperation.Arguments = shellOperation.Arguments
-                                ContaineredShellOperation.ExitCodes = shellOperation.ExitCodes })
+                                ContaineredShellOperation.Arguments = shellOperation.Arguments })
 
-                        let cache =
-                            cache &&& executionRequest.Cache
-                            ||| Cacheability.External &&& (cache ||| executionRequest.Cache)
+                        let cache = cache &&& executionRequest.Cache
                         cache, ops @ newops
                     ) (defaultCacheability, [])
 

--- a/src/Terrabuild/Core/GraphDef.fs
+++ b/src/Terrabuild/Core/GraphDef.fs
@@ -8,7 +8,6 @@ type ContaineredShellOperation = {
     MetaCommand: string
     Command: string
     Arguments: string
-    ExitCodes: Map<int, Terrabuild.Extensibility.StatusCode>
 }
 
 [<RequireQualifiedAccess>]

--- a/src/Terrabuild/Core/Logs.fs
+++ b/src/Terrabuild/Core/Logs.fs
@@ -99,8 +99,7 @@ let dumpLogs (logId: Guid) (options: ConfigOptions.Options) (cache: ICache) (gra
                 match originSummary with
                 | Some (origin, summary) ->
                     let duration = summary.Duration
-                    let isExternal = (summary.Cache &&& Terrabuild.Extensibility.Cacheability.External) <> Terrabuild.Extensibility.Cacheability.Never
-                    if origin = Origin.Local || isExternal then cost + duration, gain
+                    if origin = Origin.Local then cost + duration, gain
                     else cost, gain + duration
                 | _ -> cost, gain
             ) (TimeSpan.Zero, TimeSpan.Zero)

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -16,7 +16,6 @@ type RunTargetOptions = {
     Force: bool
     Retry: bool
     LocalOnly: bool
-    CheckState: bool
     StartedAt: DateTime
     IsLog: bool
     Targets: string set
@@ -100,7 +99,6 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
             ConfigOptions.Options.Force = options.Force
             ConfigOptions.Options.Retry = options.Retry
             ConfigOptions.Options.LocalOnly = options.LocalOnly
-            ConfigOptions.Options.CheckState = options.CheckState
             ConfigOptions.Options.StartedAt = options.StartedAt
             ConfigOptions.Options.Targets = options.Targets
             ConfigOptions.Options.CI = sourceControl.CI
@@ -185,7 +183,6 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let variables = runArgs.GetResults(RunArgs.Variable) |> Map
         let maxConcurrency = runArgs.GetResult(RunArgs.Parallel, defaultValue = Environment.ProcessorCount/2) |> max 1
         let localOnly = runArgs.Contains(RunArgs.Local_Only)
-        let checkState = runArgs.Contains(RunArgs.Check_State)
         let logs = runArgs.Contains(RunArgs.Logs)
         let tag = runArgs.TryGetResult(RunArgs.Tag)
         let whatIf = runArgs.Contains(RunArgs.WhatIf)
@@ -206,7 +203,6 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
                         RunTargetOptions.IsLog = false
                         RunTargetOptions.Targets = Set targets
                         RunTargetOptions.LocalOnly = localOnly
-                        RunTargetOptions.CheckState = checkState
                         RunTargetOptions.Configuration = configuration
                         RunTargetOptions.Note = note
                         RunTargetOptions.Tag = tag
@@ -236,7 +232,6 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
                         RunTargetOptions.IsLog = false
                         RunTargetOptions.Targets = Set [ "serve" ]
                         RunTargetOptions.LocalOnly = true
-                        RunTargetOptions.CheckState = false
                         RunTargetOptions.Configuration = configuration
                         RunTargetOptions.Note = None
                         RunTargetOptions.Tag = None
@@ -268,7 +263,6 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
                         RunTargetOptions.IsLog = true
                         RunTargetOptions.Targets = Set targets
                         RunTargetOptions.LocalOnly = true 
-                        RunTargetOptions.CheckState = false
                         RunTargetOptions.Configuration = configuration
                         RunTargetOptions.Note = None
                         RunTargetOptions.Tag = None

--- a/tests/cluster-layers/results/terrabuild-debug.build-graph.json
+++ b/tests/cluster-layers/results/terrabuild-debug.build-graph.json
@@ -68,26 +68,14 @@
           "containerVariables": [],
           "metaCommand": "@shell echo",
           "command": "echo",
-          "arguments": "building project",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "building project"
         },
         {
           "container": null,
           "containerVariables": [],
           "metaCommand": "@dotnet build",
           "command": "dotnet",
-          "arguments": "build --no-dependencies --configuration Debug    ",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "build --no-dependencies --configuration Debug    "
         }
       ],
       "cache": 0,
@@ -161,26 +149,14 @@
           "containerVariables": [],
           "metaCommand": "@shell echo",
           "command": "echo",
-          "arguments": "building project",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "building project"
         },
         {
           "container": null,
           "containerVariables": [],
           "metaCommand": "@dotnet build",
           "command": "dotnet",
-          "arguments": "build --no-dependencies --configuration Debug    ",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "build --no-dependencies --configuration Debug    "
         }
       ],
       "cache": 0,
@@ -247,39 +223,21 @@
           "containerVariables": [],
           "metaCommand": "@shell echo",
           "command": "echo",
-          "arguments": "building project",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "building project"
         },
         {
           "container": null,
           "containerVariables": [],
           "metaCommand": "@npm build",
           "command": "npm",
-          "arguments": "ci",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "ci"
         },
         {
           "container": null,
           "containerVariables": [],
           "metaCommand": "@npm build",
           "command": "npm",
-          "arguments": "run build -- ",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "run build -- "
         }
       ],
       "cache": 0,
@@ -338,13 +296,7 @@
           "containerVariables": [],
           "metaCommand": "@dotnet build",
           "command": "dotnet",
-          "arguments": "build --no-dependencies --configuration Debug    ",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "build --no-dependencies --configuration Debug    "
         }
       ],
       "cache": 0,
@@ -403,13 +355,7 @@
           "containerVariables": [],
           "metaCommand": "@dotnet build",
           "command": "dotnet",
-          "arguments": "build --no-dependencies --configuration Debug    ",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "build --no-dependencies --configuration Debug    "
         }
       ],
       "cache": 0,
@@ -459,26 +405,14 @@
           "containerVariables": [],
           "metaCommand": "@npm build",
           "command": "npm",
-          "arguments": "ci",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "ci"
         },
         {
           "container": null,
           "containerVariables": [],
           "metaCommand": "@npm build",
           "command": "npm",
-          "arguments": "run build -- ",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "run build -- "
         }
       ],
       "cache": 0,
@@ -527,26 +461,14 @@
           "containerVariables": [],
           "metaCommand": "@npm build",
           "command": "npm",
-          "arguments": "ci",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "ci"
         },
         {
           "container": null,
           "containerVariables": [],
           "metaCommand": "@npm build",
           "command": "npm",
-          "arguments": "run build -- ",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "run build -- "
         }
       ],
       "cache": 0,

--- a/tests/multirefs/results/terrabuild-debug.build-graph.json
+++ b/tests/multirefs/results/terrabuild-debug.build-graph.json
@@ -45,13 +45,7 @@
           "containerVariables": [],
           "metaCommand": "@shell echo",
           "command": "echo",
-          "arguments": "building A",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "building A"
         }
       ],
       "cache": 0,
@@ -101,13 +95,7 @@
           "containerVariables": [],
           "metaCommand": "@shell echo",
           "command": "echo",
-          "arguments": "building B",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "building B"
         }
       ],
       "cache": 0,
@@ -155,13 +143,7 @@
           "containerVariables": [],
           "metaCommand": "@shell echo",
           "command": "echo",
-          "arguments": "building C",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "building C"
         }
       ],
       "cache": 0,

--- a/tests/simple/results/terrabuild-debug.build-graph.json
+++ b/tests/simple/results/terrabuild-debug.build-graph.json
@@ -62,46 +62,24 @@
           "containerVariables": [],
           "metaCommand": "@terraform plan",
           "command": "terraform",
-          "arguments": "init",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "init"
         },
         {
           "container": null,
           "containerVariables": [],
           "metaCommand": "@terraform plan",
           "command": "terraform",
-          "arguments": "workspace select default",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "workspace select default"
         },
         {
           "container": null,
           "containerVariables": [],
           "metaCommand": "@terraform plan",
           "command": "terraform",
-          "arguments": "plan -detailed-exitcode -out=terrabuild.planfile -var=\u0022dotnet_app_version=7AFACF3AFB85FF8AD7433C5AA8FFAD5C4BF62333D184CD03DE62984692F3BBCC\u0022 -var=\u0022npm_app_version=84DFD1B132F2D433231EF2345DB2CF32D7D3867BB5C1795B3DCFE0F0304A7353\u0022",
-          "exitCodes": [
-            [
-              0,
-              "success"
-            ],
-            [
-              2,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "plan -out=terrabuild.planfile -var=\u0022dotnet_app_version=7AFACF3AFB85FF8AD7433C5AA8FFAD5C4BF62333D184CD03DE62984692F3BBCC\u0022 -var=\u0022npm_app_version=84DFD1B132F2D433231EF2345DB2CF32D7D3867BB5C1795B3DCFE0F0304A7353\u0022"
         }
       ],
-      "cache": 4,
+      "cache": 0,
       "isLeaf": true
     },
     "libraries/dotnet-lib:build": {
@@ -160,13 +138,7 @@
           "containerVariables": [],
           "metaCommand": "@dotnet build",
           "command": "dotnet",
-          "arguments": "build --no-dependencies --configuration Debug    ",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "build --no-dependencies --configuration Debug    "
         }
       ],
       "cache": 0,
@@ -213,26 +185,14 @@
           "containerVariables": [],
           "metaCommand": "@npm build",
           "command": "npm",
-          "arguments": "ci",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "ci"
         },
         {
           "container": null,
           "containerVariables": [],
           "metaCommand": "@npm build",
           "command": "npm",
-          "arguments": "run build -- ",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "run build -- "
         }
       ],
       "cache": 0,
@@ -280,13 +240,7 @@
           "containerVariables": [],
           "metaCommand": "@shell echo",
           "command": "echo",
-          "arguments": "building library1",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "building library1"
         }
       ],
       "cache": 0,
@@ -350,13 +304,7 @@
           "containerVariables": [],
           "metaCommand": "@dotnet build",
           "command": "dotnet",
-          "arguments": "build --no-dependencies --configuration Debug    ",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "build --no-dependencies --configuration Debug    "
         }
       ],
       "cache": 0,
@@ -432,26 +380,14 @@
           "containerVariables": [],
           "metaCommand": "@shell echo",
           "command": "echo",
-          "arguments": "building project1",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "building project1"
         },
         {
           "container": null,
           "containerVariables": [],
           "metaCommand": "@make build",
           "command": "make",
-          "arguments": "build secret=\u0022tagada\u0022",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "build secret=\u0022tagada\u0022"
         }
       ],
       "cache": 0,
@@ -500,26 +436,14 @@
           "containerVariables": [],
           "metaCommand": "@npm build",
           "command": "npm",
-          "arguments": "ci",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "ci"
         },
         {
           "container": null,
           "containerVariables": [],
           "metaCommand": "@npm build",
           "command": "npm",
-          "arguments": "run build -- ",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "run build -- "
         }
       ],
       "cache": 0,
@@ -568,13 +492,7 @@
           "containerVariables": [],
           "metaCommand": "@cargo build",
           "command": "cargo",
-          "arguments": "build --profile dev ",
-          "exitCodes": [
-            [
-              0,
-              "successUpdate"
-            ]
-          ]
+          "arguments": "build --profile dev "
         }
       ],
       "cache": 0,


### PR DESCRIPTION
The feature --check-state is hard to understand and used only for Terraform. It's probably better to have a flag to plan again instead of trying to workaround Terraform state management.