### PR TITLE
ignore subprojects on dependencies

### DIFF
--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -281,9 +281,11 @@ let read (options: ConfigOptions.Options) =
         let projectDependencies =
             projectInfo.Dependencies
             |> Set.map (fun dep -> FS.workspaceRelative options.Workspace projectDir dep)
+            |> Set.filter (fun dep -> dep |> String.startsWith projectId |> not)
         let projectLinks =
             projectInfo.Links
             |> Set.map (fun dep -> FS.workspaceRelative options.Workspace projectDir dep)
+            |> Set.filter (fun dep -> dep |> String.startsWith projectId |> not)
 
         let projectTargets = projectConfig.Targets
 
@@ -475,7 +477,7 @@ let read (options: ConfigOptions.Options) =
                     let projectFile = FS.combinePath dir "PROJECT" 
                     match projectFile with
                     | FS.File file ->
-                        file |> FS.parentDirectory |> FS.relativePath options.Workspace
+                        yield file |> FS.parentDirectory |> FS.relativePath options.Workspace
                     | _ ->
                         for subdir in dir |> IO.enumerateDirs do
                             yield! findDependencies false subdir

--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -218,6 +218,7 @@ let read (options: ConfigOptions.Options) =
     let loadProjectDef projectId =
         let projectDir = FS.combinePath options.Workspace projectId
         let projectFile = FS.combinePath projectDir "PROJECT"
+        let slashedProjectDir = $"{projectDir}/"
 
         let projectContent = File.ReadAllText projectFile
         let projectConfig =
@@ -281,11 +282,11 @@ let read (options: ConfigOptions.Options) =
         let projectDependencies =
             projectInfo.Dependencies
             |> Set.map (fun dep -> FS.workspaceRelative options.Workspace projectDir dep)
-            |> Set.filter (fun dep -> dep |> String.startsWith projectId |> not)
+            |> Set.filter (fun dep -> dep |> String.startsWith slashedProjectDir |> not)
         let projectLinks =
             projectInfo.Links
             |> Set.map (fun dep -> FS.workspaceRelative options.Workspace projectDir dep)
-            |> Set.filter (fun dep -> dep |> String.startsWith projectId |> not)
+            |> Set.filter (fun dep -> dep |> String.startsWith slashedProjectDir |> not)
 
         let projectTargets = projectConfig.Targets
 


### PR DESCRIPTION
Projects dependencies (and links) could include sub-projects. For simplicity, this is now forbidden.