### PR TITLE
add case insensitive scan

### DIFF
--- a/src/Terrabuild.Common/FS.fs
+++ b/src/Terrabuild.Common/FS.fs
@@ -26,5 +26,5 @@ let (|File|Directory|None|) entry =
 
 let workspaceRelative (workspaceDir: string) (currentDir: string) (relativeOrAbsolute: string) =
     match relativeOrAbsolute with
-    | String.Regex "^/(.*)$" [ absolute ] -> absolute
+    | String.Regex "^/(.*)$" [ absolute ] ->absolute
     | relative -> combinePath currentDir relative |> relativePath workspaceDir

--- a/src/Terrabuild.Common/String.fs
+++ b/src/Terrabuild.Common/String.fs
@@ -8,6 +8,9 @@ open System.Text.RegularExpressions
 let toLower (s : string) =
     s.ToLowerInvariant()
 
+let toUpper (s : string) =
+    s.ToUpperInvariant()
+
 let join (separator : string) (strings : string seq) =
     String.Join(separator, strings)
 

--- a/src/Terrabuild.Expressions.Tests/Eval.fs
+++ b/src/Terrabuild.Expressions.Tests/Eval.fs
@@ -116,8 +116,8 @@ let version() =
     let expected = Value.String "1234"
 
     let context = { evaluationContext
-                    with Versions = Map [ "toto", "1234"
-                                          "titi", "56789A" ] }
+                    with Versions = Map [ "TOTO", "1234"
+                                          "TITI", "56789A" ] }
 
     printfn $"{context.ProjectDir}"
 

--- a/src/Terrabuild.Expressions/Eval.fs
+++ b/src/Terrabuild.Expressions/Eval.fs
@@ -75,7 +75,9 @@ let rec eval (context: EvaluationContext) (expr: Expr) =
                         | Some projectDir -> projectDir
                         | _ -> TerrabuildException.Raise($"Project dir not available in this context.")
 
-                    let projectName = FS.workspaceRelative context.WorkspaceDir projectDir str
+                    let projectName =
+                        FS.workspaceRelative context.WorkspaceDir projectDir str
+                        |> String.toUpper
                     match context.Versions |> Map.tryFind projectName with
                     | Some version -> Value.String version
                     | _ -> TerrabuildException.Raise($"Unknown project reference '{str}'")

