### PR TITLE
remove useless build case when dealing with cache

### DIFF
--- a/src/Terrabuild/Core/Build.fs
+++ b/src/Terrabuild/Core/Build.fs
@@ -271,13 +271,9 @@ let run (options: ConfigOptions.Options) (cache: Cache.ICache) (api: Contracts.I
             match tryGetSummaryOnly cacheEntryId with
             | Some summary ->
                 Log.Debug("{NodeId} has existing build summary", node.Id)
-                // task is younger than children
-                if summary.StartedAt < maxCompletionChildren then
-                    Log.Debug("{NodeId} must rebuild because it is younger than child", node.Id)
-                    TaskRequest.Build, buildNode()
 
                 // task is failed and retry requested
-                elif retry && not summary.IsSuccessful then
+                if retry && not summary.IsSuccessful then
                     Log.Debug("{NodeId} must rebuild because node is failed and retry requested", node.Id)
                     TaskRequest.Build, buildNode()
 


### PR DESCRIPTION
Build was handling is case when restoring from cache: it's useless has other paths are already taking care of this.