### PR TITLE
use string instead of guid

### DIFF
--- a/src/Terrabuild.Configuration.Tests/Workspace.fs
+++ b/src/Terrabuild.Configuration.Tests/Workspace.fs
@@ -46,7 +46,7 @@ let parseWorkspace() =
               Script = Some "scripts/npm.fsx"
               Defaults = Map.empty }
 
-        { WorkspaceFile.Workspace = { Id = "d7528db2-83e0-4164-8c8e-1e0d6d6357ca" |> Guid.Parse |> Some; Ignores = Set ["**/node_modules"] }
+        { WorkspaceFile.Workspace = { Id = "d7528db2-83e0-4164-8c8e-1e0d6d6357ca" |> Some; Ignores = Set ["**/node_modules"] }
           WorkspaceFile.Targets = Map [ "build", targetBuild
                                         "dist", targetDist
                                         "dummy", targetDummy ]

--- a/src/Terrabuild.Configuration/WorkspaceParser/AST.fs
+++ b/src/Terrabuild.Configuration/WorkspaceParser/AST.fs
@@ -11,7 +11,7 @@ type WorkspaceComponents =
 
 [<RequireQualifiedAccess>]
 type Workspace = {
-    Id: Guid option
+    Id: string option
     Ignores: Set<string>
 }
 with
@@ -19,10 +19,7 @@ with
         let id =
             match components |> List.choose (function | WorkspaceComponents.Id value -> Some value | _ -> None) with
             | [] -> None
-            | [value] ->
-                match value |> Guid.TryParse with
-                | true, guid -> Some guid
-                | _ -> TerrabuildException.Raise("id is malformed")
+            | [value] -> Some value
             | _ -> TerrabuildException.Raise("multiple space declared")
 
         let ignores =

--- a/src/Terrabuild/Api/Client.fs
+++ b/src/Terrabuild/Api/Client.fs
@@ -48,7 +48,7 @@ module private Http =
 module private Auth =
     [<RequireQualifiedAccess>]
     type LoginSpaceInput = {
-        Id: Guid
+        Id: string
         Token: string
     }
 
@@ -159,7 +159,7 @@ module private Artifact =
         Http.get<Unit, AzureArtifactLocationOutput> headers $"/artifacts?path={path}" ()
 
 
-type Client(workspaceId: Guid, token: string, options: ConfigOptions.Options) =
+type Client(workspaceId: string, token: string, options: ConfigOptions.Options) =
     let accesstoken =
         let headers = [
             HttpRequestHeaders.Accept HttpContentTypes.Json

--- a/src/Terrabuild/Core/Auth.fs
+++ b/src/Terrabuild/Core/Auth.fs
@@ -3,7 +3,7 @@ open System
 
 
 type SpaceAuth = {
-    Id: Guid
+    Id: string
     Token: string
 }
 
@@ -13,7 +13,7 @@ type Configuration = {
 }
 
 
-let private removeAuthToken (workspaceId: Guid) =
+let private removeAuthToken (workspaceId: string) =
     let configFile = FS.combinePath (Cache.createTerrabuildProfile()) "config.json"
     let config =
         if configFile |> FS.fileExists then configFile |> IO.readTextFile |> Json.Deserialize<Configuration>
@@ -26,7 +26,7 @@ let private removeAuthToken (workspaceId: Guid) =
     |> IO.writeTextFile configFile
 
 
-let private addAuthToken (workspaceId: Guid) (token: string) =
+let private addAuthToken (workspaceId: string) (token: string) =
     let configFile = FS.combinePath (Cache.createTerrabuildProfile()) "config.json"
     let config =
         if configFile |> FS.fileExists then configFile |> IO.readTextFile |> Json.Deserialize<Configuration>
@@ -39,7 +39,7 @@ let private addAuthToken (workspaceId: Guid) (token: string) =
     |> IO.writeTextFile configFile
 
 
-let readAuthToken (workspaceId: Guid) =
+let readAuthToken (workspaceId: string) =
     let configFile = FS.combinePath (Cache.createTerrabuildProfile()) "config.json"
     let config =
         if configFile |> FS.fileExists then configFile |> IO.readTextFile |> Json.Deserialize<Configuration>

--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -48,7 +48,7 @@ type Project = {
 [<RequireQualifiedAccess>]
 type Workspace = {
     // Space to use
-    Id: Guid option
+    Id: string option
 
     // Computed projects selection (derived from user inputs)
     SelectedProjects: string set

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -279,24 +279,14 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         0
 
     let login (loginArgs: ParseResults<LoginArgs>) =
-        let space = loginArgs.GetResult(LoginArgs.Workspace)
+        let workspaceId = loginArgs.GetResult(LoginArgs.Workspace)
         let token = loginArgs.GetResult(LoginArgs.Token)
-
-        let workspaceId =
-            match space |> Guid.TryParse with
-            | true, guid -> guid
-            | _ -> TerrabuildException.Raise("Invalid workspaceId")
 
         Auth.login workspaceId token
         0
 
     let logout (logoutArgs: ParseResults<LogoutArgs>) =
-        let space = logoutArgs.GetResult(LogoutArgs.Space)
-        let workspaceId =
-            match space |> Guid.TryParse with
-            | true, guid -> guid
-            | _ -> TerrabuildException.Raise("Invalid workspaceId")
-
+        let workspaceId = logoutArgs.GetResult(LogoutArgs.Space)
         Auth.logout workspaceId
         0
 


### PR DESCRIPTION
No need to strongly type the workspace Id.