--- a/src/Terrabuild/Core/Builder.fs
+++ b/src/Terrabuild/Core/Builder.fs
@@ -130,9 +130,9 @@ let build (options: ConfigOptions.Options) (configuration: Configuration.Workspa
                         targetCache |> Option.defaultValue cache
 
                 let node = { Node.Id = nodeId
-                             Node.Label = $"{targetName} {projectConfig.Id}"
+                             Node.Label = $"{targetName} {projectConfig.Name}"
                              
-                             Node.Project = project
+                             Node.Project = projectConfig.Name
                              Node.Target = targetName
                              Node.ConfigurationTarget = target
                              Node.Operations = ops

--- a/src/Terrabuild/Core/Builder.fs
+++ b/src/Terrabuild/Core/Builder.fs
@@ -26,11 +26,10 @@ let build (options: ConfigOptions.Options) (configuration: Configuration.Workspa
 
 
     let rec buildTarget targetName project =
+        let projectConfig = configuration.Projects[project]
         let nodeId = $"{project}:{targetName}"
 
         let processNode () =
-            let projectConfig = configuration.Projects[project]
-
             // merge targets requirements
             let buildDependsOn =
                 configuration.Targets
@@ -131,7 +130,7 @@ let build (options: ConfigOptions.Options) (configuration: Configuration.Workspa
                         targetCache |> Option.defaultValue cache
 
                 let node = { Node.Id = nodeId
-                             Node.Label = $"{targetName} {project}"
+                             Node.Label = $"{targetName} {projectConfig.Id}"
                              
                              Node.Project = project
                              Node.Target = targetName
@@ -162,7 +161,8 @@ let build (options: ConfigOptions.Options) (configuration: Configuration.Workspa
     let rootNodes =
         configuration.SelectedProjects
         |> Seq.collect (fun dependency -> options.Targets
-                                          |> Seq.collect (fun target -> buildTarget target dependency))
+                                          |> Seq.collect (fun target ->
+                                            buildTarget target dependency))
         |> Set
 
     let endedAt = DateTime.UtcNow

--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -37,7 +37,7 @@ type Target = {
 
 [<RequireQualifiedAccess>]
 type Project = {
-    Id: string
+    Name: string
     Hash: string
     Dependencies: string set
     Files: string set
@@ -479,7 +479,7 @@ let read (options: ConfigOptions.Options) =
 
         let projectDependencies = projectDef.Dependencies |> Set.map String.toUpper
 
-        { Project.Id = projectDir
+        { Project.Name = projectDir
           Project.Hash = projectHash
           Project.Dependencies = projectDependencies
           Project.Files = files

--- a/tests/cluster-layers/results/terrabuild-debug.config.json
+++ b/tests/cluster-layers/results/terrabuild-debug.config.json
@@ -21,7 +21,7 @@
   },
   "projects": {
     "A": {
-      "id": "A",
+      "name": "A",
       "hash": "52081ACBA3AA68292E895F52D30A4916AE5F3742E44A04C119BE8F0A52DE570F",
       "dependencies": [],
       "files": [
@@ -77,7 +77,7 @@
       "labels": []
     },
     "B": {
-      "id": "B",
+      "name": "B",
       "hash": "C20F11FEA849AD53AA0FDD982A60BEB1143A591B8E3B0CDB16C1CE8D39392772",
       "dependencies": [],
       "files": [
@@ -133,7 +133,7 @@
       "labels": []
     },
     "C": {
-      "id": "C",
+      "name": "C",
       "hash": "3295C61A42D31221DCB491823FD21EF9A8921B5375720F3EF8DA74ED8F4BF1EC",
       "dependencies": [
         "A",
@@ -187,7 +187,7 @@
       "labels": []
     },
     "D": {
-      "id": "D",
+      "name": "D",
       "hash": "C61CB06CD3C39E1F35C4DC1774DE930DA6851583D98A4F13969456FB388FCD5C",
       "dependencies": [
         "C"
@@ -229,7 +229,7 @@
       "labels": []
     },
     "E": {
-      "id": "E",
+      "name": "E",
       "hash": "E1B52088E5FFFCCA0576241731FD4E4F7851EFE8522816F30BB7D8187ABF1034",
       "dependencies": [
         "C"
@@ -271,7 +271,7 @@
       "labels": []
     },
     "F": {
-      "id": "F",
+      "name": "F",
       "hash": "7DF5934D6DBA702F44818A40C3AB95F17E489524DFD3CC6AFC9B9D0EF5C83AE0",
       "dependencies": [
         "D",
@@ -309,7 +309,7 @@
       "labels": []
     },
     "G": {
-      "id": "G",
+      "name": "G",
       "hash": "FE7CDDB9279D6FFF57CCA9D71303D9D954C2B90E93EEE27097689FBF8AA676AD",
       "dependencies": [
         "C"

--- a/tests/multirefs/results/terrabuild-debug.config.json
+++ b/tests/multirefs/results/terrabuild-debug.config.json
@@ -45,7 +45,7 @@
   },
   "projects": {
     "A": {
-      "id": "A",
+      "name": "A",
       "hash": "765E269DCF725F998FEAF36185644037E2620A1D99ED0634F9D88098FD046B54",
       "dependencies": [
         "B",
@@ -83,7 +83,7 @@
       "labels": []
     },
     "B": {
-      "id": "B",
+      "name": "B",
       "hash": "4B3D703A03868D9124E4DF7F60CA5BE420D0A4C0188A9FE46C87F8A8C4E077DC",
       "dependencies": [
         "C"
@@ -120,7 +120,7 @@
       "labels": []
     },
     "C": {
-      "id": "C",
+      "name": "C",
       "hash": "286D4F1687911376819B5BF9CB07BD4B7DCF72844399A26EB2235596F5D65ABB",
       "dependencies": [],
       "files": [],

--- a/tests/simple/results/terrabuild-debug.build-graph.json
+++ b/tests/simple/results/terrabuild-debug.build-graph.json
@@ -1,7 +1,7 @@
 {
   "nodes": {
-    "deployments/terraform-deploy:build": {
-      "id": "deployments/terraform-deploy:build",
+    "DEPLOYMENTS/TERRAFORM-DEPLOY:build": {
+      "id": "DEPLOYMENTS/TERRAFORM-DEPLOY:build",
       "label": "build deployments/terraform-deploy",
       "project": "deployments/terraform-deploy",
       "target": "build",
@@ -31,11 +31,11 @@
                   {
                     "dotnet_app_version": [
                       "string",
-                      "B498617AEF0C2FECAD324FC46DA9E3477254472AAE763F9312A6175F8C2AADBA"
+                      "CA867B371D864086BCC266C5186F00A45412A15D2F95ABF3046FDA371A851B45"
                     ],
                     "npm_app_version": [
                       "string",
-                      "667E311D2450BE32EBDB6730784CBE9EFBF715D2B3248F6304645236D2F0F520"
+                      "D5C34CD09DE457A98F7F7486D177587753CECB9C1CF351EF857B0A7B6ACBA459"
                     ]
                   }
                 ],
@@ -49,14 +49,14 @@
         ]
       },
       "dependencies": [
-        "projects/dotnet-app:build",
-        "projects/npm-app:build"
+        "PROJECTS/DOTNET-APP:build",
+        "PROJECTS/NPM-APP:build"
       ],
       "outputs": [
         "*.planfile"
       ],
-      "projectHash": "7E76E02B5FB7018D6E167C095476E54192546AEEDEEB3D0A8621C781728FA738",
-      "targetHash": "9DA4C690E559C0C7D72FCF2968C128EFBB37FB9015182C4C3A5C5565539A3BE8",
+      "projectHash": "9EC6C3232028C098085052766313F5789DE2A40C2EF98A2D15E86D8F9615CFF2",
+      "targetHash": "CF54EFFC1383A18BAB9F422989D8C15AA2771C3CE9F8030322EBBEBFB4E7A720",
       "operations": [
         {
           "container": "hashicorp/terraform:1.10",
@@ -80,14 +80,14 @@
           "containerVariables": [],
           "metaCommand": "@terraform plan",
           "command": "terraform",
-          "arguments": "plan -out=terrabuild.planfile -var=\u0022dotnet_app_version=B498617AEF0C2FECAD324FC46DA9E3477254472AAE763F9312A6175F8C2AADBA\u0022 -var=\u0022npm_app_version=667E311D2450BE32EBDB6730784CBE9EFBF715D2B3248F6304645236D2F0F520\u0022"
+          "arguments": "plan -out=terrabuild.planfile -var=\u0022dotnet_app_version=CA867B371D864086BCC266C5186F00A45412A15D2F95ABF3046FDA371A851B45\u0022 -var=\u0022npm_app_version=D5C34CD09DE457A98F7F7486D177587753CECB9C1CF351EF857B0A7B6ACBA459\u0022"
         }
       ],
       "cache": 0,
       "isLeaf": true
     },
-    "libraries/dotnet-lib:build": {
-      "id": "libraries/dotnet-lib:build",
+    "LIBRARIES/DOTNET-LIB:build": {
+      "id": "LIBRARIES/DOTNET-LIB:build",
       "label": "build libraries/dotnet-lib",
       "project": "libraries/dotnet-lib",
       "target": "build",
@@ -135,8 +135,8 @@
         "obj/*.props",
         "obj/*.targets"
       ],
-      "projectHash": "4E90121393E74B43D6B727A9F23E3AE10385E7E39F1FBD240CE10180651F6851",
-      "targetHash": "A2F255CF5DAC994C7A9E0EEA752178802A87FB473EA13D002DB64D845DE66FE3",
+      "projectHash": "2800DCFECE6D1228816991BD3A72E919256ADAF59789989677863C86E447334F",
+      "targetHash": "BEC698429B2232A480596C768281D0B59206C3A2085FEB4E99C6EE1BB8D1568A",
       "operations": [
         {
           "container": "mcr.microsoft.com/dotnet/sdk:9.0.201",
@@ -150,8 +150,8 @@
       "cache": 0,
       "isLeaf": true
     },
-    "libraries/npm-lib:build": {
-      "id": "libraries/npm-lib:build",
+    "LIBRARIES/NPM-LIB:build": {
+      "id": "LIBRARIES/NPM-LIB:build",
       "label": "build libraries/npm-lib",
       "project": "libraries/npm-lib",
       "target": "build",
@@ -184,8 +184,8 @@
       "outputs": [
         "**/dist/"
       ],
-      "projectHash": "813635EFA9D98FB042EF8A761A4433B34B95BA40E1D1231B79CBDC4D29E21AF6",
-      "targetHash": "AAD43B3A0C8662FDF31611BC799DF8489DBFFAB6C533DF315660F452428F6CC7",
+      "projectHash": "8175042D97F5AE6113CBFEFC25D7DEEE3022320ABDF6F48A63CAB4B90811796B",
+      "targetHash": "5FE597649129B381AC30145322693B123902505541847C7022A0FE57EF229D5A",
       "operations": [
         {
           "container": "node:20",
@@ -207,8 +207,8 @@
       "cache": 0,
       "isLeaf": true
     },
-    "libraries/shell-lib:build": {
-      "id": "libraries/shell-lib:build",
+    "LIBRARIES/SHELL-LIB:build": {
+      "id": "LIBRARIES/SHELL-LIB:build",
       "label": "build libraries/shell-lib",
       "project": "libraries/shell-lib",
       "target": "build",
@@ -240,8 +240,8 @@
       },
       "dependencies": [],
       "outputs": [],
-      "projectHash": "90DBBB67F0EB0EEBCC7BEB1929682796805120FF8AE0C26C7FF742190F9A469A",
-      "targetHash": "C02659124F9334746951572EFC57F1DBC0DF7B973B0AC436FAD6A9BAA401A6F3",
+      "projectHash": "46479653782CE6E0A5C1667D8637D99EE9FFAB226FD0BB4496ED01CCF1037C8E",
+      "targetHash": "80DA2B24C46FA3630291F7F69D25D33DD11F9A0E016DF756EEC9E9931C6A3D10",
       "operations": [
         {
           "containerVariables": [],
@@ -253,8 +253,8 @@
       "cache": 0,
       "isLeaf": true
     },
-    "projects/dotnet-app:build": {
-      "id": "projects/dotnet-app:build",
+    "PROJECTS/DOTNET-APP:build": {
+      "id": "PROJECTS/DOTNET-APP:build",
       "label": "build projects/dotnet-app",
       "project": "projects/dotnet-app",
       "target": "build",
@@ -294,7 +294,7 @@
         ]
       },
       "dependencies": [
-        "libraries/dotnet-lib:build"
+        "LIBRARIES/DOTNET-LIB:build"
       ],
       "outputs": [
         "**/*.binlog",
@@ -304,8 +304,8 @@
         "obj/*.props",
         "obj/*.targets"
       ],
-      "projectHash": "B498617AEF0C2FECAD324FC46DA9E3477254472AAE763F9312A6175F8C2AADBA",
-      "targetHash": "A1D2FB0FCA0988AABE66E3CCC2F697BEC5D530DC8CBAC79CF1706D36E718469C",
+      "projectHash": "CA867B371D864086BCC266C5186F00A45412A15D2F95ABF3046FDA371A851B45",
+      "targetHash": "20813210889E8F5C28AEB06C066445F5EA814AC8D311B40F93524B9FB3884E48",
       "operations": [
         {
           "container": "mcr.microsoft.com/dotnet/sdk:9.0.201",
@@ -319,8 +319,8 @@
       "cache": 0,
       "isLeaf": true
     },
-    "projects/make-app:build": {
-      "id": "projects/make-app:build",
+    "PROJECTS/MAKE-APP:build": {
+      "id": "PROJECTS/MAKE-APP:build",
       "label": "build projects/make-app",
       "project": "projects/make-app",
       "target": "build",
@@ -374,13 +374,13 @@
         ]
       },
       "dependencies": [
-        "libraries/shell-lib:build"
+        "LIBRARIES/SHELL-LIB:build"
       ],
       "outputs": [
         "dist"
       ],
-      "projectHash": "A5BD059BA569E96AFE6AEC3BA05C405B454A3483F1A702D11CA978F318516307",
-      "targetHash": "5D691E5C2590242CE47093D6396E43698757F2FD1357722400EFD784A78C5365",
+      "projectHash": "F5FA23FEA48BD50A8F9C28F899E35EC01A87ECA33637953DAE5E2FDDF2F17314",
+      "targetHash": "6230F7A971DD0050B858067AF3FD259737D81D9075A3CA97AC87278C67BA032F",
       "operations": [
         {
           "containerVariables": [],
@@ -398,8 +398,8 @@
       "cache": 0,
       "isLeaf": true
     },
-    "projects/npm-app/private-npm-lib:build": {
-      "id": "projects/npm-app/private-npm-lib:build",
+    "PROJECTS/NPM-APP/PRIVATE-NPM-LIB:build": {
+      "id": "PROJECTS/NPM-APP/PRIVATE-NPM-LIB:build",
       "label": "build projects/npm-app/private-npm-lib",
       "project": "projects/npm-app/private-npm-lib",
       "target": "build",
@@ -432,8 +432,8 @@
       "outputs": [
         "**/dist/"
       ],
-      "projectHash": "F951BD1663475053E1F9C97DDA08EA553E21951BC053419D362126A2B6A4C83C",
-      "targetHash": "9253BBB223D3C6C83E7A9F4570EE523469161AF85DC76A80BC18562B22458024",
+      "projectHash": "EC303FCA7CCFE2DAC334A7C1D898BF3162FE50AC8C536BBB3F10DB8E9DF14A0D",
+      "targetHash": "38BCE4755189AA44DEF2C48D80AD8C9C38AFCA97C7C1377DD2DED1D5E287E95B",
       "operations": [
         {
           "container": "node:20",
@@ -455,8 +455,8 @@
       "cache": 0,
       "isLeaf": true
     },
-    "projects/npm-app:build": {
-      "id": "projects/npm-app:build",
+    "PROJECTS/NPM-APP:build": {
+      "id": "PROJECTS/NPM-APP:build",
       "label": "build projects/npm-app",
       "project": "projects/npm-app",
       "target": "build",
@@ -486,14 +486,14 @@
         ]
       },
       "dependencies": [
-        "libraries/npm-lib:build",
-        "projects/npm-app/private-npm-lib:build"
+        "LIBRARIES/NPM-LIB:build",
+        "PROJECTS/NPM-APP/PRIVATE-NPM-LIB:build"
       ],
       "outputs": [
         "**/dist/"
       ],
-      "projectHash": "667E311D2450BE32EBDB6730784CBE9EFBF715D2B3248F6304645236D2F0F520",
-      "targetHash": "2EE4BC698765C0B3D47800ED9896248727243C2FCA36E8A4F855EF3B8B776525",
+      "projectHash": "D5C34CD09DE457A98F7F7486D177587753CECB9C1CF351EF857B0A7B6ACBA459",
+      "targetHash": "BF8CCDC9DBF10235455D36E30FF81B4E1464639259C991ADFECE94EB9ACB0121",
       "operations": [
         {
           "container": "node:20",
@@ -515,8 +515,8 @@
       "cache": 0,
       "isLeaf": true
     },
-    "projects/open-api:build": {
-      "id": "projects/open-api:build",
+    "PROJECTS/OPEN-API:build": {
+      "id": "PROJECTS/OPEN-API:build",
       "label": "build projects/open-api",
       "project": "projects/open-api",
       "target": "build",
@@ -558,8 +558,8 @@
       },
       "dependencies": [],
       "outputs": [],
-      "projectHash": "B638983BF2E75B9D5787C0082FE7E5BFA726B4B4815F48EE7482E1051275209A",
-      "targetHash": "BBA8F064B500E57822B9C1A2F98FE77710DB517940ABDF59E2C33B0C245058D1",
+      "projectHash": "14C9C4FCBD2D336C3747CD8EA1219DC39F8D79A3372DDFD536464C2C4B7BB4B3",
+      "targetHash": "5BD945554005536C17037AAE23D75E93B92BF65EC81B0F7F19E459879B7D1A56",
       "operations": [
         {
           "container": "openapitools/openapi-generator-cli:v7.10.0",
@@ -573,8 +573,8 @@
       "cache": 0,
       "isLeaf": true
     },
-    "projects/rust-app:build": {
-      "id": "projects/rust-app:build",
+    "PROJECTS/RUST-APP:build": {
+      "id": "PROJECTS/RUST-APP:build",
       "label": "build projects/rust-app",
       "project": "projects/rust-app",
       "target": "build",
@@ -609,8 +609,8 @@
         "target/debug/",
         "target/release/"
       ],
-      "projectHash": "ABBB61CBAB614EB12FDCBC22A5549A851128357CCA09CB57D74A2D2390E4A043",
-      "targetHash": "7A87C367FB6FFA09E192B5AF4FA046679F64875033DE5BF343004C24252D8D1B",
+      "projectHash": "2FE82A1BC72FCD0EC967432A46CBB5F19F3FEFF4A4E725E170FAD4BB16336C30",
+      "targetHash": "8976026DECCBADDAED7DCA16776965F6393755198A79F865D5E896B19A125B9D",
       "operations": [
         {
           "container": "rust:1.81.0-slim",
@@ -626,15 +626,15 @@
     }
   },
   "rootNodes": [
-    "deployments/terraform-deploy:build",
-    "libraries/dotnet-lib:build",
-    "libraries/npm-lib:build",
-    "libraries/shell-lib:build",
-    "projects/dotnet-app:build",
-    "projects/make-app:build",
-    "projects/npm-app/private-npm-lib:build",
-    "projects/npm-app:build",
-    "projects/open-api:build",
-    "projects/rust-app:build"
+    "DEPLOYMENTS/TERRAFORM-DEPLOY:build",
+    "LIBRARIES/DOTNET-LIB:build",
+    "LIBRARIES/NPM-LIB:build",
+    "LIBRARIES/SHELL-LIB:build",
+    "PROJECTS/DOTNET-APP:build",
+    "PROJECTS/MAKE-APP:build",
+    "PROJECTS/NPM-APP/PRIVATE-NPM-LIB:build",
+    "PROJECTS/NPM-APP:build",
+    "PROJECTS/OPEN-API:build",
+    "PROJECTS/RUST-APP:build"
   ]
 }

--- a/tests/simple/results/terrabuild-debug.build-graph.mermaid
+++ b/tests/simple/results/terrabuild-debug.build-graph.mermaid
@@ -2,39 +2,39 @@ flowchart TD
 classDef build stroke:red,stroke-width:3px
 classDef restore stroke:orange,stroke-width:3px
 classDef ignore stroke:black,stroke-width:3px
-deployments/terraform-deploy:build("deployments/terraform-deploy
+DEPLOYMENTS/TERRAFORM-DEPLOY:build("deployments/terraform-deploy
 build ")
-libraries/dotnet-lib:build("libraries/dotnet-lib
+LIBRARIES/DOTNET-LIB:build("libraries/dotnet-lib
 build ")
-libraries/npm-lib:build("libraries/npm-lib
+LIBRARIES/NPM-LIB:build("libraries/npm-lib
 build ")
-libraries/shell-lib:build("libraries/shell-lib
+LIBRARIES/SHELL-LIB:build("libraries/shell-lib
 build ")
-projects/dotnet-app:build("projects/dotnet-app
+PROJECTS/DOTNET-APP:build("projects/dotnet-app
 build ")
-projects/make-app:build("projects/make-app
+PROJECTS/MAKE-APP:build("projects/make-app
 build ")
-projects/npm-app/private-npm-lib:build("projects/npm-app/private-npm-lib
+PROJECTS/NPM-APP/PRIVATE-NPM-LIB:build("projects/npm-app/private-npm-lib
 build ")
-projects/npm-app:build("projects/npm-app
+PROJECTS/NPM-APP:build("projects/npm-app
 build ")
-projects/open-api:build("projects/open-api
+PROJECTS/OPEN-API:build("projects/open-api
 build ")
-projects/rust-app:build("projects/rust-app
+PROJECTS/RUST-APP:build("projects/rust-app
 build ")
-deployments/terraform-deploy:build --> projects/dotnet-app:build
-deployments/terraform-deploy:build --> projects/npm-app:build
-class deployments/terraform-deploy:build ignore
-class libraries/dotnet-lib:build ignore
-class libraries/npm-lib:build ignore
-class libraries/shell-lib:build ignore
-projects/dotnet-app:build --> libraries/dotnet-lib:build
-class projects/dotnet-app:build ignore
-projects/make-app:build --> libraries/shell-lib:build
-class projects/make-app:build ignore
-class projects/npm-app/private-npm-lib:build ignore
-projects/npm-app:build --> libraries/npm-lib:build
-projects/npm-app:build --> projects/npm-app/private-npm-lib:build
-class projects/npm-app:build ignore
-class projects/open-api:build ignore
-class projects/rust-app:build ignore
+DEPLOYMENTS/TERRAFORM-DEPLOY:build --> PROJECTS/DOTNET-APP:build
+DEPLOYMENTS/TERRAFORM-DEPLOY:build --> PROJECTS/NPM-APP:build
+class DEPLOYMENTS/TERRAFORM-DEPLOY:build ignore
+class LIBRARIES/DOTNET-LIB:build ignore
+class LIBRARIES/NPM-LIB:build ignore
+class LIBRARIES/SHELL-LIB:build ignore
+PROJECTS/DOTNET-APP:build --> LIBRARIES/DOTNET-LIB:build
+class PROJECTS/DOTNET-APP:build ignore
+PROJECTS/MAKE-APP:build --> LIBRARIES/SHELL-LIB:build
+class PROJECTS/MAKE-APP:build ignore
+class PROJECTS/NPM-APP/PRIVATE-NPM-LIB:build ignore
+PROJECTS/NPM-APP:build --> LIBRARIES/NPM-LIB:build
+PROJECTS/NPM-APP:build --> PROJECTS/NPM-APP/PRIVATE-NPM-LIB:build
+class PROJECTS/NPM-APP:build ignore
+class PROJECTS/OPEN-API:build ignore
+class PROJECTS/RUST-APP:build ignore

--- a/tests/simple/results/terrabuild-debug.config.json
+++ b/tests/simple/results/terrabuild-debug.config.json
@@ -1,15 +1,15 @@
 {
   "selectedProjects": [
-    "deployments/terraform-deploy",
-    "libraries/dotnet-lib",
-    "libraries/npm-lib",
-    "libraries/shell-lib",
-    "projects/dotnet-app",
-    "projects/make-app",
-    "projects/npm-app",
-    "projects/npm-app/private-npm-lib",
-    "projects/open-api",
-    "projects/rust-app"
+    "DEPLOYMENTS/TERRAFORM-DEPLOY",
+    "LIBRARIES/DOTNET-LIB",
+    "LIBRARIES/NPM-LIB",
+    "LIBRARIES/SHELL-LIB",
+    "PROJECTS/DOTNET-APP",
+    "PROJECTS/MAKE-APP",
+    "PROJECTS/NPM-APP",
+    "PROJECTS/NPM-APP/PRIVATE-NPM-LIB",
+    "PROJECTS/OPEN-API",
+    "PROJECTS/RUST-APP"
   ],
   "targets": {
     "build": {
@@ -59,12 +59,12 @@
     }
   },
   "projects": {
-    "deployments/terraform-deploy": {
-      "id": "deployments/terraform-deploy",
-      "hash": "7E76E02B5FB7018D6E167C095476E54192546AEEDEEB3D0A8621C781728FA738",
+    "DEPLOYMENTS/TERRAFORM-DEPLOY": {
+      "name": "deployments/terraform-deploy",
+      "hash": "9EC6C3232028C098085052766313F5789DE2A40C2EF98A2D15E86D8F9615CFF2",
       "dependencies": [
-        "projects/dotnet-app",
-        "projects/npm-app"
+        "PROJECTS/DOTNET-APP",
+        "PROJECTS/NPM-APP"
       ],
       "files": [
         ".terraform.lock.hcl",
@@ -99,11 +99,11 @@
                     {
                       "dotnet_app_version": [
                         "string",
-                        "B498617AEF0C2FECAD324FC46DA9E3477254472AAE763F9312A6175F8C2AADBA"
+                        "CA867B371D864086BCC266C5186F00A45412A15D2F95ABF3046FDA371A851B45"
                       ],
                       "npm_app_version": [
                         "string",
-                        "667E311D2450BE32EBDB6730784CBE9EFBF715D2B3248F6304645236D2F0F520"
+                        "D5C34CD09DE457A98F7F7486D177587753CECB9C1CF351EF857B0A7B6ACBA459"
                       ]
                     }
                   ],
@@ -151,9 +151,9 @@
         "infra"
       ]
     },
-    "libraries/dotnet-lib": {
-      "id": "libraries/dotnet-lib",
-      "hash": "4E90121393E74B43D6B727A9F23E3AE10385E7E39F1FBD240CE10180651F6851",
+    "LIBRARIES/DOTNET-LIB": {
+      "name": "libraries/dotnet-lib",
+      "hash": "2800DCFECE6D1228816991BD3A72E919256ADAF59789989677863C86E447334F",
       "dependencies": [],
       "files": [
         "Class1.cs",
@@ -198,9 +198,9 @@
       },
       "labels": []
     },
-    "libraries/npm-lib": {
-      "id": "libraries/npm-lib",
-      "hash": "813635EFA9D98FB042EF8A761A4433B34B95BA40E1D1231B79CBDC4D29E21AF6",
+    "LIBRARIES/NPM-LIB": {
+      "name": "libraries/npm-lib",
+      "hash": "8175042D97F5AE6113CBFEFC25D7DEEE3022320ABDF6F48A63CAB4B90811796B",
       "dependencies": [],
       "files": [
         "package-lock.json",
@@ -241,9 +241,9 @@
         "app"
       ]
     },
-    "libraries/shell-lib": {
-      "id": "libraries/shell-lib",
-      "hash": "90DBBB67F0EB0EEBCC7BEB1929682796805120FF8AE0C26C7FF742190F9A469A",
+    "LIBRARIES/SHELL-LIB": {
+      "name": "libraries/shell-lib",
+      "hash": "46479653782CE6E0A5C1667D8637D99EE9FFAB226FD0BB4496ED01CCF1037C8E",
       "dependencies": [],
       "files": [],
       "targets": {
@@ -276,11 +276,11 @@
       },
       "labels": []
     },
-    "projects/dotnet-app": {
-      "id": "projects/dotnet-app",
-      "hash": "B498617AEF0C2FECAD324FC46DA9E3477254472AAE763F9312A6175F8C2AADBA",
+    "PROJECTS/DOTNET-APP": {
+      "name": "projects/dotnet-app",
+      "hash": "CA867B371D864086BCC266C5186F00A45412A15D2F95ABF3046FDA371A851B45",
       "dependencies": [
-        "libraries/dotnet-lib"
+        "LIBRARIES/DOTNET-LIB"
       ],
       "files": [
         "../shared-folder/Terminal.cs",
@@ -407,11 +407,11 @@
         "dotnet"
       ]
     },
-    "projects/make-app": {
-      "id": "projects/make-app",
-      "hash": "A5BD059BA569E96AFE6AEC3BA05C405B454A3483F1A702D11CA978F318516307",
+    "PROJECTS/MAKE-APP": {
+      "name": "projects/make-app",
+      "hash": "F5FA23FEA48BD50A8F9C28F899E35EC01A87ECA33637953DAE5E2FDDF2F17314",
       "dependencies": [
-        "libraries/shell-lib"
+        "LIBRARIES/SHELL-LIB"
       ],
       "files": [
         "Makefile"
@@ -471,12 +471,12 @@
         "app"
       ]
     },
-    "projects/npm-app": {
-      "id": "projects/npm-app",
-      "hash": "667E311D2450BE32EBDB6730784CBE9EFBF715D2B3248F6304645236D2F0F520",
+    "PROJECTS/NPM-APP": {
+      "name": "projects/npm-app",
+      "hash": "D5C34CD09DE457A98F7F7486D177587753CECB9C1CF351EF857B0A7B6ACBA459",
       "dependencies": [
-        "libraries/npm-lib",
-        "projects/npm-app/private-npm-lib"
+        "LIBRARIES/NPM-LIB",
+        "PROJECTS/NPM-APP/PRIVATE-NPM-LIB"
       ],
       "files": [
         ".gitignore",
@@ -529,9 +529,9 @@
         "app"
       ]
     },
-    "projects/npm-app/private-npm-lib": {
-      "id": "projects/npm-app/private-npm-lib",
-      "hash": "F951BD1663475053E1F9C97DDA08EA553E21951BC053419D362126A2B6A4C83C",
+    "PROJECTS/NPM-APP/PRIVATE-NPM-LIB": {
+      "name": "projects/npm-app/private-npm-lib",
+      "hash": "EC303FCA7CCFE2DAC334A7C1D898BF3162FE50AC8C536BBB3F10DB8E9DF14A0D",
       "dependencies": [],
       "files": [
         "package-lock.json",
@@ -572,9 +572,9 @@
         "app"
       ]
     },
-    "projects/open-api": {
-      "id": "projects/open-api",
-      "hash": "B638983BF2E75B9D5787C0082FE7E5BFA726B4B4815F48EE7482E1051275209A",
+    "PROJECTS/OPEN-API": {
+      "name": "projects/open-api",
+      "hash": "14C9C4FCBD2D336C3747CD8EA1219DC39F8D79A3372DDFD536464C2C4B7BB4B3",
       "dependencies": [],
       "files": [
         ".gitignore",
@@ -620,9 +620,9 @@
       },
       "labels": []
     },
-    "projects/rust-app": {
-      "id": "projects/rust-app",
-      "hash": "ABBB61CBAB614EB12FDCBC22A5549A851128357CCA09CB57D74A2D2390E4A043",
+    "PROJECTS/RUST-APP": {
+      "name": "projects/rust-app",
+      "hash": "2FE82A1BC72FCD0EC967432A46CBB5F19F3FEFF4A4E725E170FAD4BB16336C30",
       "dependencies": [],
       "files": [
         "Cargo.lock",


### PR DESCRIPTION
Dependencies can be case-insensitive on some filesystem (windows and macos).
Ensure projectId is case-insensitive to avoid multiple scans of projects.