### PR TITLE
use block syntax for defaults

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,7 +53,7 @@ extension @dotnet {
         "TEAMCITY_VERSION"
         "JB_SPACE_API_URL"
     ]
-    defaults = {
-        configuration: $configuration
+    defaults {
+        `configuration` = $configuration
     }
 }

--- a/src/Terrabuild.Configuration.Tests/TestFiles/PROJECT
+++ b/src/Terrabuild.Configuration.Tests/TestFiles/PROJECT
@@ -1,15 +1,15 @@
 # comment at top of file
 
 extension @dotnet {
-  defaults = { # comment at end of line
-    configuration : $configuration
+  defaults { # comment at end of line
+    `configuration` = $configuration
   }
 }
 
 extension @docker {
-  defaults = {
-    configuration: $configuration
-    image : "ghcr.io/magnusopera/dotnet-app"
+  defaults {
+    `configuration` = $configuration
+    `image` = "ghcr.io/magnusopera/dotnet-app"
   }
 
   variables = [ "ARM_TENANT_ID" ]

--- a/src/Terrabuild.Configuration.Tests/TestFiles/WORKSPACE
+++ b/src/Terrabuild.Configuration.Tests/TestFiles/WORKSPACE
@@ -26,8 +26,8 @@ configuration dummy
 
 extension dotnet {
   container = "mcr.microsoft.com/dotnet/sdk:8.0.101"
-  defaults = {
-    configuration: $configuration
+  defaults {
+    `configuration` = $configuration
   }
 }
 

--- a/src/Terrabuild.Configuration.Tests/TestFiles/WORKSPACE2
+++ b/src/Terrabuild.Configuration.Tests/TestFiles/WORKSPACE2
@@ -47,10 +47,10 @@ configuration {
 
 extension dotnet {
   container = "mcr.microsoft.com/dotnet/sdk:8.0.101"
-  defaults = {
-    configuration1: $map.toto
-    configuration2: $map.?titi
-    configuration3: replace("toto titi", "toto", "titi")
+  defaults {
+    configuration1 = $map.toto
+    configuration2 = $map.?titi
+    configuration3 = replace("toto titi", "toto", "titi")
   }
 }
 

--- a/src/Terrabuild.Configuration/AST.fs
+++ b/src/Terrabuild.Configuration/AST.fs
@@ -8,7 +8,7 @@ type ExtensionComponents =
     | Platform of Expr
     | Variables of Expr list
     | Script of Expr
-    | Defaults of Map<string, Expr>
+    | Defaults of (string * Expr) list
 
 type ExtensionBlock =
     { Container: Expr option
@@ -43,9 +43,9 @@ with
             | _ -> raiseParseError "multiple script declared"
 
         let defaults =
-            match components |> List.choose (function | ExtensionComponents.Defaults value -> Some value | _ -> None) with
+            match  components |> List.choose (function | ExtensionComponents.Defaults values -> Some values | _ -> None) with
             | [] -> Map.empty
-            | [value] -> value
+            | [values] -> values |> Map.ofList
             | _ -> raiseParseError "multiple defaults declared"
 
         name, { Container = container

--- a/src/Terrabuild.Configuration/Gen/ProjectParser.fs
+++ b/src/Terrabuild.Configuration/Gen/ProjectParser.fs
@@ -166,6 +166,8 @@ type nonTerminalId =
     | NONTERM_ExtensionVariables
     | NONTERM_ExtensionScript
     | NONTERM_ExtensionDefaults
+    | NONTERM_ExtensionDefaultsComponents
+    | NONTERM_ExtensionDefaultsComponentsVariable
     | NONTERM_Project
     | NONTERM_ProjectComponents
     | NONTERM_ProjectDependencies
@@ -367,39 +369,39 @@ let prodIdxToNonTerminal (prodIdx:int) =
     | 20 -> NONTERM_ExtensionVariables 
     | 21 -> NONTERM_ExtensionScript 
     | 22 -> NONTERM_ExtensionDefaults 
-    | 23 -> NONTERM_Project 
-    | 24 -> NONTERM_Project 
-    | 25 -> NONTERM_Project 
+    | 23 -> NONTERM_ExtensionDefaultsComponents 
+    | 24 -> NONTERM_ExtensionDefaultsComponents 
+    | 25 -> NONTERM_ExtensionDefaultsComponentsVariable 
     | 26 -> NONTERM_Project 
-    | 27 -> NONTERM_ProjectComponents 
-    | 28 -> NONTERM_ProjectComponents 
-    | 29 -> NONTERM_ProjectComponents 
+    | 27 -> NONTERM_Project 
+    | 28 -> NONTERM_Project 
+    | 29 -> NONTERM_Project 
     | 30 -> NONTERM_ProjectComponents 
     | 31 -> NONTERM_ProjectComponents 
     | 32 -> NONTERM_ProjectComponents 
     | 33 -> NONTERM_ProjectComponents 
-    | 34 -> NONTERM_ProjectDependencies 
-    | 35 -> NONTERM_ProjectLinks 
-    | 36 -> NONTERM_ProjectOutputs 
-    | 37 -> NONTERM_ProjectIgnores 
-    | 38 -> NONTERM_ProjectIncludes 
-    | 39 -> NONTERM_ProjectLabels 
-    | 40 -> NONTERM_Target 
-    | 41 -> NONTERM_TargetComponents 
-    | 42 -> NONTERM_TargetComponents 
-    | 43 -> NONTERM_TargetComponents 
+    | 34 -> NONTERM_ProjectComponents 
+    | 35 -> NONTERM_ProjectComponents 
+    | 36 -> NONTERM_ProjectComponents 
+    | 37 -> NONTERM_ProjectDependencies 
+    | 38 -> NONTERM_ProjectLinks 
+    | 39 -> NONTERM_ProjectOutputs 
+    | 40 -> NONTERM_ProjectIgnores 
+    | 41 -> NONTERM_ProjectIncludes 
+    | 42 -> NONTERM_ProjectLabels 
+    | 43 -> NONTERM_Target 
     | 44 -> NONTERM_TargetComponents 
     | 45 -> NONTERM_TargetComponents 
     | 46 -> NONTERM_TargetComponents 
-    | 47 -> NONTERM_TargetDependsOn 
-    | 48 -> NONTERM_TargetRebuild 
-    | 49 -> NONTERM_TargetOutputs 
-    | 50 -> NONTERM_TargetCache 
-    | 51 -> NONTERM_TargetStep 
-    | 52 -> NONTERM_TargetStep 
-    | 53 -> NONTERM_Expr 
-    | 54 -> NONTERM_Expr 
-    | 55 -> NONTERM_Expr 
+    | 47 -> NONTERM_TargetComponents 
+    | 48 -> NONTERM_TargetComponents 
+    | 49 -> NONTERM_TargetComponents 
+    | 50 -> NONTERM_TargetDependsOn 
+    | 51 -> NONTERM_TargetRebuild 
+    | 52 -> NONTERM_TargetOutputs 
+    | 53 -> NONTERM_TargetCache 
+    | 54 -> NONTERM_TargetStep 
+    | 55 -> NONTERM_TargetStep 
     | 56 -> NONTERM_Expr 
     | 57 -> NONTERM_Expr 
     | 58 -> NONTERM_Expr 
@@ -424,9 +426,9 @@ let prodIdxToNonTerminal (prodIdx:int) =
     | 77 -> NONTERM_Expr 
     | 78 -> NONTERM_Expr 
     | 79 -> NONTERM_Expr 
-    | 80 -> NONTERM_InterpolatedExpr 
-    | 81 -> NONTERM_InterpolatedExpr 
-    | 82 -> NONTERM_InterpolatedExpr 
+    | 80 -> NONTERM_Expr 
+    | 81 -> NONTERM_Expr 
+    | 82 -> NONTERM_Expr 
     | 83 -> NONTERM_InterpolatedExpr 
     | 84 -> NONTERM_InterpolatedExpr 
     | 85 -> NONTERM_InterpolatedExpr 
@@ -449,42 +451,45 @@ let prodIdxToNonTerminal (prodIdx:int) =
     | 102 -> NONTERM_InterpolatedExpr 
     | 103 -> NONTERM_InterpolatedExpr 
     | 104 -> NONTERM_InterpolatedExpr 
-    | 105 -> NONTERM_TargetIdentifier 
-    | 106 -> NONTERM_TargetIdentifier 
-    | 107 -> NONTERM_ExtensionIdentifier 
-    | 108 -> NONTERM_ExtensionIdentifier 
-    | 109 -> NONTERM_ExprIndex 
-    | 110 -> NONTERM_ExprIndex 
-    | 111 -> NONTERM_Bool 
-    | 112 -> NONTERM_Bool 
-    | 113 -> NONTERM_String 
-    | 114 -> NONTERM_String 
-    | 115 -> NONTERM_String 
-    | 116 -> NONTERM_InterpolatedString 
-    | 117 -> NONTERM_InterpolatedString 
-    | 118 -> NONTERM_ExprTuple 
-    | 119 -> NONTERM_ExprTupleContent 
-    | 120 -> NONTERM_ExprTupleContent 
-    | 121 -> NONTERM_ExprTupleContent 
-    | 122 -> NONTERM_InterpolatedExprTuple 
-    | 123 -> NONTERM_InterpolatedExprTupleContent 
-    | 124 -> NONTERM_InterpolatedExprTupleContent 
-    | 125 -> NONTERM_InterpolatedExprTupleContent 
-    | 126 -> NONTERM_ExprList 
-    | 127 -> NONTERM_ExprListContent 
-    | 128 -> NONTERM_ExprListContent 
-    | 129 -> NONTERM_ExprMap 
-    | 130 -> NONTERM_ExprMapContent 
-    | 131 -> NONTERM_ExprMapContent 
-    | 132 -> NONTERM_ListOfString 
-    | 133 -> NONTERM_Strings 
-    | 134 -> NONTERM_Strings 
-    | 135 -> NONTERM_ListOfIdentifiers 
-    | 136 -> NONTERM_Identifiers 
-    | 137 -> NONTERM_Identifiers 
-    | 138 -> NONTERM_ListOfTargetIdentifiers 
-    | 139 -> NONTERM_TargetIdentifiers 
-    | 140 -> NONTERM_TargetIdentifiers 
+    | 105 -> NONTERM_InterpolatedExpr 
+    | 106 -> NONTERM_InterpolatedExpr 
+    | 107 -> NONTERM_InterpolatedExpr 
+    | 108 -> NONTERM_TargetIdentifier 
+    | 109 -> NONTERM_TargetIdentifier 
+    | 110 -> NONTERM_ExtensionIdentifier 
+    | 111 -> NONTERM_ExtensionIdentifier 
+    | 112 -> NONTERM_ExprIndex 
+    | 113 -> NONTERM_ExprIndex 
+    | 114 -> NONTERM_Bool 
+    | 115 -> NONTERM_Bool 
+    | 116 -> NONTERM_String 
+    | 117 -> NONTERM_String 
+    | 118 -> NONTERM_String 
+    | 119 -> NONTERM_InterpolatedString 
+    | 120 -> NONTERM_InterpolatedString 
+    | 121 -> NONTERM_ExprTuple 
+    | 122 -> NONTERM_ExprTupleContent 
+    | 123 -> NONTERM_ExprTupleContent 
+    | 124 -> NONTERM_ExprTupleContent 
+    | 125 -> NONTERM_InterpolatedExprTuple 
+    | 126 -> NONTERM_InterpolatedExprTupleContent 
+    | 127 -> NONTERM_InterpolatedExprTupleContent 
+    | 128 -> NONTERM_InterpolatedExprTupleContent 
+    | 129 -> NONTERM_ExprList 
+    | 130 -> NONTERM_ExprListContent 
+    | 131 -> NONTERM_ExprListContent 
+    | 132 -> NONTERM_ExprMap 
+    | 133 -> NONTERM_ExprMapContent 
+    | 134 -> NONTERM_ExprMapContent 
+    | 135 -> NONTERM_ListOfString 
+    | 136 -> NONTERM_Strings 
+    | 137 -> NONTERM_Strings 
+    | 138 -> NONTERM_ListOfIdentifiers 
+    | 139 -> NONTERM_Identifiers 
+    | 140 -> NONTERM_Identifiers 
+    | 141 -> NONTERM_ListOfTargetIdentifiers 
+    | 142 -> NONTERM_TargetIdentifiers 
+    | 143 -> NONTERM_TargetIdentifiers 
     | _ -> failwith "prodIdxToNonTerminal: bad production index"
 
 let _fsyacc_endOfInputTag = 65 
@@ -623,18 +628,18 @@ let _fsyacc_dataOfToken (t:token) =
   | NOTHING  -> (null : System.Object) 
   | TRUE  -> (null : System.Object) 
   | FALSE  -> (null : System.Object) 
-let _fsyacc_gotos = [| 0us;65535us;1us;65535us;0us;1us;1us;65535us;0us;2us;1us;65535us;2us;4us;1us;65535us;9us;10us;1us;65535us;10us;12us;1us;65535us;2us;6us;1us;65535us;18us;19us;1us;65535us;19us;21us;1us;65535us;19us;22us;1us;65535us;19us;23us;1us;65535us;19us;24us;1us;65535us;19us;25us;1us;65535us;2us;5us;2us;65535us;42us;43us;46us;47us;2us;65535us;43us;49us;47us;49us;2us;65535us;43us;50us;47us;50us;2us;65535us;43us;51us;47us;51us;2us;65535us;43us;52us;47us;52us;2us;65535us;43us;53us;47us;53us;2us;65535us;43us;54us;47us;54us;1us;65535us;2us;7us;1us;65535us;75us;76us;1us;65535us;76us;78us;1us;65535us;76us;79us;1us;65535us;76us;80us;1us;65535us;76us;81us;1us;65535us;76us;82us;20us;65535us;14us;15us;27us;28us;30us;31us;87us;88us;126us;106us;127us;107us;128us;108us;129us;109us;130us;110us;131us;111us;148us;112us;149us;113us;150us;114us;151us;115us;163us;116us;165us;117us;167us;118us;170us;119us;172us;120us;177us;121us;0us;65535us;1us;65535us;183us;185us;3us;65535us;16us;17us;41us;45us;76us;95us;2us;65535us;122us;123us;124us;125us;0us;65535us;23us;65535us;14us;105us;27us;105us;30us;105us;36us;37us;87us;105us;93us;94us;126us;105us;127us;105us;128us;105us;129us;105us;130us;105us;131us;105us;148us;105us;149us;105us;150us;105us;151us;105us;163us;105us;165us;105us;167us;105us;170us;105us;172us;105us;177us;105us;179us;181us;1us;65535us;159us;161us;8us;65535us;132us;133us;134us;135us;136us;137us;138us;139us;140us;141us;142us;143us;144us;145us;146us;147us;1us;65535us;167us;168us;0us;65535us;0us;65535us;20us;65535us;14us;98us;27us;98us;30us;98us;87us;98us;126us;98us;127us;98us;128us;98us;129us;98us;130us;98us;131us;98us;148us;98us;149us;98us;150us;98us;151us;98us;163us;98us;165us;98us;167us;98us;170us;98us;172us;98us;177us;98us;1us;65535us;171us;172us;22us;65535us;14us;99us;27us;99us;30us;99us;39us;40us;87us;99us;96us;97us;126us;99us;127us;99us;128us;99us;129us;99us;130us;99us;131us;99us;148us;99us;149us;99us;150us;99us;151us;99us;163us;99us;165us;99us;167us;99us;170us;99us;172us;99us;177us;99us;1us;65535us;174us;175us;8us;65535us;33us;34us;56us;57us;59us;60us;62us;63us;65us;66us;68us;69us;71us;72us;90us;91us;1us;65535us;178us;179us;0us;65535us;0us;65535us;1us;65535us;84us;85us;1us;65535us;182us;183us;|]
-let _fsyacc_sparseGotoTableRowOffsets = [|0us;1us;3us;5us;7us;9us;11us;13us;15us;17us;19us;21us;23us;25us;27us;30us;33us;36us;39us;42us;45us;48us;50us;52us;54us;56us;58us;60us;62us;83us;84us;86us;90us;93us;94us;118us;120us;129us;131us;132us;133us;154us;156us;179us;181us;190us;192us;193us;194us;196us;|]
-let _fsyacc_stateToProdIdxsTableElements = [| 1us;0us;1us;0us;5us;1us;3us;4us;5us;6us;1us;1us;1us;3us;1us;4us;1us;5us;1us;6us;1us;7us;1us;7us;2us;7us;9us;1us;7us;1us;9us;1us;10us;1us;10us;11us;10us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;1us;11us;1us;11us;1us;11us;6us;11us;13us;14us;15us;16us;17us;1us;11us;1us;13us;1us;14us;1us;15us;1us;16us;1us;17us;1us;18us;1us;18us;11us;18us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;1us;19us;1us;19us;11us;19us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;1us;20us;1us;20us;1us;20us;1us;21us;1us;21us;1us;21us;1us;22us;1us;22us;1us;22us;4us;23us;24us;25us;26us;1us;24us;7us;24us;28us;29us;30us;31us;32us;33us;1us;24us;2us;25us;26us;1us;26us;7us;26us;28us;29us;30us;31us;32us;33us;1us;26us;1us;28us;1us;29us;1us;30us;1us;31us;1us;32us;1us;33us;1us;34us;1us;34us;1us;34us;1us;35us;1us;35us;1us;35us;1us;36us;1us;36us;1us;36us;1us;37us;1us;37us;1us;37us;1us;38us;1us;38us;1us;38us;1us;39us;1us;39us;1us;39us;1us;40us;1us;40us;1us;40us;6us;40us;42us;43us;44us;45us;46us;1us;40us;1us;42us;1us;43us;1us;44us;1us;45us;1us;46us;1us;47us;1us;47us;1us;47us;1us;48us;1us;48us;11us;48us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;1us;49us;1us;49us;1us;49us;1us;50us;1us;50us;1us;50us;2us;51us;52us;2us;51us;52us;1us;52us;1us;53us;1us;54us;1us;55us;1us;56us;1us;57us;1us;58us;1us;59us;1us;60us;11us;61us;62us;63us;63us;64us;65us;66us;67us;68us;77us;78us;11us;61us;62us;63us;64us;64us;65us;66us;67us;68us;77us;78us;11us;61us;62us;63us;64us;65us;65us;66us;67us;68us;77us;78us;11us;61us;62us;63us;64us;65us;66us;66us;67us;68us;77us;78us;11us;61us;62us;63us;64us;65us;66us;67us;67us;68us;77us;78us;11us;61us;62us;63us;64us;65us;66us;67us;68us;68us;77us;78us;11us;61us;62us;63us;64us;65us;66us;67us;68us;77us;77us;78us;11us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;78us;11us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;78us;11us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;79us;11us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;116us;11us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;117us;11us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;120us;11us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;121us;11us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;128us;11us;61us;62us;63us;64us;65us;66us;67us;68us;77us;78us;131us;1us;61us;1us;61us;1us;62us;1us;62us;1us;63us;1us;64us;1us;65us;1us;66us;1us;67us;1us;68us;1us;69us;1us;69us;1us;70us;1us;70us;1us;71us;1us;71us;1us;72us;1us;72us;1us;73us;1us;73us;1us;74us;1us;74us;1us;75us;1us;75us;1us;76us;1us;76us;1us;77us;1us;78us;1us;78us;1us;79us;1us;105us;1us;106us;1us;107us;1us;108us;1us;109us;1us;110us;1us;113us;2us;114us;115us;1us;114us;2us;115us;117us;1us;115us;1us;116us;1us;116us;1us;117us;1us;117us;1us;118us;2us;118us;121us;1us;118us;1us;121us;1us;126us;2us;126us;128us;1us;126us;1us;129us;2us;129us;131us;1us;129us;1us;131us;1us;132us;2us;132us;134us;1us;132us;1us;134us;1us;138us;2us;138us;140us;1us;138us;1us;140us;|]
-let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us;2us;4us;10us;12us;14us;16us;18us;20us;22us;24us;27us;29us;31us;33us;35us;47us;49us;51us;53us;60us;62us;64us;66us;68us;70us;72us;74us;76us;88us;90us;92us;104us;106us;108us;110us;112us;114us;116us;118us;120us;122us;127us;129us;137us;139us;142us;144us;152us;154us;156us;158us;160us;162us;164us;166us;168us;170us;172us;174us;176us;178us;180us;182us;184us;186us;188us;190us;192us;194us;196us;198us;200us;202us;204us;206us;208us;215us;217us;219us;221us;223us;225us;227us;229us;231us;233us;235us;237us;249us;251us;253us;255us;257us;259us;261us;264us;267us;269us;271us;273us;275us;277us;279us;281us;283us;285us;297us;309us;321us;333us;345us;357us;369us;381us;393us;405us;417us;429us;441us;453us;465us;477us;479us;481us;483us;485us;487us;489us;491us;493us;495us;497us;499us;501us;503us;505us;507us;509us;511us;513us;515us;517us;519us;521us;523us;525us;527us;529us;531us;533us;535us;537us;539us;541us;543us;545us;547us;549us;551us;554us;556us;559us;561us;563us;565us;567us;569us;571us;574us;576us;578us;580us;583us;585us;587us;590us;592us;594us;596us;599us;601us;603us;605us;608us;610us;|]
-let _fsyacc_action_rows = 186
-let _fsyacc_actionTableElements = [|0us;16386us;0us;49152us;5us;32768us;9us;8us;17us;41us;18us;16us;19us;73us;20us;3us;0us;16385us;0us;16387us;0us;16388us;0us;16389us;0us;16390us;1us;32768us;47us;9us;0us;16392us;2us;32768us;48us;11us;54us;13us;0us;16391us;0us;16393us;1us;32768us;38us;14us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;10us;16394us;21us;148us;22us;149us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;2us;32768us;53us;154us;54us;155us;1us;32768us;47us;18us;0us;16396us;6us;32768us;0us;26us;1us;29us;3us;35us;7us;38us;16us;32us;48us;20us;0us;16395us;0us;16397us;0us;16398us;0us;16399us;0us;16400us;0us;16401us;1us;32768us;38us;27us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;10us;16402us;21us;148us;22us;149us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;1us;32768us;38us;30us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;10us;16403us;21us;148us;22us;149us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;1us;32768us;38us;33us;1us;32768us;45us;178us;0us;16404us;1us;32768us;38us;36us;2us;32768us;58us;159us;59us;158us;0us;16405us;1us;32768us;38us;39us;1us;32768us;47us;174us;0us;16406us;3us;16407us;47us;42us;53us;154us;54us;155us;0us;16411us;7us;32768us;10us;55us;11us;58us;12us;61us;13us;64us;14us;67us;15us;70us;48us;44us;0us;16408us;1us;16409us;47us;46us;0us;16411us;7us;32768us;10us;55us;11us;58us;12us;61us;13us;64us;14us;67us;15us;70us;48us;48us;0us;16410us;0us;16412us;0us;16413us;0us;16414us;0us;16415us;0us;16416us;0us;16417us;1us;32768us;38us;56us;1us;32768us;45us;178us;0us;16418us;1us;32768us;38us;59us;1us;32768us;45us;178us;0us;16419us;1us;32768us;38us;62us;1us;32768us;45us;178us;0us;16420us;1us;32768us;38us;65us;1us;32768us;45us;178us;0us;16421us;1us;32768us;38us;68us;1us;32768us;45us;178us;0us;16422us;1us;32768us;38us;71us;1us;32768us;45us;178us;0us;16423us;1us;32768us;54us;74us;1us;32768us;47us;75us;0us;16425us;7us;32768us;4us;83us;5us;86us;6us;92us;12us;89us;48us;77us;53us;154us;54us;155us;0us;16424us;0us;16426us;0us;16427us;0us;16428us;0us;16429us;0us;16430us;1us;32768us;38us;84us;1us;32768us;45us;182us;0us;16431us;1us;32768us;38us;87us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;10us;16432us;21us;148us;22us;149us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;1us;32768us;38us;90us;1us;32768us;45us;178us;0us;16433us;1us;32768us;38us;93us;2us;32768us;58us;159us;59us;158us;0us;16434us;1us;32768us;54us;96us;1us;16435us;47us;174us;0us;16436us;0us;16437us;0us;16438us;0us;16439us;0us;16440us;0us;16441us;0us;16442us;0us;16443us;0us;16444us;6us;16447us;25us;130us;26us;131us;35us;129us;36us;128us;43us;122us;44us;124us;6us;16448us;25us;130us;26us;131us;35us;129us;36us;128us;43us;122us;44us;124us;4us;16449us;25us;130us;26us;131us;43us;122us;44us;124us;4us;16450us;25us;130us;26us;131us;43us;122us;44us;124us;2us;16451us;43us;122us;44us;124us;2us;16452us;43us;122us;44us;124us;8us;16461us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;11us;32768us;21us;148us;22us;149us;23us;150us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;10us;16462us;21us;148us;22us;149us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;0us;16463us;11us;32768us;21us;148us;22us;149us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;55us;164us;11us;32768us;21us;148us;22us;149us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;55us;166us;10us;16504us;21us;148us;22us;149us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;10us;16505us;21us;148us;22us;149us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;10us;16512us;21us;148us;22us;149us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;10us;16515us;21us;148us;22us;149us;25us;130us;26us;131us;35us;129us;36us;128us;39us;126us;40us;127us;43us;122us;44us;124us;2us;32768us;49us;156us;54us;157us;0us;16445us;2us;32768us;49us;156us;54us;157us;0us;16446us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;1us;32768us;41us;167us;0us;16453us;1us;32768us;41us;167us;0us;16454us;1us;32768us;41us;167us;0us;16455us;1us;32768us;41us;167us;0us;16456us;1us;32768us;41us;167us;0us;16457us;1us;32768us;41us;167us;0us;16458us;1us;32768us;41us;167us;0us;16459us;1us;32768us;41us;167us;0us;16460us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;0us;16489us;0us;16490us;0us;16491us;0us;16492us;0us;16493us;0us;16494us;0us;16497us;2us;32768us;56us;163us;57us;160us;0us;16498us;2us;32768us;56us;165us;57us;162us;0us;16499us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;0us;16500us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;0us;16501us;18us;16503us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;2us;32768us;37us;170us;42us;169us;0us;16502us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;0us;16511us;19us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;46us;173us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;0us;16510us;0us;16514us;2us;32768us;48us;176us;50us;177us;0us;16513us;18us;32768us;24us;151us;27us;132us;28us;134us;29us;136us;30us;138us;31us;140us;32us;142us;33us;144us;34us;146us;45us;171us;47us;174us;49us;103us;51us;104us;58us;159us;59us;158us;60us;100us;61us;101us;62us;102us;0us;16517us;3us;32768us;46us;180us;58us;159us;59us;158us;0us;16516us;0us;16518us;0us;16523us;3us;32768us;46us;184us;52us;152us;54us;153us;0us;16522us;0us;16524us;|]
-let _fsyacc_actionTableRowOffsets = [|0us;1us;2us;8us;9us;10us;11us;12us;13us;15us;16us;19us;20us;21us;23us;42us;53us;56us;58us;59us;66us;67us;68us;69us;70us;71us;72us;74us;93us;104us;106us;125us;136us;138us;140us;141us;143us;146us;147us;149us;151us;152us;156us;157us;165us;166us;168us;169us;177us;178us;179us;180us;181us;182us;183us;184us;186us;188us;189us;191us;193us;194us;196us;198us;199us;201us;203us;204us;206us;208us;209us;211us;213us;214us;216us;218us;219us;227us;228us;229us;230us;231us;232us;233us;235us;237us;238us;240us;259us;270us;272us;274us;275us;277us;280us;281us;283us;285us;286us;287us;288us;289us;290us;291us;292us;293us;294us;301us;308us;313us;318us;321us;324us;333us;345us;356us;357us;369us;381us;392us;403us;414us;425us;428us;429us;432us;433us;452us;471us;490us;509us;528us;547us;549us;550us;552us;553us;555us;556us;558us;559us;561us;562us;564us;565us;567us;568us;570us;571us;590us;609us;628us;647us;648us;649us;650us;651us;652us;653us;654us;657us;658us;661us;662us;681us;682us;701us;702us;721us;724us;725us;744us;745us;765us;766us;767us;770us;771us;790us;791us;795us;796us;797us;798us;802us;803us;|]
-let _fsyacc_reductionSymbolCounts = [|1us;2us;0us;2us;2us;2us;2us;4us;0us;2us;3us;5us;0us;2us;2us;2us;2us;2us;3us;3us;3us;3us;3us;1us;4us;2us;5us;0us;2us;2us;2us;2us;2us;2us;3us;3us;3us;3us;3us;3us;5us;0us;2us;2us;2us;2us;2us;3us;3us;3us;3us;2us;3us;1us;1us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;1us;1us;1us;1us;2us;3us;3us;4us;3us;0us;1us;3us;3us;0us;1us;3us;3us;0us;2us;3us;0us;3us;3us;0us;2us;3us;0us;2us;3us;0us;2us;|]
-let _fsyacc_productionToNonTerminalTable = [|0us;1us;2us;2us;2us;2us;2us;3us;4us;4us;5us;6us;7us;7us;7us;7us;7us;7us;8us;9us;10us;11us;12us;13us;13us;13us;13us;14us;14us;14us;14us;14us;14us;14us;15us;16us;17us;18us;19us;20us;21us;22us;22us;22us;22us;22us;22us;23us;24us;25us;26us;27us;27us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;28us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;29us;30us;30us;31us;31us;32us;32us;33us;33us;34us;34us;34us;35us;35us;36us;37us;37us;37us;38us;39us;39us;39us;40us;41us;41us;42us;43us;43us;44us;45us;45us;46us;47us;47us;48us;49us;49us;|]
-let _fsyacc_immediateActions = [|65535us;49152us;65535us;16385us;16387us;16388us;16389us;16390us;65535us;65535us;65535us;16391us;16393us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16395us;16397us;16398us;16399us;16400us;16401us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16404us;65535us;65535us;16405us;65535us;65535us;16406us;65535us;65535us;65535us;16408us;65535us;65535us;65535us;16410us;16412us;16413us;16414us;16415us;16416us;16417us;65535us;65535us;16418us;65535us;65535us;16419us;65535us;65535us;16420us;65535us;65535us;16421us;65535us;65535us;16422us;65535us;65535us;16423us;65535us;65535us;65535us;65535us;16424us;16426us;16427us;16428us;16429us;16430us;65535us;65535us;16431us;65535us;65535us;65535us;65535us;65535us;16433us;65535us;65535us;16434us;65535us;65535us;16436us;16437us;16438us;16439us;16440us;16441us;16442us;16443us;16444us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16445us;65535us;16446us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16453us;65535us;16454us;65535us;16455us;65535us;16456us;65535us;16457us;65535us;16458us;65535us;16459us;65535us;16460us;65535us;65535us;65535us;65535us;16489us;16490us;16491us;16492us;16493us;16494us;16497us;65535us;16498us;65535us;16499us;65535us;16500us;65535us;16501us;65535us;65535us;16502us;65535us;65535us;65535us;16510us;65535us;65535us;16513us;65535us;65535us;65535us;16516us;16518us;65535us;65535us;16522us;16524us;|]
+let _fsyacc_gotos = [| 0us;65535us;1us;65535us;0us;1us;1us;65535us;0us;2us;1us;65535us;2us;4us;1us;65535us;9us;10us;1us;65535us;10us;12us;1us;65535us;2us;6us;1us;65535us;18us;19us;1us;65535us;19us;21us;1us;65535us;19us;22us;1us;65535us;19us;23us;1us;65535us;19us;24us;1us;65535us;19us;25us;1us;65535us;39us;40us;1us;65535us;40us;42us;1us;65535us;2us;5us;2us;65535us;47us;48us;51us;52us;2us;65535us;48us;54us;52us;54us;2us;65535us;48us;55us;52us;55us;2us;65535us;48us;56us;52us;56us;2us;65535us;48us;57us;52us;57us;2us;65535us;48us;58us;52us;58us;2us;65535us;48us;59us;52us;59us;1us;65535us;2us;7us;1us;65535us;80us;81us;1us;65535us;81us;83us;1us;65535us;81us;84us;1us;65535us;81us;85us;1us;65535us;81us;86us;1us;65535us;81us;87us;21us;65535us;14us;15us;27us;28us;30us;31us;44us;45us;92us;93us;131us;111us;132us;112us;133us;113us;134us;114us;135us;115us;136us;116us;153us;117us;154us;118us;155us;119us;156us;120us;168us;121us;170us;122us;172us;123us;175us;124us;177us;125us;182us;126us;0us;65535us;1us;65535us;188us;190us;3us;65535us;16us;17us;46us;50us;81us;100us;2us;65535us;127us;128us;129us;130us;0us;65535us;24us;65535us;14us;110us;27us;110us;30us;110us;36us;37us;44us;110us;92us;110us;98us;99us;131us;110us;132us;110us;133us;110us;134us;110us;135us;110us;136us;110us;153us;110us;154us;110us;155us;110us;156us;110us;168us;110us;170us;110us;172us;110us;175us;110us;177us;110us;182us;110us;184us;186us;1us;65535us;164us;166us;8us;65535us;137us;138us;139us;140us;141us;142us;143us;144us;145us;146us;147us;148us;149us;150us;151us;152us;1us;65535us;172us;173us;0us;65535us;0us;65535us;21us;65535us;14us;103us;27us;103us;30us;103us;44us;103us;92us;103us;131us;103us;132us;103us;133us;103us;134us;103us;135us;103us;136us;103us;153us;103us;154us;103us;155us;103us;156us;103us;168us;103us;170us;103us;172us;103us;175us;103us;177us;103us;182us;103us;1us;65535us;176us;177us;22us;65535us;14us;104us;27us;104us;30us;104us;44us;104us;92us;104us;101us;102us;131us;104us;132us;104us;133us;104us;134us;104us;135us;104us;136us;104us;153us;104us;154us;104us;155us;104us;156us;104us;168us;104us;170us;104us;172us;104us;175us;104us;177us;104us;182us;104us;1us;65535us;179us;180us;8us;65535us;33us;34us;61us;62us;64us;65us;67us;68us;70us;71us;73us;74us;76us;77us;95us;96us;1us;65535us;183us;184us;0us;65535us;0us;65535us;1us;65535us;89us;90us;1us;65535us;187us;188us;|]
+let _fsyacc_sparseGotoTableRowOffsets = [|0us;1us;3us;5us;7us;9us;11us;13us;15us;17us;19us;21us;23us;25us;27us;29us;31us;34us;37us;40us;43us;46us;49us;52us;54us;56us;58us;60us;62us;64us;66us;88us;89us;91us;95us;98us;99us;124us;126us;135us;137us;138us;139us;161us;163us;186us;188us;197us;199us;200us;201us;203us;|]
+let _fsyacc_stateToProdIdxsTableElements = [| 1us;0us;1us;0us;5us;1us;3us;4us;5us;6us;1us;1us;1us;3us;1us;4us;1us;5us;1us;6us;1us;7us;1us;7us;2us;7us;9us;1us;7us;1us;9us;1us;10us;1us;10us;11us;10us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;1us;11us;1us;11us;1us;11us;6us;11us;13us;14us;15us;16us;17us;1us;11us;1us;13us;1us;14us;1us;15us;1us;16us;1us;17us;1us;18us;1us;18us;11us;18us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;1us;19us;1us;19us;11us;19us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;1us;20us;1us;20us;1us;20us;1us;21us;1us;21us;1us;21us;1us;22us;1us;22us;2us;22us;24us;1us;22us;1us;24us;1us;25us;1us;25us;11us;25us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;4us;26us;27us;28us;29us;1us;27us;7us;27us;31us;32us;33us;34us;35us;36us;1us;27us;2us;28us;29us;1us;29us;7us;29us;31us;32us;33us;34us;35us;36us;1us;29us;1us;31us;1us;32us;1us;33us;1us;34us;1us;35us;1us;36us;1us;37us;1us;37us;1us;37us;1us;38us;1us;38us;1us;38us;1us;39us;1us;39us;1us;39us;1us;40us;1us;40us;1us;40us;1us;41us;1us;41us;1us;41us;1us;42us;1us;42us;1us;42us;1us;43us;1us;43us;1us;43us;6us;43us;45us;46us;47us;48us;49us;1us;43us;1us;45us;1us;46us;1us;47us;1us;48us;1us;49us;1us;50us;1us;50us;1us;50us;1us;51us;1us;51us;11us;51us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;1us;52us;1us;52us;1us;52us;1us;53us;1us;53us;1us;53us;2us;54us;55us;2us;54us;55us;1us;55us;1us;56us;1us;57us;1us;58us;1us;59us;1us;60us;1us;61us;1us;62us;1us;63us;11us;64us;65us;66us;66us;67us;68us;69us;70us;71us;80us;81us;11us;64us;65us;66us;67us;67us;68us;69us;70us;71us;80us;81us;11us;64us;65us;66us;67us;68us;68us;69us;70us;71us;80us;81us;11us;64us;65us;66us;67us;68us;69us;69us;70us;71us;80us;81us;11us;64us;65us;66us;67us;68us;69us;70us;70us;71us;80us;81us;11us;64us;65us;66us;67us;68us;69us;70us;71us;71us;80us;81us;11us;64us;65us;66us;67us;68us;69us;70us;71us;80us;80us;81us;11us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;81us;11us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;81us;11us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;82us;11us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;119us;11us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;120us;11us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;123us;11us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;124us;11us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;131us;11us;64us;65us;66us;67us;68us;69us;70us;71us;80us;81us;134us;1us;64us;1us;64us;1us;65us;1us;65us;1us;66us;1us;67us;1us;68us;1us;69us;1us;70us;1us;71us;1us;72us;1us;72us;1us;73us;1us;73us;1us;74us;1us;74us;1us;75us;1us;75us;1us;76us;1us;76us;1us;77us;1us;77us;1us;78us;1us;78us;1us;79us;1us;79us;1us;80us;1us;81us;1us;81us;1us;82us;1us;108us;1us;109us;1us;110us;1us;111us;1us;112us;1us;113us;1us;116us;2us;117us;118us;1us;117us;2us;118us;120us;1us;118us;1us;119us;1us;119us;1us;120us;1us;120us;1us;121us;2us;121us;124us;1us;121us;1us;124us;1us;129us;2us;129us;131us;1us;129us;1us;132us;2us;132us;134us;1us;132us;1us;134us;1us;135us;2us;135us;137us;1us;135us;1us;137us;1us;141us;2us;141us;143us;1us;141us;1us;143us;|]
+let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us;2us;4us;10us;12us;14us;16us;18us;20us;22us;24us;27us;29us;31us;33us;35us;47us;49us;51us;53us;60us;62us;64us;66us;68us;70us;72us;74us;76us;88us;90us;92us;104us;106us;108us;110us;112us;114us;116us;118us;120us;123us;125us;127us;129us;131us;143us;148us;150us;158us;160us;163us;165us;173us;175us;177us;179us;181us;183us;185us;187us;189us;191us;193us;195us;197us;199us;201us;203us;205us;207us;209us;211us;213us;215us;217us;219us;221us;223us;225us;227us;229us;236us;238us;240us;242us;244us;246us;248us;250us;252us;254us;256us;258us;270us;272us;274us;276us;278us;280us;282us;285us;288us;290us;292us;294us;296us;298us;300us;302us;304us;306us;318us;330us;342us;354us;366us;378us;390us;402us;414us;426us;438us;450us;462us;474us;486us;498us;500us;502us;504us;506us;508us;510us;512us;514us;516us;518us;520us;522us;524us;526us;528us;530us;532us;534us;536us;538us;540us;542us;544us;546us;548us;550us;552us;554us;556us;558us;560us;562us;564us;566us;568us;570us;572us;575us;577us;580us;582us;584us;586us;588us;590us;592us;595us;597us;599us;601us;604us;606us;608us;611us;613us;615us;617us;620us;622us;624us;626us;629us;631us;|]
+let _fsyacc_action_rows = 191
+let _fsyacc_actionTableElements = [|0us;16386us;0us;49152us;5us;32768us;9us;8us;17us;46us;18us;16us;19us;78us;20us;3us;0us;16385us;0us;16387us;0us;16388us;0us;16389us;0us;16390us;1us;32768us;47us;9us;0us;16392us;2us;32768us;48us;11us;54us;13us;0us;16391us;0us;16393us;1us;32768us;38us;14us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;10us;16394us;21us;153us;22us;154us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;2us;32768us;53us;159us;54us;160us;1us;32768us;47us;18us;0us;16396us;6us;32768us;0us;26us;1us;29us;3us;35us;7us;38us;16us;32us;48us;20us;0us;16395us;0us;16397us;0us;16398us;0us;16399us;0us;16400us;0us;16401us;1us;32768us;38us;27us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;10us;16402us;21us;153us;22us;154us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;1us;32768us;38us;30us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;10us;16403us;21us;153us;22us;154us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;1us;32768us;38us;33us;1us;32768us;45us;183us;0us;16404us;1us;32768us;38us;36us;2us;32768us;58us;164us;59us;163us;0us;16405us;1us;32768us;47us;39us;0us;16407us;2us;32768us;48us;41us;54us;43us;0us;16406us;0us;16408us;1us;32768us;38us;44us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;10us;16409us;21us;153us;22us;154us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;3us;16410us;47us;47us;53us;159us;54us;160us;0us;16414us;7us;32768us;10us;60us;11us;63us;12us;66us;13us;69us;14us;72us;15us;75us;48us;49us;0us;16411us;1us;16412us;47us;51us;0us;16414us;7us;32768us;10us;60us;11us;63us;12us;66us;13us;69us;14us;72us;15us;75us;48us;53us;0us;16413us;0us;16415us;0us;16416us;0us;16417us;0us;16418us;0us;16419us;0us;16420us;1us;32768us;38us;61us;1us;32768us;45us;183us;0us;16421us;1us;32768us;38us;64us;1us;32768us;45us;183us;0us;16422us;1us;32768us;38us;67us;1us;32768us;45us;183us;0us;16423us;1us;32768us;38us;70us;1us;32768us;45us;183us;0us;16424us;1us;32768us;38us;73us;1us;32768us;45us;183us;0us;16425us;1us;32768us;38us;76us;1us;32768us;45us;183us;0us;16426us;1us;32768us;54us;79us;1us;32768us;47us;80us;0us;16428us;7us;32768us;4us;88us;5us;91us;6us;97us;12us;94us;48us;82us;53us;159us;54us;160us;0us;16427us;0us;16429us;0us;16430us;0us;16431us;0us;16432us;0us;16433us;1us;32768us;38us;89us;1us;32768us;45us;187us;0us;16434us;1us;32768us;38us;92us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;10us;16435us;21us;153us;22us;154us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;1us;32768us;38us;95us;1us;32768us;45us;183us;0us;16436us;1us;32768us;38us;98us;2us;32768us;58us;164us;59us;163us;0us;16437us;1us;32768us;54us;101us;1us;16438us;47us;179us;0us;16439us;0us;16440us;0us;16441us;0us;16442us;0us;16443us;0us;16444us;0us;16445us;0us;16446us;0us;16447us;6us;16450us;25us;135us;26us;136us;35us;134us;36us;133us;43us;127us;44us;129us;6us;16451us;25us;135us;26us;136us;35us;134us;36us;133us;43us;127us;44us;129us;4us;16452us;25us;135us;26us;136us;43us;127us;44us;129us;4us;16453us;25us;135us;26us;136us;43us;127us;44us;129us;2us;16454us;43us;127us;44us;129us;2us;16455us;43us;127us;44us;129us;8us;16464us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;11us;32768us;21us;153us;22us;154us;23us;155us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;10us;16465us;21us;153us;22us;154us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;0us;16466us;11us;32768us;21us;153us;22us;154us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;55us;169us;11us;32768us;21us;153us;22us;154us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;55us;171us;10us;16507us;21us;153us;22us;154us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;10us;16508us;21us;153us;22us;154us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;10us;16515us;21us;153us;22us;154us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;10us;16518us;21us;153us;22us;154us;25us;135us;26us;136us;35us;134us;36us;133us;39us;131us;40us;132us;43us;127us;44us;129us;2us;32768us;49us;161us;54us;162us;0us;16448us;2us;32768us;49us;161us;54us;162us;0us;16449us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;1us;32768us;41us;172us;0us;16456us;1us;32768us;41us;172us;0us;16457us;1us;32768us;41us;172us;0us;16458us;1us;32768us;41us;172us;0us;16459us;1us;32768us;41us;172us;0us;16460us;1us;32768us;41us;172us;0us;16461us;1us;32768us;41us;172us;0us;16462us;1us;32768us;41us;172us;0us;16463us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;0us;16492us;0us;16493us;0us;16494us;0us;16495us;0us;16496us;0us;16497us;0us;16500us;2us;32768us;56us;168us;57us;165us;0us;16501us;2us;32768us;56us;170us;57us;167us;0us;16502us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;0us;16503us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;0us;16504us;18us;16506us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;2us;32768us;37us;175us;42us;174us;0us;16505us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;0us;16514us;19us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;46us;178us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;0us;16513us;0us;16517us;2us;32768us;48us;181us;50us;182us;0us;16516us;18us;32768us;24us;156us;27us;137us;28us;139us;29us;141us;30us;143us;31us;145us;32us;147us;33us;149us;34us;151us;45us;176us;47us;179us;49us;108us;51us;109us;58us;164us;59us;163us;60us;105us;61us;106us;62us;107us;0us;16520us;3us;32768us;46us;185us;58us;164us;59us;163us;0us;16519us;0us;16521us;0us;16526us;3us;32768us;46us;189us;52us;157us;54us;158us;0us;16525us;0us;16527us;|]
+let _fsyacc_actionTableRowOffsets = [|0us;1us;2us;8us;9us;10us;11us;12us;13us;15us;16us;19us;20us;21us;23us;42us;53us;56us;58us;59us;66us;67us;68us;69us;70us;71us;72us;74us;93us;104us;106us;125us;136us;138us;140us;141us;143us;146us;147us;149us;150us;153us;154us;155us;157us;176us;187us;191us;192us;200us;201us;203us;204us;212us;213us;214us;215us;216us;217us;218us;219us;221us;223us;224us;226us;228us;229us;231us;233us;234us;236us;238us;239us;241us;243us;244us;246us;248us;249us;251us;253us;254us;262us;263us;264us;265us;266us;267us;268us;270us;272us;273us;275us;294us;305us;307us;309us;310us;312us;315us;316us;318us;320us;321us;322us;323us;324us;325us;326us;327us;328us;329us;336us;343us;348us;353us;356us;359us;368us;380us;391us;392us;404us;416us;427us;438us;449us;460us;463us;464us;467us;468us;487us;506us;525us;544us;563us;582us;584us;585us;587us;588us;590us;591us;593us;594us;596us;597us;599us;600us;602us;603us;605us;606us;625us;644us;663us;682us;683us;684us;685us;686us;687us;688us;689us;692us;693us;696us;697us;716us;717us;736us;737us;756us;759us;760us;779us;780us;800us;801us;802us;805us;806us;825us;826us;830us;831us;832us;833us;837us;838us;|]
+let _fsyacc_reductionSymbolCounts = [|1us;2us;0us;2us;2us;2us;2us;4us;0us;2us;3us;5us;0us;2us;2us;2us;2us;2us;3us;3us;3us;3us;4us;0us;2us;3us;1us;4us;2us;5us;0us;2us;2us;2us;2us;2us;2us;3us;3us;3us;3us;3us;3us;5us;0us;2us;2us;2us;2us;2us;3us;3us;3us;3us;2us;3us;1us;1us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;1us;1us;1us;1us;2us;3us;3us;4us;3us;0us;1us;3us;3us;0us;1us;3us;3us;0us;2us;3us;0us;3us;3us;0us;2us;3us;0us;2us;3us;0us;2us;|]
+let _fsyacc_productionToNonTerminalTable = [|0us;1us;2us;2us;2us;2us;2us;3us;4us;4us;5us;6us;7us;7us;7us;7us;7us;7us;8us;9us;10us;11us;12us;13us;13us;14us;15us;15us;15us;15us;16us;16us;16us;16us;16us;16us;16us;17us;18us;19us;20us;21us;22us;23us;24us;24us;24us;24us;24us;24us;25us;26us;27us;28us;29us;29us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;30us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;31us;32us;32us;33us;33us;34us;34us;35us;35us;36us;36us;36us;37us;37us;38us;39us;39us;39us;40us;41us;41us;41us;42us;43us;43us;44us;45us;45us;46us;47us;47us;48us;49us;49us;50us;51us;51us;|]
+let _fsyacc_immediateActions = [|65535us;49152us;65535us;16385us;16387us;16388us;16389us;16390us;65535us;65535us;65535us;16391us;16393us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16395us;16397us;16398us;16399us;16400us;16401us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16404us;65535us;65535us;16405us;65535us;65535us;65535us;16406us;16408us;65535us;65535us;65535us;65535us;65535us;65535us;16411us;65535us;65535us;65535us;16413us;16415us;16416us;16417us;16418us;16419us;16420us;65535us;65535us;16421us;65535us;65535us;16422us;65535us;65535us;16423us;65535us;65535us;16424us;65535us;65535us;16425us;65535us;65535us;16426us;65535us;65535us;65535us;65535us;16427us;16429us;16430us;16431us;16432us;16433us;65535us;65535us;16434us;65535us;65535us;65535us;65535us;65535us;16436us;65535us;65535us;16437us;65535us;65535us;16439us;16440us;16441us;16442us;16443us;16444us;16445us;16446us;16447us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16448us;65535us;16449us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16456us;65535us;16457us;65535us;16458us;65535us;16459us;65535us;16460us;65535us;16461us;65535us;16462us;65535us;16463us;65535us;65535us;65535us;65535us;16492us;16493us;16494us;16495us;16496us;16497us;16500us;65535us;16501us;65535us;16502us;65535us;16503us;65535us;16504us;65535us;65535us;16505us;65535us;65535us;65535us;16513us;65535us;65535us;16516us;65535us;65535us;65535us;16519us;16521us;65535us;65535us;16525us;16527us;|]
 let _fsyacc_reductions = lazy [|
-# 637 "Gen/ProjectParser.fs"
+# 642 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Terrabuild.Configuration.AST.Project.ProjectFile in
             Microsoft.FSharp.Core.Operators.box
@@ -643,7 +648,7 @@ let _fsyacc_reductions = lazy [|
                       raise (FSharp.Text.Parsing.Accept(Microsoft.FSharp.Core.Operators.box _1))
                    )
                  : 'gentype__startProjectFile));
-# 646 "Gen/ProjectParser.fs"
+# 651 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             Microsoft.FSharp.Core.Operators.box
@@ -654,7 +659,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 62 "ProjectParser/Parser.fsy"
                  : Terrabuild.Configuration.AST.Project.ProjectFile));
-# 657 "Gen/ProjectParser.fs"
+# 662 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -664,7 +669,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 65 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 667 "Gen/ProjectParser.fs"
+# 672 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Locals in
@@ -676,7 +681,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 66 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 679 "Gen/ProjectParser.fs"
+# 684 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Project in
@@ -688,7 +693,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 67 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 691 "Gen/ProjectParser.fs"
+# 696 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Extension in
@@ -700,7 +705,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 68 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 703 "Gen/ProjectParser.fs"
+# 708 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Target in
@@ -712,7 +717,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 69 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectFileComponents));
-# 715 "Gen/ProjectParser.fs"
+# 720 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_LocalsComponents in
             Microsoft.FSharp.Core.Operators.box
@@ -723,7 +728,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 72 "ProjectParser/Parser.fsy"
                  : 'gentype_Locals));
-# 726 "Gen/ProjectParser.fs"
+# 731 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -733,7 +738,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 74 "ProjectParser/Parser.fsy"
                  : 'gentype_LocalsComponents));
-# 736 "Gen/ProjectParser.fs"
+# 741 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_LocalsComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Local in
@@ -745,7 +750,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 75 "ProjectParser/Parser.fsy"
                  : 'gentype_LocalsComponents));
-# 748 "Gen/ProjectParser.fs"
+# 753 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -757,7 +762,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 77 "ProjectParser/Parser.fsy"
                  : 'gentype_Local));
-# 760 "Gen/ProjectParser.fs"
+# 765 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionIdentifier in
             let _4 = parseState.GetInput(4) :?> 'gentype_ExtensionComponents in
@@ -769,7 +774,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 80 "ProjectParser/Parser.fsy"
                  : 'gentype_Extension));
-# 772 "Gen/ProjectParser.fs"
+# 777 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -779,7 +784,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 82 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 782 "Gen/ProjectParser.fs"
+# 787 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionContainer in
@@ -791,7 +796,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 83 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 794 "Gen/ProjectParser.fs"
+# 799 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionPlaform in
@@ -803,7 +808,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 84 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 806 "Gen/ProjectParser.fs"
+# 811 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionVariables in
@@ -815,7 +820,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 85 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 818 "Gen/ProjectParser.fs"
+# 823 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionScript in
@@ -827,7 +832,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 86 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 830 "Gen/ProjectParser.fs"
+# 835 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionDefaults in
@@ -839,7 +844,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 87 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 842 "Gen/ProjectParser.fs"
+# 847 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
@@ -850,7 +855,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 89 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionContainer));
-# 853 "Gen/ProjectParser.fs"
+# 858 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
@@ -861,7 +866,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 91 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionPlaform));
-# 864 "Gen/ProjectParser.fs"
+# 869 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
@@ -872,7 +877,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 93 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionVariables));
-# 875 "Gen/ProjectParser.fs"
+# 880 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
@@ -883,348 +888,382 @@ let _fsyacc_reductions = lazy [|
                    )
 # 95 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionScript));
-# 886 "Gen/ProjectParser.fs"
+# 891 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_ExprMap in
+            let _3 = parseState.GetInput(3) :?> 'gentype_ExtensionDefaultsComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 97 "ProjectParser/Parser.fsy"
-                                                    ExtensionComponents.Defaults _3 
+                                                                                ExtensionComponents.Defaults _3 
                    )
 # 97 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionDefaults));
-# 897 "Gen/ProjectParser.fs"
+# 902 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 101 "ProjectParser/Parser.fsy"
+# 99 "ProjectParser/Parser.fsy"
+                                         [] 
+                   )
+# 99 "ProjectParser/Parser.fsy"
+                 : 'gentype_ExtensionDefaultsComponents));
+# 912 "Gen/ProjectParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionDefaultsComponents in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionDefaultsComponentsVariable in
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 100 "ProjectParser/Parser.fsy"
+                                                                                             _1 @ [_2] 
+                   )
+# 100 "ProjectParser/Parser.fsy"
+                 : 'gentype_ExtensionDefaultsComponents));
+# 924 "Gen/ProjectParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            let _1 = parseState.GetInput(1) :?> string in
+            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 102 "ProjectParser/Parser.fsy"
+                                                   (_1, _3) 
+                   )
+# 102 "ProjectParser/Parser.fsy"
+                 : 'gentype_ExtensionDefaultsComponentsVariable));
+# 936 "Gen/ProjectParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 106 "ProjectParser/Parser.fsy"
                                      ProjectBlock.Build None [] |> ProjectFileComponents.Project 
                    )
-# 101 "ProjectParser/Parser.fsy"
+# 106 "ProjectParser/Parser.fsy"
                  : 'gentype_Project));
-# 907 "Gen/ProjectParser.fs"
+# 946 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ProjectComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 102 "ProjectParser/Parser.fsy"
+# 107 "ProjectParser/Parser.fsy"
                                                                      ProjectBlock.Build None _3 |> ProjectFileComponents.Project 
                    )
-# 102 "ProjectParser/Parser.fsy"
+# 107 "ProjectParser/Parser.fsy"
                  : 'gentype_Project));
-# 918 "Gen/ProjectParser.fs"
+# 957 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionIdentifier in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 103 "ProjectParser/Parser.fsy"
+# 108 "ProjectParser/Parser.fsy"
                                                          ProjectBlock.Build (Some _2) [] |> ProjectFileComponents.Project 
                    )
-# 103 "ProjectParser/Parser.fsy"
+# 108 "ProjectParser/Parser.fsy"
                  : 'gentype_Project));
-# 929 "Gen/ProjectParser.fs"
+# 968 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionIdentifier in
             let _4 = parseState.GetInput(4) :?> 'gentype_ProjectComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 104 "ProjectParser/Parser.fsy"
+# 109 "ProjectParser/Parser.fsy"
                                                                                          ProjectBlock.Build (Some _2) _4 |> ProjectFileComponents.Project 
                    )
-# 104 "ProjectParser/Parser.fsy"
+# 109 "ProjectParser/Parser.fsy"
                  : 'gentype_Project));
-# 941 "Gen/ProjectParser.fs"
+# 980 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 106 "ProjectParser/Parser.fsy"
+# 111 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 106 "ProjectParser/Parser.fsy"
+# 111 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 951 "Gen/ProjectParser.fs"
+# 990 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectDependencies in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 107 "ProjectParser/Parser.fsy"
+# 112 "ProjectParser/Parser.fsy"
                                                                    _1 @ [_2] 
                    )
-# 107 "ProjectParser/Parser.fsy"
+# 112 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 963 "Gen/ProjectParser.fs"
+# 1002 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectLinks in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 108 "ProjectParser/Parser.fsy"
+# 113 "ProjectParser/Parser.fsy"
                                                             _1 @ [_2] 
                    )
-# 108 "ProjectParser/Parser.fsy"
+# 113 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 975 "Gen/ProjectParser.fs"
+# 1014 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectOutputs in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 109 "ProjectParser/Parser.fsy"
+# 114 "ProjectParser/Parser.fsy"
                                                               _1 @ [_2] 
                    )
-# 109 "ProjectParser/Parser.fsy"
+# 114 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 987 "Gen/ProjectParser.fs"
+# 1026 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectIgnores in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 110 "ProjectParser/Parser.fsy"
+# 115 "ProjectParser/Parser.fsy"
                                                               _1 @ [_2] 
                    )
-# 110 "ProjectParser/Parser.fsy"
+# 115 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 999 "Gen/ProjectParser.fs"
+# 1038 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectIncludes in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 111 "ProjectParser/Parser.fsy"
+# 116 "ProjectParser/Parser.fsy"
                                                                _1 @ [_2] 
                    )
-# 111 "ProjectParser/Parser.fsy"
+# 116 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 1011 "Gen/ProjectParser.fs"
+# 1050 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ProjectComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ProjectLabels in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 112 "ProjectParser/Parser.fsy"
+# 117 "ProjectParser/Parser.fsy"
                                                              _1 @ [_2] 
                    )
-# 112 "ProjectParser/Parser.fsy"
+# 117 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectComponents));
-# 1023 "Gen/ProjectParser.fs"
+# 1062 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 114 "ProjectParser/Parser.fsy"
+# 119 "ProjectParser/Parser.fsy"
                                                              ProjectComponents.Dependencies _3 
                    )
-# 114 "ProjectParser/Parser.fsy"
+# 119 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectDependencies));
-# 1034 "Gen/ProjectParser.fs"
+# 1073 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 116 "ProjectParser/Parser.fsy"
+# 121 "ProjectParser/Parser.fsy"
                                                       ProjectComponents.Links _3 
                    )
-# 116 "ProjectParser/Parser.fsy"
+# 121 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectLinks));
-# 1045 "Gen/ProjectParser.fs"
+# 1084 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 118 "ProjectParser/Parser.fsy"
+# 123 "ProjectParser/Parser.fsy"
                                                         ProjectComponents.Outputs _3 
                    )
-# 118 "ProjectParser/Parser.fsy"
+# 123 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectOutputs));
-# 1056 "Gen/ProjectParser.fs"
+# 1095 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 120 "ProjectParser/Parser.fsy"
+# 125 "ProjectParser/Parser.fsy"
                                                         ProjectComponents.Ignores _3 
                    )
-# 120 "ProjectParser/Parser.fsy"
+# 125 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectIgnores));
-# 1067 "Gen/ProjectParser.fs"
+# 1106 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 122 "ProjectParser/Parser.fsy"
+# 127 "ProjectParser/Parser.fsy"
                                                          ProjectComponents.Includes _3 
                    )
-# 122 "ProjectParser/Parser.fsy"
+# 127 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectIncludes));
-# 1078 "Gen/ProjectParser.fs"
+# 1117 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 124 "ProjectParser/Parser.fsy"
+# 129 "ProjectParser/Parser.fsy"
                                                        ProjectComponents.Labels _3 
                    )
-# 124 "ProjectParser/Parser.fsy"
+# 129 "ProjectParser/Parser.fsy"
                  : 'gentype_ProjectLabels));
-# 1089 "Gen/ProjectParser.fs"
+# 1128 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             let _4 = parseState.GetInput(4) :?> 'gentype_TargetComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 127 "ProjectParser/Parser.fsy"
+# 132 "ProjectParser/Parser.fsy"
                                                                               TargetBlock.Build _2 _4 |> ProjectFileComponents.Target 
                    )
-# 127 "ProjectParser/Parser.fsy"
+# 132 "ProjectParser/Parser.fsy"
                  : 'gentype_Target));
-# 1101 "Gen/ProjectParser.fs"
+# 1140 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 129 "ProjectParser/Parser.fsy"
+# 134 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 129 "ProjectParser/Parser.fsy"
+# 134 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 1111 "Gen/ProjectParser.fs"
+# 1150 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetDependsOn in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 130 "ProjectParser/Parser.fsy"
+# 135 "ProjectParser/Parser.fsy"
                                                               _1 @ [_2] 
                    )
-# 130 "ProjectParser/Parser.fsy"
+# 135 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 1123 "Gen/ProjectParser.fs"
+# 1162 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetRebuild in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 131 "ProjectParser/Parser.fsy"
+# 136 "ProjectParser/Parser.fsy"
                                                             _1 @ [_2] 
                    )
-# 131 "ProjectParser/Parser.fsy"
+# 136 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 1135 "Gen/ProjectParser.fs"
+# 1174 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetOutputs in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 132 "ProjectParser/Parser.fsy"
+# 137 "ProjectParser/Parser.fsy"
                                                             _1 @ [_2] 
                    )
-# 132 "ProjectParser/Parser.fsy"
+# 137 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 1147 "Gen/ProjectParser.fs"
+# 1186 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetCache in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 133 "ProjectParser/Parser.fsy"
+# 138 "ProjectParser/Parser.fsy"
                                                           _1 @ [_2] 
                    )
-# 133 "ProjectParser/Parser.fsy"
+# 138 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 1159 "Gen/ProjectParser.fs"
+# 1198 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetStep in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 134 "ProjectParser/Parser.fsy"
+# 139 "ProjectParser/Parser.fsy"
                                                          _1 @ [_2] 
                    )
-# 134 "ProjectParser/Parser.fsy"
+# 139 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 1171 "Gen/ProjectParser.fs"
+# 1210 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfTargetIdentifiers in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 136 "ProjectParser/Parser.fsy"
+# 141 "ProjectParser/Parser.fsy"
                                                                       TargetComponents.DependsOn _3 
                    )
-# 136 "ProjectParser/Parser.fsy"
+# 141 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetDependsOn));
-# 1182 "Gen/ProjectParser.fs"
+# 1221 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 138 "ProjectParser/Parser.fsy"
+# 143 "ProjectParser/Parser.fsy"
                                                 TargetComponents.Rebuild _3 
                    )
-# 138 "ProjectParser/Parser.fsy"
+# 143 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetRebuild));
-# 1193 "Gen/ProjectParser.fs"
+# 1232 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 140 "ProjectParser/Parser.fsy"
+# 145 "ProjectParser/Parser.fsy"
                                                         TargetComponents.Outputs _3 
                    )
-# 140 "ProjectParser/Parser.fsy"
+# 145 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetOutputs));
-# 1204 "Gen/ProjectParser.fs"
+# 1243 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 142 "ProjectParser/Parser.fsy"
+# 147 "ProjectParser/Parser.fsy"
                                                 TargetComponents.Cache _3 
                    )
-# 142 "ProjectParser/Parser.fsy"
+# 147 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetCache));
-# 1215 "Gen/ProjectParser.fs"
+# 1254 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionIdentifier in
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 144 "ProjectParser/Parser.fsy"
+# 149 "ProjectParser/Parser.fsy"
                                                             TargetComponents.Step { Extension = _1; Command = _2; Parameters = Map.empty } 
                    )
-# 144 "ProjectParser/Parser.fsy"
+# 149 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetStep));
-# 1227 "Gen/ProjectParser.fs"
+# 1266 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionIdentifier in
             let _2 = parseState.GetInput(2) :?> string in
@@ -1232,293 +1271,293 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 145 "ProjectParser/Parser.fsy"
+# 150 "ProjectParser/Parser.fsy"
                                                                     TargetComponents.Step { Extension = _1; Command = _2; Parameters = _3 } 
                    )
-# 145 "ProjectParser/Parser.fsy"
+# 150 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetStep));
-# 1240 "Gen/ProjectParser.fs"
+# 1279 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprList in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 149 "ProjectParser/Parser.fsy"
+# 154 "ProjectParser/Parser.fsy"
                                       Expr.List _1 
                    )
-# 149 "ProjectParser/Parser.fsy"
+# 154 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1251 "Gen/ProjectParser.fs"
+# 1290 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprMap in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 150 "ProjectParser/Parser.fsy"
+# 155 "ProjectParser/Parser.fsy"
                                      Expr.Map _1 
                    )
-# 150 "ProjectParser/Parser.fsy"
+# 155 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1262 "Gen/ProjectParser.fs"
+# 1301 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 152 "ProjectParser/Parser.fsy"
+# 157 "ProjectParser/Parser.fsy"
                                      Expr.Nothing 
                    )
-# 152 "ProjectParser/Parser.fsy"
+# 157 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1272 "Gen/ProjectParser.fs"
+# 1311 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 153 "ProjectParser/Parser.fsy"
+# 158 "ProjectParser/Parser.fsy"
                                   Expr.Bool true 
                    )
-# 153 "ProjectParser/Parser.fsy"
+# 158 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1282 "Gen/ProjectParser.fs"
+# 1321 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 154 "ProjectParser/Parser.fsy"
+# 159 "ProjectParser/Parser.fsy"
                                    Expr.Bool false 
                    )
-# 154 "ProjectParser/Parser.fsy"
+# 159 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1292 "Gen/ProjectParser.fs"
+# 1331 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 155 "ProjectParser/Parser.fsy"
+# 160 "ProjectParser/Parser.fsy"
                                     Expr.Number _1 
                    )
-# 155 "ProjectParser/Parser.fsy"
+# 160 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1303 "Gen/ProjectParser.fs"
+# 1342 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 156 "ProjectParser/Parser.fsy"
+# 161 "ProjectParser/Parser.fsy"
                                       Expr.Variable _1 
                    )
-# 156 "ProjectParser/Parser.fsy"
+# 161 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1314 "Gen/ProjectParser.fs"
+# 1353 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 157 "ProjectParser/Parser.fsy"
+# 162 "ProjectParser/Parser.fsy"
                                     _1 
                    )
-# 157 "ProjectParser/Parser.fsy"
+# 162 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1325 "Gen/ProjectParser.fs"
+# 1364 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 159 "ProjectParser/Parser.fsy"
+# 164 "ProjectParser/Parser.fsy"
                                                 Expr.Function (Function.Item, [_1;  _3]) 
                    )
-# 159 "ProjectParser/Parser.fsy"
+# 164 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1337 "Gen/ProjectParser.fs"
+# 1376 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 160 "ProjectParser/Parser.fsy"
+# 165 "ProjectParser/Parser.fsy"
                                                          Expr.Function (Function.TryItem, [_1; _3]) 
                    )
-# 160 "ProjectParser/Parser.fsy"
+# 165 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1349 "Gen/ProjectParser.fs"
+# 1388 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 161 "ProjectParser/Parser.fsy"
+# 166 "ProjectParser/Parser.fsy"
                                                     Expr.Function (Function.Equal, [_1; _3]) 
                    )
-# 161 "ProjectParser/Parser.fsy"
+# 166 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1361 "Gen/ProjectParser.fs"
+# 1400 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 162 "ProjectParser/Parser.fsy"
+# 167 "ProjectParser/Parser.fsy"
                                                  Expr.Function (Function.NotEqual, [_1; _3]) 
                    )
-# 162 "ProjectParser/Parser.fsy"
+# 167 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1373 "Gen/ProjectParser.fs"
+# 1412 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 163 "ProjectParser/Parser.fsy"
+# 168 "ProjectParser/Parser.fsy"
                                             Expr.Function (Function.Plus, [_1; _3]) 
                    )
-# 163 "ProjectParser/Parser.fsy"
+# 168 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1385 "Gen/ProjectParser.fs"
+# 1424 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 164 "ProjectParser/Parser.fsy"
+# 169 "ProjectParser/Parser.fsy"
                                              Expr.Function (Function.Minus, [_1; _3]) 
                    )
-# 164 "ProjectParser/Parser.fsy"
+# 169 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1397 "Gen/ProjectParser.fs"
+# 1436 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 165 "ProjectParser/Parser.fsy"
+# 170 "ProjectParser/Parser.fsy"
                                            Expr.Function (Function.And, [_1; _3]) 
                    )
-# 165 "ProjectParser/Parser.fsy"
+# 170 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1409 "Gen/ProjectParser.fs"
+# 1448 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 166 "ProjectParser/Parser.fsy"
+# 171 "ProjectParser/Parser.fsy"
                                           Expr.Function (Function.Or, [_1; _3]) 
                    )
-# 166 "ProjectParser/Parser.fsy"
+# 171 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1421 "Gen/ProjectParser.fs"
+# 1460 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 167 "ProjectParser/Parser.fsy"
+# 172 "ProjectParser/Parser.fsy"
                                             Expr.Function (Function.Trim, _2) 
                    )
-# 167 "ProjectParser/Parser.fsy"
+# 172 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1432 "Gen/ProjectParser.fs"
+# 1471 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 168 "ProjectParser/Parser.fsy"
+# 173 "ProjectParser/Parser.fsy"
                                              Expr.Function (Function.Upper, _2) 
                    )
-# 168 "ProjectParser/Parser.fsy"
+# 173 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1443 "Gen/ProjectParser.fs"
+# 1482 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 169 "ProjectParser/Parser.fsy"
+# 174 "ProjectParser/Parser.fsy"
                                              Expr.Function (Function.Lower, _2) 
                    )
-# 169 "ProjectParser/Parser.fsy"
+# 174 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1454 "Gen/ProjectParser.fs"
+# 1493 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 170 "ProjectParser/Parser.fsy"
+# 175 "ProjectParser/Parser.fsy"
                                                Expr.Function (Function.Replace, _2) 
                    )
-# 170 "ProjectParser/Parser.fsy"
+# 175 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1465 "Gen/ProjectParser.fs"
+# 1504 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 171 "ProjectParser/Parser.fsy"
+# 176 "ProjectParser/Parser.fsy"
                                              Expr.Function (Function.Count, _2)
                    )
-# 171 "ProjectParser/Parser.fsy"
+# 176 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1476 "Gen/ProjectParser.fs"
+# 1515 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 172 "ProjectParser/Parser.fsy"
+# 177 "ProjectParser/Parser.fsy"
                                                Expr.Function (Function.Version, _2) 
                    )
-# 172 "ProjectParser/Parser.fsy"
+# 177 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1487 "Gen/ProjectParser.fs"
+# 1526 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 173 "ProjectParser/Parser.fsy"
+# 178 "ProjectParser/Parser.fsy"
                                               Expr.Function (Function.Format, _2) 
                    )
-# 173 "ProjectParser/Parser.fsy"
+# 178 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1498 "Gen/ProjectParser.fs"
+# 1537 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 174 "ProjectParser/Parser.fsy"
+# 179 "ProjectParser/Parser.fsy"
                                                 Expr.Function (Function.ToString, _2) 
                    )
-# 174 "ProjectParser/Parser.fsy"
+# 179 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1509 "Gen/ProjectParser.fs"
+# 1548 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 175 "ProjectParser/Parser.fsy"
+# 180 "ProjectParser/Parser.fsy"
                                                        Expr.Function (Function.Coalesce, [_1; _3]) 
                    )
-# 175 "ProjectParser/Parser.fsy"
+# 180 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1521 "Gen/ProjectParser.fs"
+# 1560 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1526,282 +1565,282 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 176 "ProjectParser/Parser.fsy"
+# 181 "ProjectParser/Parser.fsy"
                                                            Expr.Function (Function.Ternary, [_1; _3; _5] ) 
                    )
-# 176 "ProjectParser/Parser.fsy"
+# 181 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1534 "Gen/ProjectParser.fs"
+# 1573 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 177 "ProjectParser/Parser.fsy"
+# 182 "ProjectParser/Parser.fsy"
                                        Expr.Function (Function.Not, [_2]) 
                    )
-# 177 "ProjectParser/Parser.fsy"
+# 182 "ProjectParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1545 "Gen/ProjectParser.fs"
+# 1584 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 181 "ProjectParser/Parser.fsy"
+# 186 "ProjectParser/Parser.fsy"
                                      Expr.Nothing 
                    )
-# 181 "ProjectParser/Parser.fsy"
+# 186 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1555 "Gen/ProjectParser.fs"
+# 1594 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 182 "ProjectParser/Parser.fsy"
+# 187 "ProjectParser/Parser.fsy"
                                   Expr.Bool true 
                    )
-# 182 "ProjectParser/Parser.fsy"
+# 187 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1565 "Gen/ProjectParser.fs"
+# 1604 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 183 "ProjectParser/Parser.fsy"
+# 188 "ProjectParser/Parser.fsy"
                                    Expr.Bool false 
                    )
-# 183 "ProjectParser/Parser.fsy"
+# 188 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1575 "Gen/ProjectParser.fs"
+# 1614 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 184 "ProjectParser/Parser.fsy"
+# 189 "ProjectParser/Parser.fsy"
                                     Expr.Number _1 
                    )
-# 184 "ProjectParser/Parser.fsy"
+# 189 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1586 "Gen/ProjectParser.fs"
+# 1625 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 185 "ProjectParser/Parser.fsy"
+# 190 "ProjectParser/Parser.fsy"
                                       Expr.Variable _1 
                    )
-# 185 "ProjectParser/Parser.fsy"
+# 190 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1597 "Gen/ProjectParser.fs"
+# 1636 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 186 "ProjectParser/Parser.fsy"
+# 191 "ProjectParser/Parser.fsy"
                                     Expr.String _1 
                    )
-# 186 "ProjectParser/Parser.fsy"
+# 191 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1608 "Gen/ProjectParser.fs"
+# 1647 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 188 "ProjectParser/Parser.fsy"
+# 193 "ProjectParser/Parser.fsy"
                                                             Expr.Function (Function.Item, [_1;  _3]) 
                    )
-# 188 "ProjectParser/Parser.fsy"
+# 193 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1620 "Gen/ProjectParser.fs"
+# 1659 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 189 "ProjectParser/Parser.fsy"
+# 194 "ProjectParser/Parser.fsy"
                                                                      Expr.Function (Function.TryItem, [_1; _3]) 
                    )
-# 189 "ProjectParser/Parser.fsy"
+# 194 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1632 "Gen/ProjectParser.fs"
+# 1671 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 190 "ProjectParser/Parser.fsy"
+# 195 "ProjectParser/Parser.fsy"
                                                                             Expr.Function (Function.Equal, [_1; _3]) 
                    )
-# 190 "ProjectParser/Parser.fsy"
+# 195 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1644 "Gen/ProjectParser.fs"
+# 1683 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 191 "ProjectParser/Parser.fsy"
+# 196 "ProjectParser/Parser.fsy"
                                                                          Expr.Function (Function.NotEqual, [_1; _3]) 
                    )
-# 191 "ProjectParser/Parser.fsy"
+# 196 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1656 "Gen/ProjectParser.fs"
+# 1695 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 192 "ProjectParser/Parser.fsy"
+# 197 "ProjectParser/Parser.fsy"
                                                                     Expr.Function (Function.Plus, [_1; _3]) 
                    )
-# 192 "ProjectParser/Parser.fsy"
+# 197 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1668 "Gen/ProjectParser.fs"
+# 1707 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 193 "ProjectParser/Parser.fsy"
+# 198 "ProjectParser/Parser.fsy"
                                                                      Expr.Function (Function.Minus, [_1; _3]) 
                    )
-# 193 "ProjectParser/Parser.fsy"
+# 198 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1680 "Gen/ProjectParser.fs"
+# 1719 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 194 "ProjectParser/Parser.fsy"
+# 199 "ProjectParser/Parser.fsy"
                                                                    Expr.Function (Function.And, [_1; _3]) 
                    )
-# 194 "ProjectParser/Parser.fsy"
+# 199 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1692 "Gen/ProjectParser.fs"
+# 1731 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 195 "ProjectParser/Parser.fsy"
+# 200 "ProjectParser/Parser.fsy"
                                                                   Expr.Function (Function.Or, [_1; _3]) 
                    )
-# 195 "ProjectParser/Parser.fsy"
+# 200 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1704 "Gen/ProjectParser.fs"
+# 1743 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 196 "ProjectParser/Parser.fsy"
+# 201 "ProjectParser/Parser.fsy"
                                                         Expr.Function (Function.Trim, _2) 
                    )
-# 196 "ProjectParser/Parser.fsy"
+# 201 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1715 "Gen/ProjectParser.fs"
+# 1754 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 197 "ProjectParser/Parser.fsy"
+# 202 "ProjectParser/Parser.fsy"
                                                          Expr.Function (Function.Upper, _2) 
                    )
-# 197 "ProjectParser/Parser.fsy"
+# 202 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1726 "Gen/ProjectParser.fs"
+# 1765 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 198 "ProjectParser/Parser.fsy"
+# 203 "ProjectParser/Parser.fsy"
                                                          Expr.Function (Function.Lower, _2) 
                    )
-# 198 "ProjectParser/Parser.fsy"
+# 203 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1737 "Gen/ProjectParser.fs"
+# 1776 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 199 "ProjectParser/Parser.fsy"
+# 204 "ProjectParser/Parser.fsy"
                                                            Expr.Function (Function.Replace, _2) 
                    )
-# 199 "ProjectParser/Parser.fsy"
+# 204 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1748 "Gen/ProjectParser.fs"
+# 1787 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 200 "ProjectParser/Parser.fsy"
+# 205 "ProjectParser/Parser.fsy"
                                                          Expr.Function (Function.Count, _2)
                    )
-# 200 "ProjectParser/Parser.fsy"
+# 205 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1759 "Gen/ProjectParser.fs"
+# 1798 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 201 "ProjectParser/Parser.fsy"
+# 206 "ProjectParser/Parser.fsy"
                                                            Expr.Function (Function.Version, _2) 
                    )
-# 201 "ProjectParser/Parser.fsy"
+# 206 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1770 "Gen/ProjectParser.fs"
+# 1809 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 202 "ProjectParser/Parser.fsy"
+# 207 "ProjectParser/Parser.fsy"
                                                           Expr.Function (Function.Format, _2) 
                    )
-# 202 "ProjectParser/Parser.fsy"
+# 207 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1781 "Gen/ProjectParser.fs"
+# 1820 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 203 "ProjectParser/Parser.fsy"
+# 208 "ProjectParser/Parser.fsy"
                                                             Expr.Function (Function.ToString, _2) 
                    )
-# 203 "ProjectParser/Parser.fsy"
+# 208 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1792 "Gen/ProjectParser.fs"
+# 1831 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 204 "ProjectParser/Parser.fsy"
+# 209 "ProjectParser/Parser.fsy"
                                                                                Expr.Function (Function.Coalesce, [_1; _3]) 
                    )
-# 204 "ProjectParser/Parser.fsy"
+# 209 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1804 "Gen/ProjectParser.fs"
+# 1843 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
@@ -1809,161 +1848,161 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 205 "ProjectParser/Parser.fsy"
+# 210 "ProjectParser/Parser.fsy"
                                                                                    Expr.Function (Function.Ternary, [_1; _3; _5] ) 
                    )
-# 205 "ProjectParser/Parser.fsy"
+# 210 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1817 "Gen/ProjectParser.fs"
+# 1856 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 206 "ProjectParser/Parser.fsy"
+# 211 "ProjectParser/Parser.fsy"
                                                    Expr.Function (Function.Not, [_2]) 
                    )
-# 206 "ProjectParser/Parser.fsy"
+# 211 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1828 "Gen/ProjectParser.fs"
+# 1867 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 209 "ProjectParser/Parser.fsy"
+# 214 "ProjectParser/Parser.fsy"
                                                _1 
                    )
-# 209 "ProjectParser/Parser.fsy"
+# 214 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetIdentifier));
-# 1839 "Gen/ProjectParser.fs"
+# 1878 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 210 "ProjectParser/Parser.fsy"
+# 215 "ProjectParser/Parser.fsy"
                                         _1 
                    )
-# 210 "ProjectParser/Parser.fsy"
+# 215 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetIdentifier));
-# 1850 "Gen/ProjectParser.fs"
+# 1889 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 213 "ProjectParser/Parser.fsy"
+# 218 "ProjectParser/Parser.fsy"
                                                   _1 
                    )
-# 213 "ProjectParser/Parser.fsy"
+# 218 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionIdentifier));
-# 1861 "Gen/ProjectParser.fs"
+# 1900 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 214 "ProjectParser/Parser.fsy"
+# 219 "ProjectParser/Parser.fsy"
                                         _1 
                    )
-# 214 "ProjectParser/Parser.fsy"
+# 219 "ProjectParser/Parser.fsy"
                  : 'gentype_ExtensionIdentifier));
-# 1872 "Gen/ProjectParser.fs"
+# 1911 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 217 "ProjectParser/Parser.fsy"
+# 222 "ProjectParser/Parser.fsy"
                                     Expr.Number _1 
                    )
-# 217 "ProjectParser/Parser.fsy"
+# 222 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprIndex));
-# 1883 "Gen/ProjectParser.fs"
+# 1922 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 218 "ProjectParser/Parser.fsy"
+# 223 "ProjectParser/Parser.fsy"
                                         Expr.String _1 
                    )
-# 218 "ProjectParser/Parser.fsy"
+# 223 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprIndex));
-# 1894 "Gen/ProjectParser.fs"
+# 1933 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 221 "ProjectParser/Parser.fsy"
+# 226 "ProjectParser/Parser.fsy"
                                   true 
                    )
-# 221 "ProjectParser/Parser.fsy"
+# 226 "ProjectParser/Parser.fsy"
                  : 'gentype_Bool));
-# 1904 "Gen/ProjectParser.fs"
+# 1943 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 222 "ProjectParser/Parser.fsy"
+# 227 "ProjectParser/Parser.fsy"
                                    false 
                    )
-# 222 "ProjectParser/Parser.fsy"
+# 227 "ProjectParser/Parser.fsy"
                  : 'gentype_Bool));
-# 1914 "Gen/ProjectParser.fs"
+# 1953 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 225 "ProjectParser/Parser.fsy"
+# 230 "ProjectParser/Parser.fsy"
                                     Expr.String _1 
                    )
-# 225 "ProjectParser/Parser.fsy"
+# 230 "ProjectParser/Parser.fsy"
                  : 'gentype_String));
-# 1925 "Gen/ProjectParser.fs"
+# 1964 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 226 "ProjectParser/Parser.fsy"
+# 231 "ProjectParser/Parser.fsy"
                                                      Expr.String _2 
                    )
-# 226 "ProjectParser/Parser.fsy"
+# 231 "ProjectParser/Parser.fsy"
                  : 'gentype_String));
-# 1936 "Gen/ProjectParser.fs"
+# 1975 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedString in
             let _3 = parseState.GetInput(3) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 227 "ProjectParser/Parser.fsy"
+# 232 "ProjectParser/Parser.fsy"
                                                                         
                              if _3 |> String.IsNullOrEmpty then Expr.Function (Function.ToString, [_2])
                              else Expr.Function (Function.Format, [Expr.String "{0}{1}"; _2; Expr.String _3]) 
                          
                    )
-# 227 "ProjectParser/Parser.fsy"
+# 232 "ProjectParser/Parser.fsy"
                  : 'gentype_String));
-# 1951 "Gen/ProjectParser.fs"
+# 1990 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 233 "ProjectParser/Parser.fsy"
+# 238 "ProjectParser/Parser.fsy"
                                                                   
                              if _1 |> String.IsNullOrEmpty then _2
                              else Expr.Function (Function.Format, [Expr.String "{0}{1}"; Expr.String _1; _2])
                          
                    )
-# 233 "ProjectParser/Parser.fsy"
+# 238 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedString));
-# 1966 "Gen/ProjectParser.fs"
+# 2005 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedString in
             let _2 = parseState.GetInput(2) :?> string in
@@ -1971,157 +2010,157 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 237 "ProjectParser/Parser.fsy"
+# 242 "ProjectParser/Parser.fsy"
                                                                                     
                              if _2 |> String.IsNullOrEmpty then Expr.Function (Function.Format, [Expr.String "{0}{1}"; _1; _3])
                              else Expr.Function (Function.Format, [Expr.String "{0}{1}{2}"; _1; Expr.String _2; _3])
                          
                    )
-# 237 "ProjectParser/Parser.fsy"
+# 242 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedString));
-# 1982 "Gen/ProjectParser.fs"
+# 2021 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTupleContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 243 "ProjectParser/Parser.fsy"
+# 248 "ProjectParser/Parser.fsy"
                                                             _2 
                    )
-# 243 "ProjectParser/Parser.fsy"
+# 248 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprTuple));
-# 1993 "Gen/ProjectParser.fs"
+# 2032 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 245 "ProjectParser/Parser.fsy"
+# 250 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 245 "ProjectParser/Parser.fsy"
+# 250 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprTupleContent));
-# 2003 "Gen/ProjectParser.fs"
+# 2042 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 246 "ProjectParser/Parser.fsy"
+# 251 "ProjectParser/Parser.fsy"
                                   [_1] 
                    )
-# 246 "ProjectParser/Parser.fsy"
+# 251 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprTupleContent));
-# 2014 "Gen/ProjectParser.fs"
+# 2053 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprTupleContent in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 247 "ProjectParser/Parser.fsy"
+# 252 "ProjectParser/Parser.fsy"
                                                          _1 @ [_3] 
                    )
-# 247 "ProjectParser/Parser.fsy"
+# 252 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprTupleContent));
-# 2026 "Gen/ProjectParser.fs"
+# 2065 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTupleContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 250 "ProjectParser/Parser.fsy"
+# 255 "ProjectParser/Parser.fsy"
                                                                         _2 
                    )
-# 250 "ProjectParser/Parser.fsy"
+# 255 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExprTuple));
-# 2037 "Gen/ProjectParser.fs"
+# 2076 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 252 "ProjectParser/Parser.fsy"
+# 257 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 252 "ProjectParser/Parser.fsy"
+# 257 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExprTupleContent));
-# 2047 "Gen/ProjectParser.fs"
+# 2086 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 253 "ProjectParser/Parser.fsy"
+# 258 "ProjectParser/Parser.fsy"
                                               [_1] 
                    )
-# 253 "ProjectParser/Parser.fsy"
+# 258 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExprTupleContent));
-# 2058 "Gen/ProjectParser.fs"
+# 2097 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExprTupleContent in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 254 "ProjectParser/Parser.fsy"
+# 259 "ProjectParser/Parser.fsy"
                                                                                  _1 @ [_3] 
                    )
-# 254 "ProjectParser/Parser.fsy"
+# 259 "ProjectParser/Parser.fsy"
                  : 'gentype_InterpolatedExprTupleContent));
-# 2070 "Gen/ProjectParser.fs"
+# 2109 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprListContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 257 "ProjectParser/Parser.fsy"
+# 262 "ProjectParser/Parser.fsy"
                                                                    _2 
                    )
-# 257 "ProjectParser/Parser.fsy"
+# 262 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprList));
-# 2081 "Gen/ProjectParser.fs"
+# 2120 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 259 "ProjectParser/Parser.fsy"
+# 264 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 259 "ProjectParser/Parser.fsy"
+# 264 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprListContent));
-# 2091 "Gen/ProjectParser.fs"
+# 2130 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprListContent in
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 260 "ProjectParser/Parser.fsy"
+# 265 "ProjectParser/Parser.fsy"
                                                   _1 @ [_2] 
                    )
-# 260 "ProjectParser/Parser.fsy"
+# 265 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprListContent));
-# 2103 "Gen/ProjectParser.fs"
+# 2142 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprMapContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 263 "ProjectParser/Parser.fsy"
+# 268 "ProjectParser/Parser.fsy"
                                                           _2 
                    )
-# 263 "ProjectParser/Parser.fsy"
+# 268 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprMap));
-# 2114 "Gen/ProjectParser.fs"
+# 2153 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 265 "ProjectParser/Parser.fsy"
+# 270 "ProjectParser/Parser.fsy"
                                          Map.empty 
                    )
-# 265 "ProjectParser/Parser.fsy"
+# 270 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprMapContent));
-# 2124 "Gen/ProjectParser.fs"
+# 2163 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprMapContent in
             let _2 = parseState.GetInput(2) :?> string in
@@ -2129,112 +2168,112 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 266 "ProjectParser/Parser.fsy"
+# 271 "ProjectParser/Parser.fsy"
                                                      _1.Add (_2, _3) 
                    )
-# 266 "ProjectParser/Parser.fsy"
+# 271 "ProjectParser/Parser.fsy"
                  : 'gentype_ExprMapContent));
-# 2137 "Gen/ProjectParser.fs"
+# 2176 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Strings in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 269 "ProjectParser/Parser.fsy"
+# 274 "ProjectParser/Parser.fsy"
                                                            _2 
                    )
-# 269 "ProjectParser/Parser.fsy"
+# 274 "ProjectParser/Parser.fsy"
                  : 'gentype_ListOfString));
-# 2148 "Gen/ProjectParser.fs"
+# 2187 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 271 "ProjectParser/Parser.fsy"
+# 276 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 271 "ProjectParser/Parser.fsy"
+# 276 "ProjectParser/Parser.fsy"
                  : 'gentype_Strings));
-# 2158 "Gen/ProjectParser.fs"
+# 2197 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Strings in
             let _2 = parseState.GetInput(2) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 272 "ProjectParser/Parser.fsy"
+# 277 "ProjectParser/Parser.fsy"
                                             _1 @ [_2] 
                    )
-# 272 "ProjectParser/Parser.fsy"
+# 277 "ProjectParser/Parser.fsy"
                  : 'gentype_Strings));
-# 2170 "Gen/ProjectParser.fs"
+# 2209 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Identifiers in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 275 "ProjectParser/Parser.fsy"
+# 280 "ProjectParser/Parser.fsy"
                                                                _2 
                    )
-# 275 "ProjectParser/Parser.fsy"
+# 280 "ProjectParser/Parser.fsy"
                  : 'gentype_ListOfIdentifiers));
-# 2181 "Gen/ProjectParser.fs"
+# 2220 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 277 "ProjectParser/Parser.fsy"
+# 282 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 277 "ProjectParser/Parser.fsy"
+# 282 "ProjectParser/Parser.fsy"
                  : 'gentype_Identifiers));
-# 2191 "Gen/ProjectParser.fs"
+# 2230 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Identifiers in
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 278 "ProjectParser/Parser.fsy"
+# 283 "ProjectParser/Parser.fsy"
                                                     _1 @ [_2] 
                    )
-# 278 "ProjectParser/Parser.fsy"
+# 283 "ProjectParser/Parser.fsy"
                  : 'gentype_Identifiers));
-# 2203 "Gen/ProjectParser.fs"
+# 2242 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetIdentifiers in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 281 "ProjectParser/Parser.fsy"
+# 286 "ProjectParser/Parser.fsy"
                                                                      _2 
                    )
-# 281 "ProjectParser/Parser.fsy"
+# 286 "ProjectParser/Parser.fsy"
                  : 'gentype_ListOfTargetIdentifiers));
-# 2214 "Gen/ProjectParser.fs"
+# 2253 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 283 "ProjectParser/Parser.fsy"
+# 288 "ProjectParser/Parser.fsy"
                                          [] 
                    )
-# 283 "ProjectParser/Parser.fsy"
+# 288 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetIdentifiers));
-# 2224 "Gen/ProjectParser.fs"
+# 2263 "Gen/ProjectParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetIdentifiers in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetIdentifier in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 284 "ProjectParser/Parser.fsy"
+# 289 "ProjectParser/Parser.fsy"
                                                                 _1 @ [_2] 
                    )
-# 284 "ProjectParser/Parser.fsy"
+# 289 "ProjectParser/Parser.fsy"
                  : 'gentype_TargetIdentifiers));
 |]
-# 2237 "Gen/ProjectParser.fs"
+# 2276 "Gen/ProjectParser.fs"
 let tables : FSharp.Text.Parsing.Tables<_> = 
   { reductions = _fsyacc_reductions.Value;
     endOfInputTag = _fsyacc_endOfInputTag;

--- a/src/Terrabuild.Configuration/Gen/ProjectParser.fsi
+++ b/src/Terrabuild.Configuration/Gen/ProjectParser.fsi
@@ -144,6 +144,8 @@ type nonTerminalId =
     | NONTERM_ExtensionVariables
     | NONTERM_ExtensionScript
     | NONTERM_ExtensionDefaults
+    | NONTERM_ExtensionDefaultsComponents
+    | NONTERM_ExtensionDefaultsComponentsVariable
     | NONTERM_Project
     | NONTERM_ProjectComponents
     | NONTERM_ProjectDependencies

--- a/src/Terrabuild.Configuration/Gen/WorkspaceParser.fs
+++ b/src/Terrabuild.Configuration/Gen/WorkspaceParser.fs
@@ -166,6 +166,8 @@ type nonTerminalId =
     | NONTERM_ExtensionVariables
     | NONTERM_ExtensionScript
     | NONTERM_ExtensionDefaults
+    | NONTERM_ExtensionDefaultsComponents
+    | NONTERM_ExtensionDefaultsComponentsVariable
     | NONTERM_Expr
     | NONTERM_InterpolatedExpr
     | NONTERM_TargetIdentifier
@@ -357,9 +359,9 @@ let prodIdxToNonTerminal (prodIdx:int) =
     | 35 -> NONTERM_ExtensionVariables 
     | 36 -> NONTERM_ExtensionScript 
     | 37 -> NONTERM_ExtensionDefaults 
-    | 38 -> NONTERM_Expr 
-    | 39 -> NONTERM_Expr 
-    | 40 -> NONTERM_Expr 
+    | 38 -> NONTERM_ExtensionDefaultsComponents 
+    | 39 -> NONTERM_ExtensionDefaultsComponents 
+    | 40 -> NONTERM_ExtensionDefaultsComponentsVariable 
     | 41 -> NONTERM_Expr 
     | 42 -> NONTERM_Expr 
     | 43 -> NONTERM_Expr 
@@ -384,9 +386,9 @@ let prodIdxToNonTerminal (prodIdx:int) =
     | 62 -> NONTERM_Expr 
     | 63 -> NONTERM_Expr 
     | 64 -> NONTERM_Expr 
-    | 65 -> NONTERM_InterpolatedExpr 
-    | 66 -> NONTERM_InterpolatedExpr 
-    | 67 -> NONTERM_InterpolatedExpr 
+    | 65 -> NONTERM_Expr 
+    | 66 -> NONTERM_Expr 
+    | 67 -> NONTERM_Expr 
     | 68 -> NONTERM_InterpolatedExpr 
     | 69 -> NONTERM_InterpolatedExpr 
     | 70 -> NONTERM_InterpolatedExpr 
@@ -408,39 +410,42 @@ let prodIdxToNonTerminal (prodIdx:int) =
     | 86 -> NONTERM_InterpolatedExpr 
     | 87 -> NONTERM_InterpolatedExpr 
     | 88 -> NONTERM_InterpolatedExpr 
-    | 89 -> NONTERM_TargetIdentifier 
-    | 90 -> NONTERM_TargetIdentifier 
-    | 91 -> NONTERM_ExtensionIdentifier 
-    | 92 -> NONTERM_ExtensionIdentifier 
-    | 93 -> NONTERM_ExprIndex 
-    | 94 -> NONTERM_ExprIndex 
-    | 95 -> NONTERM_Bool 
-    | 96 -> NONTERM_Bool 
-    | 97 -> NONTERM_String 
-    | 98 -> NONTERM_String 
-    | 99 -> NONTERM_String 
-    | 100 -> NONTERM_InterpolatedString 
-    | 101 -> NONTERM_InterpolatedString 
-    | 102 -> NONTERM_ExprTuple 
-    | 103 -> NONTERM_ExprTupleContent 
-    | 104 -> NONTERM_ExprTupleContent 
-    | 105 -> NONTERM_ExprTupleContent 
-    | 106 -> NONTERM_InterpolatedExprTuple 
-    | 107 -> NONTERM_InterpolatedExprTupleContent 
-    | 108 -> NONTERM_InterpolatedExprTupleContent 
-    | 109 -> NONTERM_InterpolatedExprTupleContent 
-    | 110 -> NONTERM_ExprList 
-    | 111 -> NONTERM_ExprListContent 
-    | 112 -> NONTERM_ExprListContent 
-    | 113 -> NONTERM_ExprMap 
-    | 114 -> NONTERM_ExprMapContent 
-    | 115 -> NONTERM_ExprMapContent 
-    | 116 -> NONTERM_ListOfString 
-    | 117 -> NONTERM_Strings 
-    | 118 -> NONTERM_Strings 
-    | 119 -> NONTERM_ListOfTargetIdentifiers 
-    | 120 -> NONTERM_TargetIdentifiers 
-    | 121 -> NONTERM_TargetIdentifiers 
+    | 89 -> NONTERM_InterpolatedExpr 
+    | 90 -> NONTERM_InterpolatedExpr 
+    | 91 -> NONTERM_InterpolatedExpr 
+    | 92 -> NONTERM_TargetIdentifier 
+    | 93 -> NONTERM_TargetIdentifier 
+    | 94 -> NONTERM_ExtensionIdentifier 
+    | 95 -> NONTERM_ExtensionIdentifier 
+    | 96 -> NONTERM_ExprIndex 
+    | 97 -> NONTERM_ExprIndex 
+    | 98 -> NONTERM_Bool 
+    | 99 -> NONTERM_Bool 
+    | 100 -> NONTERM_String 
+    | 101 -> NONTERM_String 
+    | 102 -> NONTERM_String 
+    | 103 -> NONTERM_InterpolatedString 
+    | 104 -> NONTERM_InterpolatedString 
+    | 105 -> NONTERM_ExprTuple 
+    | 106 -> NONTERM_ExprTupleContent 
+    | 107 -> NONTERM_ExprTupleContent 
+    | 108 -> NONTERM_ExprTupleContent 
+    | 109 -> NONTERM_InterpolatedExprTuple 
+    | 110 -> NONTERM_InterpolatedExprTupleContent 
+    | 111 -> NONTERM_InterpolatedExprTupleContent 
+    | 112 -> NONTERM_InterpolatedExprTupleContent 
+    | 113 -> NONTERM_ExprList 
+    | 114 -> NONTERM_ExprListContent 
+    | 115 -> NONTERM_ExprListContent 
+    | 116 -> NONTERM_ExprMap 
+    | 117 -> NONTERM_ExprMapContent 
+    | 118 -> NONTERM_ExprMapContent 
+    | 119 -> NONTERM_ListOfString 
+    | 120 -> NONTERM_Strings 
+    | 121 -> NONTERM_Strings 
+    | 122 -> NONTERM_ListOfTargetIdentifiers 
+    | 123 -> NONTERM_TargetIdentifiers 
+    | 124 -> NONTERM_TargetIdentifiers 
     | _ -> failwith "prodIdxToNonTerminal: bad production index"
 
 let _fsyacc_endOfInputTag = 61 
@@ -571,18 +576,18 @@ let _fsyacc_dataOfToken (t:token) =
   | NOTHING  -> (null : System.Object) 
   | TRUE  -> (null : System.Object) 
   | FALSE  -> (null : System.Object) 
-let _fsyacc_gotos = [| 0us;65535us;1us;65535us;0us;1us;1us;65535us;0us;2us;1us;65535us;2us;4us;1us;65535us;9us;10us;1us;65535us;10us;12us;1us;65535us;10us;13us;1us;65535us;2us;5us;1us;65535us;22us;23us;1us;65535us;23us;25us;1us;65535us;23us;26us;1us;65535us;2us;6us;2us;65535us;35us;36us;38us;39us;2us;65535us;36us;41us;39us;41us;1us;65535us;2us;7us;1us;65535us;47us;48us;1us;65535us;48us;50us;1us;65535us;48us;51us;1us;65535us;48us;52us;1us;65535us;48us;53us;1us;65535us;48us;54us;20us;65535us;31us;32us;43us;44us;56us;57us;59us;60us;98us;78us;99us;79us;100us;80us;101us;81us;102us;82us;103us;83us;120us;84us;121us;85us;122us;86us;123us;87us;135us;88us;137us;89us;139us;90us;142us;91us;144us;92us;149us;93us;0us;65535us;1us;65535us;155us;157us;1us;65535us;45us;46us;2us;65535us;94us;95us;96us;97us;0us;65535us;23us;65535us;15us;16us;31us;77us;43us;77us;56us;77us;59us;77us;65us;66us;98us;77us;99us;77us;100us;77us;101us;77us;102us;77us;103us;77us;120us;77us;121us;77us;122us;77us;123us;77us;135us;77us;137us;77us;139us;77us;142us;77us;144us;77us;149us;77us;151us;153us;1us;65535us;131us;133us;8us;65535us;104us;105us;106us;107us;108us;109us;110us;111us;112us;113us;114us;115us;116us;117us;118us;119us;1us;65535us;139us;140us;0us;65535us;0us;65535us;20us;65535us;31us;70us;43us;70us;56us;70us;59us;70us;98us;70us;99us;70us;100us;70us;101us;70us;102us;70us;103us;70us;120us;70us;121us;70us;122us;70us;123us;70us;135us;70us;137us;70us;139us;70us;142us;70us;144us;70us;149us;70us;1us;65535us;143us;144us;21us;65535us;31us;71us;43us;71us;56us;71us;59us;71us;68us;69us;98us;71us;99us;71us;100us;71us;101us;71us;102us;71us;103us;71us;120us;71us;121us;71us;122us;71us;123us;71us;135us;71us;137us;71us;139us;71us;142us;71us;144us;71us;149us;71us;1us;65535us;146us;147us;2us;65535us;18us;19us;62us;63us;1us;65535us;150us;151us;1us;65535us;28us;29us;1us;65535us;154us;155us;|]
-let _fsyacc_sparseGotoTableRowOffsets = [|0us;1us;3us;5us;7us;9us;11us;13us;15us;17us;19us;21us;23us;26us;29us;31us;33us;35us;37us;39us;41us;43us;64us;65us;67us;69us;72us;73us;97us;99us;108us;110us;111us;112us;133us;135us;157us;159us;162us;164us;166us;|]
-let _fsyacc_stateToProdIdxsTableElements = [| 1us;0us;1us;0us;5us;1us;3us;4us;5us;6us;1us;1us;1us;3us;1us;4us;1us;5us;1us;6us;1us;7us;1us;7us;3us;7us;9us;10us;1us;7us;1us;9us;1us;10us;1us;11us;1us;11us;1us;11us;1us;12us;1us;12us;1us;12us;2us;13us;14us;2us;13us;14us;1us;14us;3us;14us;16us;17us;1us;14us;1us;16us;1us;17us;1us;18us;1us;18us;1us;18us;1us;19us;1us;19us;11us;19us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;3us;20us;21us;22us;2us;20us;22us;1us;21us;2us;21us;24us;1us;21us;1us;22us;2us;22us;24us;1us;22us;1us;24us;1us;25us;1us;25us;11us;25us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;1us;26us;1us;26us;1us;26us;6us;26us;28us;29us;30us;31us;32us;1us;26us;1us;28us;1us;29us;1us;30us;1us;31us;1us;32us;1us;33us;1us;33us;11us;33us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;1us;34us;1us;34us;11us;34us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;1us;35us;1us;35us;1us;35us;1us;36us;1us;36us;1us;36us;1us;37us;1us;37us;1us;37us;1us;38us;1us;39us;1us;40us;1us;41us;1us;42us;1us;43us;1us;44us;1us;45us;11us;46us;47us;48us;48us;49us;50us;51us;52us;53us;62us;63us;11us;46us;47us;48us;49us;49us;50us;51us;52us;53us;62us;63us;11us;46us;47us;48us;49us;50us;50us;51us;52us;53us;62us;63us;11us;46us;47us;48us;49us;50us;51us;51us;52us;53us;62us;63us;11us;46us;47us;48us;49us;50us;51us;52us;52us;53us;62us;63us;11us;46us;47us;48us;49us;50us;51us;52us;53us;53us;62us;63us;11us;46us;47us;48us;49us;50us;51us;52us;53us;62us;62us;63us;11us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;63us;11us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;63us;11us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;64us;11us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;100us;11us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;101us;11us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;104us;11us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;105us;11us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;112us;11us;46us;47us;48us;49us;50us;51us;52us;53us;62us;63us;115us;1us;46us;1us;46us;1us;47us;1us;47us;1us;48us;1us;49us;1us;50us;1us;51us;1us;52us;1us;53us;1us;54us;1us;54us;1us;55us;1us;55us;1us;56us;1us;56us;1us;57us;1us;57us;1us;58us;1us;58us;1us;59us;1us;59us;1us;60us;1us;60us;1us;61us;1us;61us;1us;62us;1us;63us;1us;63us;1us;64us;1us;89us;1us;90us;1us;91us;1us;92us;1us;93us;1us;94us;1us;97us;2us;98us;99us;1us;98us;2us;99us;101us;1us;99us;1us;100us;1us;100us;1us;101us;1us;101us;1us;102us;2us;102us;105us;1us;102us;1us;105us;1us;110us;2us;110us;112us;1us;110us;1us;113us;2us;113us;115us;1us;113us;1us;115us;1us;116us;2us;116us;118us;1us;116us;1us;118us;1us;119us;2us;119us;121us;1us;119us;1us;121us;|]
-let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us;2us;4us;10us;12us;14us;16us;18us;20us;22us;24us;28us;30us;32us;34us;36us;38us;40us;42us;44us;46us;49us;52us;54us;58us;60us;62us;64us;66us;68us;70us;72us;74us;86us;90us;93us;95us;98us;100us;102us;105us;107us;109us;111us;113us;125us;127us;129us;131us;138us;140us;142us;144us;146us;148us;150us;152us;154us;166us;168us;170us;182us;184us;186us;188us;190us;192us;194us;196us;198us;200us;202us;204us;206us;208us;210us;212us;214us;216us;228us;240us;252us;264us;276us;288us;300us;312us;324us;336us;348us;360us;372us;384us;396us;408us;410us;412us;414us;416us;418us;420us;422us;424us;426us;428us;430us;432us;434us;436us;438us;440us;442us;444us;446us;448us;450us;452us;454us;456us;458us;460us;462us;464us;466us;468us;470us;472us;474us;476us;478us;480us;482us;485us;487us;490us;492us;494us;496us;498us;500us;502us;505us;507us;509us;511us;514us;516us;518us;521us;523us;525us;527us;530us;532us;534us;536us;539us;541us;|]
-let _fsyacc_action_rows = 158
-let _fsyacc_actionTableElements = [|0us;16386us;0us;49152us;5us;32768us;12us;8us;13us;20us;14us;33us;15us;45us;16us;3us;0us;16385us;0us;16387us;0us;16388us;0us;16389us;0us;16390us;1us;32768us;43us;9us;0us;16392us;3us;32768us;1us;17us;2us;14us;44us;11us;0us;16391us;0us;16393us;0us;16394us;1us;32768us;34us;15us;2us;32768us;54us;131us;55us;130us;0us;16395us;1us;32768us;34us;18us;1us;32768us;41us;150us;0us;16396us;1us;32768us;50us;21us;1us;16397us;43us;22us;0us;16399us;3us;32768us;3us;27us;4us;30us;44us;24us;0us;16398us;0us;16400us;0us;16401us;1us;32768us;34us;28us;1us;32768us;41us;154us;0us;16402us;1us;32768us;34us;31us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;10us;16403us;17us;120us;18us;121us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;2us;32768us;43us;35us;50us;34us;1us;16404us;43us;38us;0us;16407us;2us;32768us;44us;37us;50us;42us;0us;16405us;0us;16407us;2us;32768us;44us;40us;50us;42us;0us;16406us;0us;16408us;1us;32768us;34us;43us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;10us;16409us;17us;120us;18us;121us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;2us;32768us;49us;126us;50us;127us;1us;32768us;43us;47us;0us;16411us;6us;32768us;5us;61us;6us;55us;7us;58us;9us;64us;10us;67us;44us;49us;0us;16410us;0us;16412us;0us;16413us;0us;16414us;0us;16415us;0us;16416us;1us;32768us;34us;56us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;10us;16417us;17us;120us;18us;121us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;1us;32768us;34us;59us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;10us;16418us;17us;120us;18us;121us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;1us;32768us;34us;62us;1us;32768us;41us;150us;0us;16419us;1us;32768us;34us;65us;2us;32768us;54us;131us;55us;130us;0us;16420us;1us;32768us;34us;68us;1us;32768us;43us;146us;0us;16421us;0us;16422us;0us;16423us;0us;16424us;0us;16425us;0us;16426us;0us;16427us;0us;16428us;0us;16429us;6us;16432us;21us;102us;22us;103us;31us;101us;32us;100us;39us;94us;40us;96us;6us;16433us;21us;102us;22us;103us;31us;101us;32us;100us;39us;94us;40us;96us;4us;16434us;21us;102us;22us;103us;39us;94us;40us;96us;4us;16435us;21us;102us;22us;103us;39us;94us;40us;96us;2us;16436us;39us;94us;40us;96us;2us;16437us;39us;94us;40us;96us;8us;16446us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;11us;32768us;17us;120us;18us;121us;19us;122us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;10us;16447us;17us;120us;18us;121us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;0us;16448us;11us;32768us;17us;120us;18us;121us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;51us;136us;11us;32768us;17us;120us;18us;121us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;51us;138us;10us;16488us;17us;120us;18us;121us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;10us;16489us;17us;120us;18us;121us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;10us;16496us;17us;120us;18us;121us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;10us;16499us;17us;120us;18us;121us;21us;102us;22us;103us;31us;101us;32us;100us;35us;98us;36us;99us;39us;94us;40us;96us;2us;32768us;45us;128us;50us;129us;0us;16430us;2us;32768us;45us;128us;50us;129us;0us;16431us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;1us;32768us;37us;139us;0us;16438us;1us;32768us;37us;139us;0us;16439us;1us;32768us;37us;139us;0us;16440us;1us;32768us;37us;139us;0us;16441us;1us;32768us;37us;139us;0us;16442us;1us;32768us;37us;139us;0us;16443us;1us;32768us;37us;139us;0us;16444us;1us;32768us;37us;139us;0us;16445us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;0us;16473us;0us;16474us;0us;16475us;0us;16476us;0us;16477us;0us;16478us;0us;16481us;2us;32768us;52us;135us;53us;132us;0us;16482us;2us;32768us;52us;137us;53us;134us;0us;16483us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;0us;16484us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;0us;16485us;18us;16487us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;2us;32768us;33us;142us;38us;141us;0us;16486us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;0us;16495us;19us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;42us;145us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;0us;16494us;0us;16498us;2us;32768us;44us;148us;46us;149us;0us;16497us;18us;32768us;20us;123us;23us;104us;24us;106us;25us;108us;26us;110us;27us;112us;28us;114us;29us;116us;30us;118us;41us;143us;43us;146us;45us;75us;47us;76us;54us;131us;55us;130us;56us;72us;57us;73us;58us;74us;0us;16501us;3us;32768us;42us;152us;54us;131us;55us;130us;0us;16500us;0us;16502us;0us;16504us;3us;32768us;42us;156us;48us;124us;50us;125us;0us;16503us;0us;16505us;|]
-let _fsyacc_actionTableRowOffsets = [|0us;1us;2us;8us;9us;10us;11us;12us;13us;15us;16us;20us;21us;22us;23us;25us;28us;29us;31us;33us;34us;36us;38us;39us;43us;44us;45us;46us;48us;50us;51us;53us;72us;83us;86us;88us;89us;92us;93us;94us;97us;98us;99us;101us;120us;131us;134us;136us;137us;144us;145us;146us;147us;148us;149us;150us;152us;171us;182us;184us;203us;214us;216us;218us;219us;221us;224us;225us;227us;229us;230us;231us;232us;233us;234us;235us;236us;237us;238us;245us;252us;257us;262us;265us;268us;277us;289us;300us;301us;313us;325us;336us;347us;358us;369us;372us;373us;376us;377us;396us;415us;434us;453us;472us;491us;493us;494us;496us;497us;499us;500us;502us;503us;505us;506us;508us;509us;511us;512us;514us;515us;534us;553us;572us;591us;592us;593us;594us;595us;596us;597us;598us;601us;602us;605us;606us;625us;626us;645us;646us;665us;668us;669us;688us;689us;709us;710us;711us;714us;715us;734us;735us;739us;740us;741us;742us;746us;747us;|]
-let _fsyacc_reductionSymbolCounts = [|1us;2us;0us;2us;2us;2us;2us;4us;0us;2us;2us;3us;3us;2us;5us;0us;2us;2us;3us;3us;2us;4us;5us;0us;2us;3us;5us;0us;2us;2us;2us;2us;2us;3us;3us;3us;3us;3us;1us;1us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;1us;1us;1us;1us;2us;3us;3us;4us;3us;0us;1us;3us;3us;0us;1us;3us;3us;0us;2us;3us;0us;3us;3us;0us;2us;3us;0us;2us;|]
-let _fsyacc_productionToNonTerminalTable = [|0us;1us;2us;2us;2us;2us;2us;3us;4us;4us;4us;5us;6us;7us;7us;8us;8us;8us;9us;10us;11us;11us;11us;12us;12us;13us;14us;15us;15us;15us;15us;15us;15us;16us;17us;18us;19us;20us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;21us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;22us;23us;23us;24us;24us;25us;25us;26us;26us;27us;27us;27us;28us;28us;29us;30us;30us;30us;31us;32us;32us;32us;33us;34us;34us;35us;36us;36us;37us;38us;38us;39us;40us;40us;|]
-let _fsyacc_immediateActions = [|65535us;49152us;65535us;16385us;16387us;16388us;16389us;16390us;65535us;65535us;65535us;16391us;16393us;16394us;65535us;65535us;16395us;65535us;65535us;16396us;65535us;65535us;65535us;65535us;16398us;16400us;16401us;65535us;65535us;16402us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16405us;65535us;65535us;16406us;16408us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16410us;16412us;16413us;16414us;16415us;16416us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16419us;65535us;65535us;16420us;65535us;65535us;16421us;16422us;16423us;16424us;16425us;16426us;16427us;16428us;16429us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16430us;65535us;16431us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16438us;65535us;16439us;65535us;16440us;65535us;16441us;65535us;16442us;65535us;16443us;65535us;16444us;65535us;16445us;65535us;65535us;65535us;65535us;16473us;16474us;16475us;16476us;16477us;16478us;16481us;65535us;16482us;65535us;16483us;65535us;16484us;65535us;16485us;65535us;65535us;16486us;65535us;65535us;65535us;16494us;65535us;65535us;16497us;65535us;65535us;65535us;16500us;16502us;65535us;65535us;16503us;16505us;|]
+let _fsyacc_gotos = [| 0us;65535us;1us;65535us;0us;1us;1us;65535us;0us;2us;1us;65535us;2us;4us;1us;65535us;9us;10us;1us;65535us;10us;12us;1us;65535us;10us;13us;1us;65535us;2us;5us;1us;65535us;22us;23us;1us;65535us;23us;25us;1us;65535us;23us;26us;1us;65535us;2us;6us;2us;65535us;35us;36us;38us;39us;2us;65535us;36us;41us;39us;41us;1us;65535us;2us;7us;1us;65535us;47us;48us;1us;65535us;48us;50us;1us;65535us;48us;51us;1us;65535us;48us;52us;1us;65535us;48us;53us;1us;65535us;48us;54us;1us;65535us;68us;69us;1us;65535us;69us;71us;21us;65535us;31us;32us;43us;44us;56us;57us;59us;60us;73us;74us;103us;83us;104us;84us;105us;85us;106us;86us;107us;87us;108us;88us;125us;89us;126us;90us;127us;91us;128us;92us;140us;93us;142us;94us;144us;95us;147us;96us;149us;97us;154us;98us;0us;65535us;1us;65535us;160us;162us;1us;65535us;45us;46us;2us;65535us;99us;100us;101us;102us;0us;65535us;24us;65535us;15us;16us;31us;82us;43us;82us;56us;82us;59us;82us;65us;66us;73us;82us;103us;82us;104us;82us;105us;82us;106us;82us;107us;82us;108us;82us;125us;82us;126us;82us;127us;82us;128us;82us;140us;82us;142us;82us;144us;82us;147us;82us;149us;82us;154us;82us;156us;158us;1us;65535us;136us;138us;8us;65535us;109us;110us;111us;112us;113us;114us;115us;116us;117us;118us;119us;120us;121us;122us;123us;124us;1us;65535us;144us;145us;0us;65535us;0us;65535us;21us;65535us;31us;75us;43us;75us;56us;75us;59us;75us;73us;75us;103us;75us;104us;75us;105us;75us;106us;75us;107us;75us;108us;75us;125us;75us;126us;75us;127us;75us;128us;75us;140us;75us;142us;75us;144us;75us;147us;75us;149us;75us;154us;75us;1us;65535us;148us;149us;21us;65535us;31us;76us;43us;76us;56us;76us;59us;76us;73us;76us;103us;76us;104us;76us;105us;76us;106us;76us;107us;76us;108us;76us;125us;76us;126us;76us;127us;76us;128us;76us;140us;76us;142us;76us;144us;76us;147us;76us;149us;76us;154us;76us;1us;65535us;151us;152us;2us;65535us;18us;19us;62us;63us;1us;65535us;155us;156us;1us;65535us;28us;29us;1us;65535us;159us;160us;|]
+let _fsyacc_sparseGotoTableRowOffsets = [|0us;1us;3us;5us;7us;9us;11us;13us;15us;17us;19us;21us;23us;26us;29us;31us;33us;35us;37us;39us;41us;43us;45us;47us;69us;70us;72us;74us;77us;78us;103us;105us;114us;116us;117us;118us;140us;142us;164us;166us;169us;171us;173us;|]
+let _fsyacc_stateToProdIdxsTableElements = [| 1us;0us;1us;0us;5us;1us;3us;4us;5us;6us;1us;1us;1us;3us;1us;4us;1us;5us;1us;6us;1us;7us;1us;7us;3us;7us;9us;10us;1us;7us;1us;9us;1us;10us;1us;11us;1us;11us;1us;11us;1us;12us;1us;12us;1us;12us;2us;13us;14us;2us;13us;14us;1us;14us;3us;14us;16us;17us;1us;14us;1us;16us;1us;17us;1us;18us;1us;18us;1us;18us;1us;19us;1us;19us;11us;19us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;3us;20us;21us;22us;2us;20us;22us;1us;21us;2us;21us;24us;1us;21us;1us;22us;2us;22us;24us;1us;22us;1us;24us;1us;25us;1us;25us;11us;25us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;1us;26us;1us;26us;1us;26us;6us;26us;28us;29us;30us;31us;32us;1us;26us;1us;28us;1us;29us;1us;30us;1us;31us;1us;32us;1us;33us;1us;33us;11us;33us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;1us;34us;1us;34us;11us;34us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;1us;35us;1us;35us;1us;35us;1us;36us;1us;36us;1us;36us;1us;37us;1us;37us;2us;37us;39us;1us;37us;1us;39us;1us;40us;1us;40us;11us;40us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;1us;41us;1us;42us;1us;43us;1us;44us;1us;45us;1us;46us;1us;47us;1us;48us;11us;49us;50us;51us;51us;52us;53us;54us;55us;56us;65us;66us;11us;49us;50us;51us;52us;52us;53us;54us;55us;56us;65us;66us;11us;49us;50us;51us;52us;53us;53us;54us;55us;56us;65us;66us;11us;49us;50us;51us;52us;53us;54us;54us;55us;56us;65us;66us;11us;49us;50us;51us;52us;53us;54us;55us;55us;56us;65us;66us;11us;49us;50us;51us;52us;53us;54us;55us;56us;56us;65us;66us;11us;49us;50us;51us;52us;53us;54us;55us;56us;65us;65us;66us;11us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;66us;11us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;66us;11us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;67us;11us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;103us;11us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;104us;11us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;107us;11us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;108us;11us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;115us;11us;49us;50us;51us;52us;53us;54us;55us;56us;65us;66us;118us;1us;49us;1us;49us;1us;50us;1us;50us;1us;51us;1us;52us;1us;53us;1us;54us;1us;55us;1us;56us;1us;57us;1us;57us;1us;58us;1us;58us;1us;59us;1us;59us;1us;60us;1us;60us;1us;61us;1us;61us;1us;62us;1us;62us;1us;63us;1us;63us;1us;64us;1us;64us;1us;65us;1us;66us;1us;66us;1us;67us;1us;92us;1us;93us;1us;94us;1us;95us;1us;96us;1us;97us;1us;100us;2us;101us;102us;1us;101us;2us;102us;104us;1us;102us;1us;103us;1us;103us;1us;104us;1us;104us;1us;105us;2us;105us;108us;1us;105us;1us;108us;1us;113us;2us;113us;115us;1us;113us;1us;116us;2us;116us;118us;1us;116us;1us;118us;1us;119us;2us;119us;121us;1us;119us;1us;121us;1us;122us;2us;122us;124us;1us;122us;1us;124us;|]
+let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us;2us;4us;10us;12us;14us;16us;18us;20us;22us;24us;28us;30us;32us;34us;36us;38us;40us;42us;44us;46us;49us;52us;54us;58us;60us;62us;64us;66us;68us;70us;72us;74us;86us;90us;93us;95us;98us;100us;102us;105us;107us;109us;111us;113us;125us;127us;129us;131us;138us;140us;142us;144us;146us;148us;150us;152us;154us;166us;168us;170us;182us;184us;186us;188us;190us;192us;194us;196us;198us;201us;203us;205us;207us;209us;221us;223us;225us;227us;229us;231us;233us;235us;237us;249us;261us;273us;285us;297us;309us;321us;333us;345us;357us;369us;381us;393us;405us;417us;429us;431us;433us;435us;437us;439us;441us;443us;445us;447us;449us;451us;453us;455us;457us;459us;461us;463us;465us;467us;469us;471us;473us;475us;477us;479us;481us;483us;485us;487us;489us;491us;493us;495us;497us;499us;501us;503us;506us;508us;511us;513us;515us;517us;519us;521us;523us;526us;528us;530us;532us;535us;537us;539us;542us;544us;546us;548us;551us;553us;555us;557us;560us;562us;|]
+let _fsyacc_action_rows = 163
+let _fsyacc_actionTableElements = [|0us;16386us;0us;49152us;5us;32768us;12us;8us;13us;20us;14us;33us;15us;45us;16us;3us;0us;16385us;0us;16387us;0us;16388us;0us;16389us;0us;16390us;1us;32768us;43us;9us;0us;16392us;3us;32768us;1us;17us;2us;14us;44us;11us;0us;16391us;0us;16393us;0us;16394us;1us;32768us;34us;15us;2us;32768us;54us;136us;55us;135us;0us;16395us;1us;32768us;34us;18us;1us;32768us;41us;155us;0us;16396us;1us;32768us;50us;21us;1us;16397us;43us;22us;0us;16399us;3us;32768us;3us;27us;4us;30us;44us;24us;0us;16398us;0us;16400us;0us;16401us;1us;32768us;34us;28us;1us;32768us;41us;159us;0us;16402us;1us;32768us;34us;31us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;10us;16403us;17us;125us;18us;126us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;2us;32768us;43us;35us;50us;34us;1us;16404us;43us;38us;0us;16407us;2us;32768us;44us;37us;50us;42us;0us;16405us;0us;16407us;2us;32768us;44us;40us;50us;42us;0us;16406us;0us;16408us;1us;32768us;34us;43us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;10us;16409us;17us;125us;18us;126us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;2us;32768us;49us;131us;50us;132us;1us;32768us;43us;47us;0us;16411us;6us;32768us;5us;61us;6us;55us;7us;58us;9us;64us;10us;67us;44us;49us;0us;16410us;0us;16412us;0us;16413us;0us;16414us;0us;16415us;0us;16416us;1us;32768us;34us;56us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;10us;16417us;17us;125us;18us;126us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;1us;32768us;34us;59us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;10us;16418us;17us;125us;18us;126us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;1us;32768us;34us;62us;1us;32768us;41us;155us;0us;16419us;1us;32768us;34us;65us;2us;32768us;54us;136us;55us;135us;0us;16420us;1us;32768us;43us;68us;0us;16422us;2us;32768us;44us;70us;50us;72us;0us;16421us;0us;16423us;1us;32768us;34us;73us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;10us;16424us;17us;125us;18us;126us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;0us;16425us;0us;16426us;0us;16427us;0us;16428us;0us;16429us;0us;16430us;0us;16431us;0us;16432us;6us;16435us;21us;107us;22us;108us;31us;106us;32us;105us;39us;99us;40us;101us;6us;16436us;21us;107us;22us;108us;31us;106us;32us;105us;39us;99us;40us;101us;4us;16437us;21us;107us;22us;108us;39us;99us;40us;101us;4us;16438us;21us;107us;22us;108us;39us;99us;40us;101us;2us;16439us;39us;99us;40us;101us;2us;16440us;39us;99us;40us;101us;8us;16449us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;11us;32768us;17us;125us;18us;126us;19us;127us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;10us;16450us;17us;125us;18us;126us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;0us;16451us;11us;32768us;17us;125us;18us;126us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;51us;141us;11us;32768us;17us;125us;18us;126us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;51us;143us;10us;16491us;17us;125us;18us;126us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;10us;16492us;17us;125us;18us;126us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;10us;16499us;17us;125us;18us;126us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;10us;16502us;17us;125us;18us;126us;21us;107us;22us;108us;31us;106us;32us;105us;35us;103us;36us;104us;39us;99us;40us;101us;2us;32768us;45us;133us;50us;134us;0us;16433us;2us;32768us;45us;133us;50us;134us;0us;16434us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;1us;32768us;37us;144us;0us;16441us;1us;32768us;37us;144us;0us;16442us;1us;32768us;37us;144us;0us;16443us;1us;32768us;37us;144us;0us;16444us;1us;32768us;37us;144us;0us;16445us;1us;32768us;37us;144us;0us;16446us;1us;32768us;37us;144us;0us;16447us;1us;32768us;37us;144us;0us;16448us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;0us;16476us;0us;16477us;0us;16478us;0us;16479us;0us;16480us;0us;16481us;0us;16484us;2us;32768us;52us;140us;53us;137us;0us;16485us;2us;32768us;52us;142us;53us;139us;0us;16486us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;0us;16487us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;0us;16488us;18us;16490us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;2us;32768us;33us;147us;38us;146us;0us;16489us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;0us;16498us;19us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;42us;150us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;0us;16497us;0us;16501us;2us;32768us;44us;153us;46us;154us;0us;16500us;18us;32768us;20us;128us;23us;109us;24us;111us;25us;113us;26us;115us;27us;117us;28us;119us;29us;121us;30us;123us;41us;148us;43us;151us;45us;80us;47us;81us;54us;136us;55us;135us;56us;77us;57us;78us;58us;79us;0us;16504us;3us;32768us;42us;157us;54us;136us;55us;135us;0us;16503us;0us;16505us;0us;16507us;3us;32768us;42us;161us;48us;129us;50us;130us;0us;16506us;0us;16508us;|]
+let _fsyacc_actionTableRowOffsets = [|0us;1us;2us;8us;9us;10us;11us;12us;13us;15us;16us;20us;21us;22us;23us;25us;28us;29us;31us;33us;34us;36us;38us;39us;43us;44us;45us;46us;48us;50us;51us;53us;72us;83us;86us;88us;89us;92us;93us;94us;97us;98us;99us;101us;120us;131us;134us;136us;137us;144us;145us;146us;147us;148us;149us;150us;152us;171us;182us;184us;203us;214us;216us;218us;219us;221us;224us;225us;227us;228us;231us;232us;233us;235us;254us;265us;266us;267us;268us;269us;270us;271us;272us;273us;280us;287us;292us;297us;300us;303us;312us;324us;335us;336us;348us;360us;371us;382us;393us;404us;407us;408us;411us;412us;431us;450us;469us;488us;507us;526us;528us;529us;531us;532us;534us;535us;537us;538us;540us;541us;543us;544us;546us;547us;549us;550us;569us;588us;607us;626us;627us;628us;629us;630us;631us;632us;633us;636us;637us;640us;641us;660us;661us;680us;681us;700us;703us;704us;723us;724us;744us;745us;746us;749us;750us;769us;770us;774us;775us;776us;777us;781us;782us;|]
+let _fsyacc_reductionSymbolCounts = [|1us;2us;0us;2us;2us;2us;2us;4us;0us;2us;2us;3us;3us;2us;5us;0us;2us;2us;3us;3us;2us;4us;5us;0us;2us;3us;5us;0us;2us;2us;2us;2us;2us;3us;3us;3us;3us;4us;0us;2us;3us;1us;1us;1us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;3us;3us;3us;3us;3us;3us;3us;3us;2us;2us;2us;2us;2us;2us;2us;2us;3us;5us;2us;1us;1us;1us;1us;1us;1us;1us;1us;1us;2us;3us;3us;4us;3us;0us;1us;3us;3us;0us;1us;3us;3us;0us;2us;3us;0us;3us;3us;0us;2us;3us;0us;2us;|]
+let _fsyacc_productionToNonTerminalTable = [|0us;1us;2us;2us;2us;2us;2us;3us;4us;4us;4us;5us;6us;7us;7us;8us;8us;8us;9us;10us;11us;11us;11us;12us;12us;13us;14us;15us;15us;15us;15us;15us;15us;16us;17us;18us;19us;20us;21us;21us;22us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;23us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;24us;25us;25us;26us;26us;27us;27us;28us;28us;29us;29us;29us;30us;30us;31us;32us;32us;32us;33us;34us;34us;34us;35us;36us;36us;37us;38us;38us;39us;40us;40us;41us;42us;42us;|]
+let _fsyacc_immediateActions = [|65535us;49152us;65535us;16385us;16387us;16388us;16389us;16390us;65535us;65535us;65535us;16391us;16393us;16394us;65535us;65535us;16395us;65535us;65535us;16396us;65535us;65535us;65535us;65535us;16398us;16400us;16401us;65535us;65535us;16402us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16405us;65535us;65535us;16406us;16408us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16410us;16412us;16413us;16414us;16415us;16416us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16419us;65535us;65535us;16420us;65535us;65535us;65535us;16421us;16423us;65535us;65535us;65535us;16425us;16426us;16427us;16428us;16429us;16430us;16431us;16432us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16433us;65535us;16434us;65535us;65535us;65535us;65535us;65535us;65535us;65535us;16441us;65535us;16442us;65535us;16443us;65535us;16444us;65535us;16445us;65535us;16446us;65535us;16447us;65535us;16448us;65535us;65535us;65535us;65535us;16476us;16477us;16478us;16479us;16480us;16481us;16484us;65535us;16485us;65535us;16486us;65535us;16487us;65535us;16488us;65535us;65535us;16489us;65535us;65535us;65535us;16497us;65535us;65535us;16500us;65535us;65535us;65535us;16503us;16505us;65535us;65535us;16506us;16508us;|]
 let _fsyacc_reductions = lazy [|
-# 585 "Gen/WorkspaceParser.fs"
+# 590 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Terrabuild.Configuration.AST.Workspace.WorkspaceFile in
             Microsoft.FSharp.Core.Operators.box
@@ -591,7 +596,7 @@ let _fsyacc_reductions = lazy [|
                       raise (FSharp.Text.Parsing.Accept(Microsoft.FSharp.Core.Operators.box _1))
                    )
                  : 'gentype__startWorkspaceFile));
-# 594 "Gen/WorkspaceParser.fs"
+# 599 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             Microsoft.FSharp.Core.Operators.box
@@ -602,7 +607,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 61 "WorkspaceParser/Parser.fsy"
                  : Terrabuild.Configuration.AST.Workspace.WorkspaceFile));
-# 605 "Gen/WorkspaceParser.fs"
+# 610 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -612,7 +617,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 64 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 615 "Gen/WorkspaceParser.fs"
+# 620 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Workspace in
@@ -624,7 +629,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 65 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 627 "Gen/WorkspaceParser.fs"
+# 632 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Target in
@@ -636,7 +641,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 66 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 639 "Gen/WorkspaceParser.fs"
+# 644 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Configuration in
@@ -648,7 +653,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 67 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 651 "Gen/WorkspaceParser.fs"
+# 656 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceFileComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_Extension in
@@ -660,7 +665,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 68 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceFileComponents));
-# 663 "Gen/WorkspaceParser.fs"
+# 668 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_WorkspaceComponents in
             Microsoft.FSharp.Core.Operators.box
@@ -671,7 +676,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 71 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Workspace));
-# 674 "Gen/WorkspaceParser.fs"
+# 679 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -681,7 +686,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 73 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceComponents));
-# 684 "Gen/WorkspaceParser.fs"
+# 689 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_WorkspaceSpace in
@@ -693,7 +698,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 74 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceComponents));
-# 696 "Gen/WorkspaceParser.fs"
+# 701 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_WorkspaceComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_WorkspaceIgnores in
@@ -705,7 +710,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 75 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceComponents));
-# 708 "Gen/WorkspaceParser.fs"
+# 713 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
@@ -716,7 +721,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 77 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceSpace));
-# 719 "Gen/WorkspaceParser.fs"
+# 724 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
@@ -727,7 +732,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 79 "WorkspaceParser/Parser.fsy"
                  : 'gentype_WorkspaceIgnores));
-# 730 "Gen/WorkspaceParser.fs"
+# 735 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -738,7 +743,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 82 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Target));
-# 741 "Gen/WorkspaceParser.fs"
+# 746 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             let _4 = parseState.GetInput(4) :?> 'gentype_TargetComponents in
@@ -750,7 +755,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 83 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Target));
-# 753 "Gen/WorkspaceParser.fs"
+# 758 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -760,7 +765,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 85 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 763 "Gen/WorkspaceParser.fs"
+# 768 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetDependsOn in
@@ -772,7 +777,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 86 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 775 "Gen/WorkspaceParser.fs"
+# 780 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetRebuild in
@@ -784,7 +789,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 87 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetComponents));
-# 787 "Gen/WorkspaceParser.fs"
+# 792 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfTargetIdentifiers in
             Microsoft.FSharp.Core.Operators.box
@@ -795,7 +800,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 89 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetDependsOn));
-# 798 "Gen/WorkspaceParser.fs"
+# 803 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
@@ -806,7 +811,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 91 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetRebuild));
-# 809 "Gen/WorkspaceParser.fs"
+# 814 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
@@ -817,7 +822,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 94 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Configuration));
-# 820 "Gen/WorkspaceParser.fs"
+# 825 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ConfigurationComponents in
             Microsoft.FSharp.Core.Operators.box
@@ -828,7 +833,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 95 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Configuration));
-# 831 "Gen/WorkspaceParser.fs"
+# 836 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             let _4 = parseState.GetInput(4) :?> 'gentype_ConfigurationComponents in
@@ -840,7 +845,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 96 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Configuration));
-# 843 "Gen/WorkspaceParser.fs"
+# 848 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -850,7 +855,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 98 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ConfigurationComponents));
-# 853 "Gen/WorkspaceParser.fs"
+# 858 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ConfigurationComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ConfigurationVariable in
@@ -862,7 +867,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 99 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ConfigurationComponents));
-# 865 "Gen/WorkspaceParser.fs"
+# 870 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -874,7 +879,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 101 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ConfigurationVariable));
-# 877 "Gen/WorkspaceParser.fs"
+# 882 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionIdentifier in
             let _4 = parseState.GetInput(4) :?> 'gentype_ExtensionComponents in
@@ -886,7 +891,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 105 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Extension));
-# 889 "Gen/WorkspaceParser.fs"
+# 894 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -896,7 +901,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 107 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 899 "Gen/WorkspaceParser.fs"
+# 904 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionContainer in
@@ -908,7 +913,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 108 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 911 "Gen/WorkspaceParser.fs"
+# 916 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionPlaform in
@@ -920,7 +925,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 109 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 923 "Gen/WorkspaceParser.fs"
+# 928 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionVariables in
@@ -932,7 +937,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 110 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 935 "Gen/WorkspaceParser.fs"
+# 940 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionScript in
@@ -944,7 +949,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 111 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 947 "Gen/WorkspaceParser.fs"
+# 952 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionComponents in
             let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionDefaults in
@@ -956,7 +961,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 112 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionComponents));
-# 959 "Gen/WorkspaceParser.fs"
+# 964 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
@@ -967,7 +972,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 114 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionContainer));
-# 970 "Gen/WorkspaceParser.fs"
+# 975 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
@@ -978,7 +983,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 116 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionPlaform));
-# 981 "Gen/WorkspaceParser.fs"
+# 986 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_ListOfString in
             Microsoft.FSharp.Core.Operators.box
@@ -989,7 +994,7 @@ let _fsyacc_reductions = lazy [|
                    )
 # 118 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionVariables));
-# 992 "Gen/WorkspaceParser.fs"
+# 997 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
@@ -1000,299 +1005,333 @@ let _fsyacc_reductions = lazy [|
                    )
 # 120 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionScript));
-# 1003 "Gen/WorkspaceParser.fs"
+# 1008 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
-            let _3 = parseState.GetInput(3) :?> 'gentype_ExprMap in
+            let _3 = parseState.GetInput(3) :?> 'gentype_ExtensionDefaultsComponents in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
 # 122 "WorkspaceParser/Parser.fsy"
-                                                    ExtensionComponents.Defaults _3 
+                                                                                ExtensionComponents.Defaults _3 
                    )
 # 122 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionDefaults));
-# 1014 "Gen/WorkspaceParser.fs"
+# 1019 "Gen/WorkspaceParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 124 "WorkspaceParser/Parser.fsy"
+                                         [] 
+                   )
+# 124 "WorkspaceParser/Parser.fsy"
+                 : 'gentype_ExtensionDefaultsComponents));
+# 1029 "Gen/WorkspaceParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            let _1 = parseState.GetInput(1) :?> 'gentype_ExtensionDefaultsComponents in
+            let _2 = parseState.GetInput(2) :?> 'gentype_ExtensionDefaultsComponentsVariable in
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 125 "WorkspaceParser/Parser.fsy"
+                                                                                             _1 @ [_2] 
+                   )
+# 125 "WorkspaceParser/Parser.fsy"
+                 : 'gentype_ExtensionDefaultsComponents));
+# 1041 "Gen/WorkspaceParser.fs"
+        (fun (parseState : FSharp.Text.Parsing.IParseState) ->
+            let _1 = parseState.GetInput(1) :?> string in
+            let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
+            Microsoft.FSharp.Core.Operators.box
+                (
+                   (
+# 127 "WorkspaceParser/Parser.fsy"
+                                                   (_1, _3) 
+                   )
+# 127 "WorkspaceParser/Parser.fsy"
+                 : 'gentype_ExtensionDefaultsComponentsVariable));
+# 1053 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprList in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 126 "WorkspaceParser/Parser.fsy"
+# 133 "WorkspaceParser/Parser.fsy"
                                       Expr.List _1 
                    )
-# 126 "WorkspaceParser/Parser.fsy"
+# 133 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1025 "Gen/WorkspaceParser.fs"
+# 1064 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprMap in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 127 "WorkspaceParser/Parser.fsy"
+# 134 "WorkspaceParser/Parser.fsy"
                                      Expr.Map _1 
                    )
-# 127 "WorkspaceParser/Parser.fsy"
+# 134 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1036 "Gen/WorkspaceParser.fs"
+# 1075 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 129 "WorkspaceParser/Parser.fsy"
+# 136 "WorkspaceParser/Parser.fsy"
                                      Expr.Nothing 
                    )
-# 129 "WorkspaceParser/Parser.fsy"
+# 136 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1046 "Gen/WorkspaceParser.fs"
+# 1085 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 130 "WorkspaceParser/Parser.fsy"
+# 137 "WorkspaceParser/Parser.fsy"
                                   Expr.Bool true 
                    )
-# 130 "WorkspaceParser/Parser.fsy"
+# 137 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1056 "Gen/WorkspaceParser.fs"
+# 1095 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 131 "WorkspaceParser/Parser.fsy"
+# 138 "WorkspaceParser/Parser.fsy"
                                    Expr.Bool false 
                    )
-# 131 "WorkspaceParser/Parser.fsy"
+# 138 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1066 "Gen/WorkspaceParser.fs"
+# 1105 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 132 "WorkspaceParser/Parser.fsy"
+# 139 "WorkspaceParser/Parser.fsy"
                                     Expr.Number _1 
                    )
-# 132 "WorkspaceParser/Parser.fsy"
+# 139 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1077 "Gen/WorkspaceParser.fs"
+# 1116 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 133 "WorkspaceParser/Parser.fsy"
+# 140 "WorkspaceParser/Parser.fsy"
                                       Expr.Variable _1 
                    )
-# 133 "WorkspaceParser/Parser.fsy"
+# 140 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1088 "Gen/WorkspaceParser.fs"
+# 1127 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 134 "WorkspaceParser/Parser.fsy"
+# 141 "WorkspaceParser/Parser.fsy"
                                     _1 
                    )
-# 134 "WorkspaceParser/Parser.fsy"
+# 141 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1099 "Gen/WorkspaceParser.fs"
+# 1138 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 136 "WorkspaceParser/Parser.fsy"
+# 143 "WorkspaceParser/Parser.fsy"
                                                 Expr.Function (Function.Item, [_1;  _3]) 
                    )
-# 136 "WorkspaceParser/Parser.fsy"
+# 143 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1111 "Gen/WorkspaceParser.fs"
+# 1150 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 137 "WorkspaceParser/Parser.fsy"
+# 144 "WorkspaceParser/Parser.fsy"
                                                          Expr.Function (Function.TryItem, [_1; _3]) 
                    )
-# 137 "WorkspaceParser/Parser.fsy"
+# 144 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1123 "Gen/WorkspaceParser.fs"
+# 1162 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 138 "WorkspaceParser/Parser.fsy"
+# 145 "WorkspaceParser/Parser.fsy"
                                                     Expr.Function (Function.Equal, [_1; _3]) 
                    )
-# 138 "WorkspaceParser/Parser.fsy"
+# 145 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1135 "Gen/WorkspaceParser.fs"
+# 1174 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 139 "WorkspaceParser/Parser.fsy"
+# 146 "WorkspaceParser/Parser.fsy"
                                                  Expr.Function (Function.NotEqual, [_1; _3]) 
                    )
-# 139 "WorkspaceParser/Parser.fsy"
+# 146 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1147 "Gen/WorkspaceParser.fs"
+# 1186 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 140 "WorkspaceParser/Parser.fsy"
+# 147 "WorkspaceParser/Parser.fsy"
                                             Expr.Function (Function.Plus, [_1; _3]) 
                    )
-# 140 "WorkspaceParser/Parser.fsy"
+# 147 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1159 "Gen/WorkspaceParser.fs"
+# 1198 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 141 "WorkspaceParser/Parser.fsy"
+# 148 "WorkspaceParser/Parser.fsy"
                                              Expr.Function (Function.Minus, [_1; _3]) 
                    )
-# 141 "WorkspaceParser/Parser.fsy"
+# 148 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1171 "Gen/WorkspaceParser.fs"
+# 1210 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 142 "WorkspaceParser/Parser.fsy"
+# 149 "WorkspaceParser/Parser.fsy"
                                            Expr.Function (Function.And, [_1; _3]) 
                    )
-# 142 "WorkspaceParser/Parser.fsy"
+# 149 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1183 "Gen/WorkspaceParser.fs"
+# 1222 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 143 "WorkspaceParser/Parser.fsy"
+# 150 "WorkspaceParser/Parser.fsy"
                                           Expr.Function (Function.Or, [_1; _3]) 
                    )
-# 143 "WorkspaceParser/Parser.fsy"
+# 150 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1195 "Gen/WorkspaceParser.fs"
+# 1234 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 144 "WorkspaceParser/Parser.fsy"
+# 151 "WorkspaceParser/Parser.fsy"
                                             Expr.Function (Function.Trim, _2) 
                    )
-# 144 "WorkspaceParser/Parser.fsy"
+# 151 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1206 "Gen/WorkspaceParser.fs"
+# 1245 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 145 "WorkspaceParser/Parser.fsy"
+# 152 "WorkspaceParser/Parser.fsy"
                                              Expr.Function (Function.Upper, _2) 
                    )
-# 145 "WorkspaceParser/Parser.fsy"
+# 152 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1217 "Gen/WorkspaceParser.fs"
+# 1256 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 146 "WorkspaceParser/Parser.fsy"
+# 153 "WorkspaceParser/Parser.fsy"
                                              Expr.Function (Function.Lower, _2) 
                    )
-# 146 "WorkspaceParser/Parser.fsy"
+# 153 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1228 "Gen/WorkspaceParser.fs"
+# 1267 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 147 "WorkspaceParser/Parser.fsy"
+# 154 "WorkspaceParser/Parser.fsy"
                                                Expr.Function (Function.Replace, _2) 
                    )
-# 147 "WorkspaceParser/Parser.fsy"
+# 154 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1239 "Gen/WorkspaceParser.fs"
+# 1278 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 148 "WorkspaceParser/Parser.fsy"
+# 155 "WorkspaceParser/Parser.fsy"
                                              Expr.Function (Function.Count, _2)
                    )
-# 148 "WorkspaceParser/Parser.fsy"
+# 155 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1250 "Gen/WorkspaceParser.fs"
+# 1289 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 149 "WorkspaceParser/Parser.fsy"
+# 156 "WorkspaceParser/Parser.fsy"
                                                Expr.Function (Function.Version, _2) 
                    )
-# 149 "WorkspaceParser/Parser.fsy"
+# 156 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1261 "Gen/WorkspaceParser.fs"
+# 1300 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 150 "WorkspaceParser/Parser.fsy"
+# 157 "WorkspaceParser/Parser.fsy"
                                               Expr.Function (Function.Format, _2) 
                    )
-# 150 "WorkspaceParser/Parser.fsy"
+# 157 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1272 "Gen/WorkspaceParser.fs"
+# 1311 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 151 "WorkspaceParser/Parser.fsy"
+# 158 "WorkspaceParser/Parser.fsy"
                                                 Expr.Function (Function.ToString, _2) 
                    )
-# 151 "WorkspaceParser/Parser.fsy"
+# 158 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1283 "Gen/WorkspaceParser.fs"
+# 1322 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 152 "WorkspaceParser/Parser.fsy"
+# 159 "WorkspaceParser/Parser.fsy"
                                                        Expr.Function (Function.Coalesce, [_1; _3]) 
                    )
-# 152 "WorkspaceParser/Parser.fsy"
+# 159 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1295 "Gen/WorkspaceParser.fs"
+# 1334 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
@@ -1300,271 +1339,271 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 153 "WorkspaceParser/Parser.fsy"
+# 160 "WorkspaceParser/Parser.fsy"
                                                            Expr.Function (Function.Ternary, [_1; _3; _5] ) 
                    )
-# 153 "WorkspaceParser/Parser.fsy"
+# 160 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1308 "Gen/WorkspaceParser.fs"
+# 1347 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 154 "WorkspaceParser/Parser.fsy"
+# 161 "WorkspaceParser/Parser.fsy"
                                        Expr.Function (Function.Not, [_2]) 
                    )
-# 154 "WorkspaceParser/Parser.fsy"
+# 161 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Expr));
-# 1319 "Gen/WorkspaceParser.fs"
+# 1358 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 158 "WorkspaceParser/Parser.fsy"
+# 165 "WorkspaceParser/Parser.fsy"
                                      Expr.Nothing 
                    )
-# 158 "WorkspaceParser/Parser.fsy"
+# 165 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1329 "Gen/WorkspaceParser.fs"
+# 1368 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 159 "WorkspaceParser/Parser.fsy"
+# 166 "WorkspaceParser/Parser.fsy"
                                   Expr.Bool true 
                    )
-# 159 "WorkspaceParser/Parser.fsy"
+# 166 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1339 "Gen/WorkspaceParser.fs"
+# 1378 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 160 "WorkspaceParser/Parser.fsy"
+# 167 "WorkspaceParser/Parser.fsy"
                                    Expr.Bool false 
                    )
-# 160 "WorkspaceParser/Parser.fsy"
+# 167 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1349 "Gen/WorkspaceParser.fs"
+# 1388 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 161 "WorkspaceParser/Parser.fsy"
+# 168 "WorkspaceParser/Parser.fsy"
                                     Expr.Number _1 
                    )
-# 161 "WorkspaceParser/Parser.fsy"
+# 168 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1360 "Gen/WorkspaceParser.fs"
+# 1399 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 162 "WorkspaceParser/Parser.fsy"
+# 169 "WorkspaceParser/Parser.fsy"
                                       Expr.Variable _1 
                    )
-# 162 "WorkspaceParser/Parser.fsy"
+# 169 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1371 "Gen/WorkspaceParser.fs"
+# 1410 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 164 "WorkspaceParser/Parser.fsy"
+# 171 "WorkspaceParser/Parser.fsy"
                                                             Expr.Function (Function.Item, [_1;  _3]) 
                    )
-# 164 "WorkspaceParser/Parser.fsy"
+# 171 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1383 "Gen/WorkspaceParser.fs"
+# 1422 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_ExprIndex in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 165 "WorkspaceParser/Parser.fsy"
+# 172 "WorkspaceParser/Parser.fsy"
                                                                      Expr.Function (Function.TryItem, [_1; _3]) 
                    )
-# 165 "WorkspaceParser/Parser.fsy"
+# 172 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1395 "Gen/WorkspaceParser.fs"
+# 1434 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 166 "WorkspaceParser/Parser.fsy"
+# 173 "WorkspaceParser/Parser.fsy"
                                                                             Expr.Function (Function.Equal, [_1; _3]) 
                    )
-# 166 "WorkspaceParser/Parser.fsy"
+# 173 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1407 "Gen/WorkspaceParser.fs"
+# 1446 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 167 "WorkspaceParser/Parser.fsy"
+# 174 "WorkspaceParser/Parser.fsy"
                                                                          Expr.Function (Function.NotEqual, [_1; _3]) 
                    )
-# 167 "WorkspaceParser/Parser.fsy"
+# 174 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1419 "Gen/WorkspaceParser.fs"
+# 1458 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 168 "WorkspaceParser/Parser.fsy"
+# 175 "WorkspaceParser/Parser.fsy"
                                                                     Expr.Function (Function.Plus, [_1; _3]) 
                    )
-# 168 "WorkspaceParser/Parser.fsy"
+# 175 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1431 "Gen/WorkspaceParser.fs"
+# 1470 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 169 "WorkspaceParser/Parser.fsy"
+# 176 "WorkspaceParser/Parser.fsy"
                                                                      Expr.Function (Function.Minus, [_1; _3]) 
                    )
-# 169 "WorkspaceParser/Parser.fsy"
+# 176 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1443 "Gen/WorkspaceParser.fs"
+# 1482 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 170 "WorkspaceParser/Parser.fsy"
+# 177 "WorkspaceParser/Parser.fsy"
                                                                    Expr.Function (Function.And, [_1; _3]) 
                    )
-# 170 "WorkspaceParser/Parser.fsy"
+# 177 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1455 "Gen/WorkspaceParser.fs"
+# 1494 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 171 "WorkspaceParser/Parser.fsy"
+# 178 "WorkspaceParser/Parser.fsy"
                                                                   Expr.Function (Function.Or, [_1; _3]) 
                    )
-# 171 "WorkspaceParser/Parser.fsy"
+# 178 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1467 "Gen/WorkspaceParser.fs"
+# 1506 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 172 "WorkspaceParser/Parser.fsy"
+# 179 "WorkspaceParser/Parser.fsy"
                                                         Expr.Function (Function.Trim, _2) 
                    )
-# 172 "WorkspaceParser/Parser.fsy"
+# 179 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1478 "Gen/WorkspaceParser.fs"
+# 1517 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 173 "WorkspaceParser/Parser.fsy"
+# 180 "WorkspaceParser/Parser.fsy"
                                                          Expr.Function (Function.Upper, _2) 
                    )
-# 173 "WorkspaceParser/Parser.fsy"
+# 180 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1489 "Gen/WorkspaceParser.fs"
+# 1528 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 174 "WorkspaceParser/Parser.fsy"
+# 181 "WorkspaceParser/Parser.fsy"
                                                          Expr.Function (Function.Lower, _2) 
                    )
-# 174 "WorkspaceParser/Parser.fsy"
+# 181 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1500 "Gen/WorkspaceParser.fs"
+# 1539 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 175 "WorkspaceParser/Parser.fsy"
+# 182 "WorkspaceParser/Parser.fsy"
                                                            Expr.Function (Function.Replace, _2) 
                    )
-# 175 "WorkspaceParser/Parser.fsy"
+# 182 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1511 "Gen/WorkspaceParser.fs"
+# 1550 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 176 "WorkspaceParser/Parser.fsy"
+# 183 "WorkspaceParser/Parser.fsy"
                                                          Expr.Function (Function.Count, _2)
                    )
-# 176 "WorkspaceParser/Parser.fsy"
+# 183 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1522 "Gen/WorkspaceParser.fs"
+# 1561 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 177 "WorkspaceParser/Parser.fsy"
+# 184 "WorkspaceParser/Parser.fsy"
                                                            Expr.Function (Function.Version, _2) 
                    )
-# 177 "WorkspaceParser/Parser.fsy"
+# 184 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1533 "Gen/WorkspaceParser.fs"
+# 1572 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 178 "WorkspaceParser/Parser.fsy"
+# 185 "WorkspaceParser/Parser.fsy"
                                                           Expr.Function (Function.Format, _2) 
                    )
-# 178 "WorkspaceParser/Parser.fsy"
+# 185 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1544 "Gen/WorkspaceParser.fs"
+# 1583 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTuple in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 179 "WorkspaceParser/Parser.fsy"
+# 186 "WorkspaceParser/Parser.fsy"
                                                             Expr.Function (Function.ToString, _2) 
                    )
-# 179 "WorkspaceParser/Parser.fsy"
+# 186 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1555 "Gen/WorkspaceParser.fs"
+# 1594 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 180 "WorkspaceParser/Parser.fsy"
+# 187 "WorkspaceParser/Parser.fsy"
                                                                                Expr.Function (Function.Coalesce, [_1; _3]) 
                    )
-# 180 "WorkspaceParser/Parser.fsy"
+# 187 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1567 "Gen/WorkspaceParser.fs"
+# 1606 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
@@ -1572,161 +1611,161 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 181 "WorkspaceParser/Parser.fsy"
+# 188 "WorkspaceParser/Parser.fsy"
                                                                                    Expr.Function (Function.Ternary, [_1; _3; _5] ) 
                    )
-# 181 "WorkspaceParser/Parser.fsy"
+# 188 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1580 "Gen/WorkspaceParser.fs"
+# 1619 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 182 "WorkspaceParser/Parser.fsy"
+# 189 "WorkspaceParser/Parser.fsy"
                                                    Expr.Function (Function.Not, [_2]) 
                    )
-# 182 "WorkspaceParser/Parser.fsy"
+# 189 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExpr));
-# 1591 "Gen/WorkspaceParser.fs"
+# 1630 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 185 "WorkspaceParser/Parser.fsy"
+# 192 "WorkspaceParser/Parser.fsy"
                                                _1 
                    )
-# 185 "WorkspaceParser/Parser.fsy"
+# 192 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetIdentifier));
-# 1602 "Gen/WorkspaceParser.fs"
+# 1641 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 186 "WorkspaceParser/Parser.fsy"
+# 193 "WorkspaceParser/Parser.fsy"
                                         _1 
                    )
-# 186 "WorkspaceParser/Parser.fsy"
+# 193 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetIdentifier));
-# 1613 "Gen/WorkspaceParser.fs"
+# 1652 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 189 "WorkspaceParser/Parser.fsy"
+# 196 "WorkspaceParser/Parser.fsy"
                                                   _1 
                    )
-# 189 "WorkspaceParser/Parser.fsy"
+# 196 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionIdentifier));
-# 1624 "Gen/WorkspaceParser.fs"
+# 1663 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 190 "WorkspaceParser/Parser.fsy"
+# 197 "WorkspaceParser/Parser.fsy"
                                         _1 
                    )
-# 190 "WorkspaceParser/Parser.fsy"
+# 197 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExtensionIdentifier));
-# 1635 "Gen/WorkspaceParser.fs"
+# 1674 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> int in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 193 "WorkspaceParser/Parser.fsy"
+# 200 "WorkspaceParser/Parser.fsy"
                                     Expr.Number _1 
                    )
-# 193 "WorkspaceParser/Parser.fsy"
+# 200 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprIndex));
-# 1646 "Gen/WorkspaceParser.fs"
+# 1685 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 194 "WorkspaceParser/Parser.fsy"
+# 201 "WorkspaceParser/Parser.fsy"
                                         Expr.String _1 
                    )
-# 194 "WorkspaceParser/Parser.fsy"
+# 201 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprIndex));
-# 1657 "Gen/WorkspaceParser.fs"
+# 1696 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 197 "WorkspaceParser/Parser.fsy"
+# 204 "WorkspaceParser/Parser.fsy"
                                   true 
                    )
-# 197 "WorkspaceParser/Parser.fsy"
+# 204 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Bool));
-# 1667 "Gen/WorkspaceParser.fs"
+# 1706 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 198 "WorkspaceParser/Parser.fsy"
+# 205 "WorkspaceParser/Parser.fsy"
                                    false 
                    )
-# 198 "WorkspaceParser/Parser.fsy"
+# 205 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Bool));
-# 1677 "Gen/WorkspaceParser.fs"
+# 1716 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 201 "WorkspaceParser/Parser.fsy"
+# 208 "WorkspaceParser/Parser.fsy"
                                     Expr.String _1 
                    )
-# 201 "WorkspaceParser/Parser.fsy"
+# 208 "WorkspaceParser/Parser.fsy"
                  : 'gentype_String));
-# 1688 "Gen/WorkspaceParser.fs"
+# 1727 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 202 "WorkspaceParser/Parser.fsy"
+# 209 "WorkspaceParser/Parser.fsy"
                                                      Expr.String _2 
                    )
-# 202 "WorkspaceParser/Parser.fsy"
+# 209 "WorkspaceParser/Parser.fsy"
                  : 'gentype_String));
-# 1699 "Gen/WorkspaceParser.fs"
+# 1738 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedString in
             let _3 = parseState.GetInput(3) :?> string in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 203 "WorkspaceParser/Parser.fsy"
+# 210 "WorkspaceParser/Parser.fsy"
                                                                         
                              if _3 |> String.IsNullOrEmpty then Expr.Function (Function.ToString, [_2])
                              else Expr.Function (Function.Format, [Expr.String "{0}{1}"; _2; Expr.String _3]) 
                          
                    )
-# 203 "WorkspaceParser/Parser.fsy"
+# 210 "WorkspaceParser/Parser.fsy"
                  : 'gentype_String));
-# 1714 "Gen/WorkspaceParser.fs"
+# 1753 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> string in
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 209 "WorkspaceParser/Parser.fsy"
+# 216 "WorkspaceParser/Parser.fsy"
                                                                   
                              if _1 |> String.IsNullOrEmpty then _2
                              else Expr.Function (Function.Format, [Expr.String "{0}{1}"; Expr.String _1; _2])
                          
                    )
-# 209 "WorkspaceParser/Parser.fsy"
+# 216 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedString));
-# 1729 "Gen/WorkspaceParser.fs"
+# 1768 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedString in
             let _2 = parseState.GetInput(2) :?> string in
@@ -1734,157 +1773,157 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 213 "WorkspaceParser/Parser.fsy"
+# 220 "WorkspaceParser/Parser.fsy"
                                                                                     
                              if _2 |> String.IsNullOrEmpty then Expr.Function (Function.Format, [Expr.String "{0}{1}"; _1; _3])
                              else Expr.Function (Function.Format, [Expr.String "{0}{1}{2}"; _1; Expr.String _2; _3])
                          
                    )
-# 213 "WorkspaceParser/Parser.fsy"
+# 220 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedString));
-# 1745 "Gen/WorkspaceParser.fs"
+# 1784 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprTupleContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 219 "WorkspaceParser/Parser.fsy"
+# 226 "WorkspaceParser/Parser.fsy"
                                                             _2 
                    )
-# 219 "WorkspaceParser/Parser.fsy"
+# 226 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprTuple));
-# 1756 "Gen/WorkspaceParser.fs"
+# 1795 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 221 "WorkspaceParser/Parser.fsy"
+# 228 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 221 "WorkspaceParser/Parser.fsy"
+# 228 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprTupleContent));
-# 1766 "Gen/WorkspaceParser.fs"
+# 1805 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 222 "WorkspaceParser/Parser.fsy"
+# 229 "WorkspaceParser/Parser.fsy"
                                   [_1] 
                    )
-# 222 "WorkspaceParser/Parser.fsy"
+# 229 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprTupleContent));
-# 1777 "Gen/WorkspaceParser.fs"
+# 1816 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprTupleContent in
             let _3 = parseState.GetInput(3) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 223 "WorkspaceParser/Parser.fsy"
+# 230 "WorkspaceParser/Parser.fsy"
                                                          _1 @ [_3] 
                    )
-# 223 "WorkspaceParser/Parser.fsy"
+# 230 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprTupleContent));
-# 1789 "Gen/WorkspaceParser.fs"
+# 1828 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_InterpolatedExprTupleContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 226 "WorkspaceParser/Parser.fsy"
+# 233 "WorkspaceParser/Parser.fsy"
                                                                         _2 
                    )
-# 226 "WorkspaceParser/Parser.fsy"
+# 233 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExprTuple));
-# 1800 "Gen/WorkspaceParser.fs"
+# 1839 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 228 "WorkspaceParser/Parser.fsy"
+# 235 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 228 "WorkspaceParser/Parser.fsy"
+# 235 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExprTupleContent));
-# 1810 "Gen/WorkspaceParser.fs"
+# 1849 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 229 "WorkspaceParser/Parser.fsy"
+# 236 "WorkspaceParser/Parser.fsy"
                                               [_1] 
                    )
-# 229 "WorkspaceParser/Parser.fsy"
+# 236 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExprTupleContent));
-# 1821 "Gen/WorkspaceParser.fs"
+# 1860 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_InterpolatedExprTupleContent in
             let _3 = parseState.GetInput(3) :?> 'gentype_InterpolatedExpr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 230 "WorkspaceParser/Parser.fsy"
+# 237 "WorkspaceParser/Parser.fsy"
                                                                                  _1 @ [_3] 
                    )
-# 230 "WorkspaceParser/Parser.fsy"
+# 237 "WorkspaceParser/Parser.fsy"
                  : 'gentype_InterpolatedExprTupleContent));
-# 1833 "Gen/WorkspaceParser.fs"
+# 1872 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprListContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 233 "WorkspaceParser/Parser.fsy"
+# 240 "WorkspaceParser/Parser.fsy"
                                                                    _2 
                    )
-# 233 "WorkspaceParser/Parser.fsy"
+# 240 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprList));
-# 1844 "Gen/WorkspaceParser.fs"
+# 1883 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 235 "WorkspaceParser/Parser.fsy"
+# 242 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 235 "WorkspaceParser/Parser.fsy"
+# 242 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprListContent));
-# 1854 "Gen/WorkspaceParser.fs"
+# 1893 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprListContent in
             let _2 = parseState.GetInput(2) :?> 'gentype_Expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 236 "WorkspaceParser/Parser.fsy"
+# 243 "WorkspaceParser/Parser.fsy"
                                                   _1 @ [_2] 
                    )
-# 236 "WorkspaceParser/Parser.fsy"
+# 243 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprListContent));
-# 1866 "Gen/WorkspaceParser.fs"
+# 1905 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_ExprMapContent in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 239 "WorkspaceParser/Parser.fsy"
+# 246 "WorkspaceParser/Parser.fsy"
                                                           _2 
                    )
-# 239 "WorkspaceParser/Parser.fsy"
+# 246 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprMap));
-# 1877 "Gen/WorkspaceParser.fs"
+# 1916 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 241 "WorkspaceParser/Parser.fsy"
+# 248 "WorkspaceParser/Parser.fsy"
                                          Map.empty 
                    )
-# 241 "WorkspaceParser/Parser.fsy"
+# 248 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprMapContent));
-# 1887 "Gen/WorkspaceParser.fs"
+# 1926 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_ExprMapContent in
             let _2 = parseState.GetInput(2) :?> string in
@@ -1892,79 +1931,79 @@ let _fsyacc_reductions = lazy [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 242 "WorkspaceParser/Parser.fsy"
+# 249 "WorkspaceParser/Parser.fsy"
                                                      _1.Add (_2, _3) 
                    )
-# 242 "WorkspaceParser/Parser.fsy"
+# 249 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ExprMapContent));
-# 1900 "Gen/WorkspaceParser.fs"
+# 1939 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_Strings in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 245 "WorkspaceParser/Parser.fsy"
+# 252 "WorkspaceParser/Parser.fsy"
                                                            _2 
                    )
-# 245 "WorkspaceParser/Parser.fsy"
+# 252 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ListOfString));
-# 1911 "Gen/WorkspaceParser.fs"
+# 1950 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 247 "WorkspaceParser/Parser.fsy"
+# 254 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 247 "WorkspaceParser/Parser.fsy"
+# 254 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Strings));
-# 1921 "Gen/WorkspaceParser.fs"
+# 1960 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_Strings in
             let _2 = parseState.GetInput(2) :?> 'gentype_String in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 248 "WorkspaceParser/Parser.fsy"
+# 255 "WorkspaceParser/Parser.fsy"
                                             _1 @ [_2] 
                    )
-# 248 "WorkspaceParser/Parser.fsy"
+# 255 "WorkspaceParser/Parser.fsy"
                  : 'gentype_Strings));
-# 1933 "Gen/WorkspaceParser.fs"
+# 1972 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetIdentifiers in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 251 "WorkspaceParser/Parser.fsy"
+# 258 "WorkspaceParser/Parser.fsy"
                                                                      _2 
                    )
-# 251 "WorkspaceParser/Parser.fsy"
+# 258 "WorkspaceParser/Parser.fsy"
                  : 'gentype_ListOfTargetIdentifiers));
-# 1944 "Gen/WorkspaceParser.fs"
+# 1983 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 253 "WorkspaceParser/Parser.fsy"
+# 260 "WorkspaceParser/Parser.fsy"
                                          [] 
                    )
-# 253 "WorkspaceParser/Parser.fsy"
+# 260 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetIdentifiers));
-# 1954 "Gen/WorkspaceParser.fs"
+# 1993 "Gen/WorkspaceParser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_TargetIdentifiers in
             let _2 = parseState.GetInput(2) :?> 'gentype_TargetIdentifier in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 254 "WorkspaceParser/Parser.fsy"
+# 261 "WorkspaceParser/Parser.fsy"
                                                                 _1 @ [_2] 
                    )
-# 254 "WorkspaceParser/Parser.fsy"
+# 261 "WorkspaceParser/Parser.fsy"
                  : 'gentype_TargetIdentifiers));
 |]
-# 1967 "Gen/WorkspaceParser.fs"
+# 2006 "Gen/WorkspaceParser.fs"
 let tables : FSharp.Text.Parsing.Tables<_> = 
   { reductions = _fsyacc_reductions.Value;
     endOfInputTag = _fsyacc_endOfInputTag;

--- a/src/Terrabuild.Configuration/Gen/WorkspaceParser.fsi
+++ b/src/Terrabuild.Configuration/Gen/WorkspaceParser.fsi
@@ -144,6 +144,8 @@ type nonTerminalId =
     | NONTERM_ExtensionVariables
     | NONTERM_ExtensionScript
     | NONTERM_ExtensionDefaults
+    | NONTERM_ExtensionDefaultsComponents
+    | NONTERM_ExtensionDefaultsComponentsVariable
     | NONTERM_Expr
     | NONTERM_InterpolatedExpr
     | NONTERM_TargetIdentifier

--- a/src/Terrabuild.Configuration/ProjectParser/Parser.fsy
+++ b/src/Terrabuild.Configuration/ProjectParser/Parser.fsy
@@ -94,7 +94,12 @@ ExtensionVariables:
 ExtensionScript:
     | SCRIPT EQUAL String { ExtensionComponents.Script $3 }
 ExtensionDefaults:
-    | DEFAULTS EQUAL ExprMap { ExtensionComponents.Defaults $3 }
+    | DEFAULTS LBRACE ExtensionDefaultsComponents RBRACE { ExtensionComponents.Defaults $3 }
+ExtensionDefaultsComponents:
+    | /* empty */ { [] }
+    | ExtensionDefaultsComponents ExtensionDefaultsComponentsVariable { $1 @ [$2] }
+ExtensionDefaultsComponentsVariable:
+    | IDENTIFIER EQUAL Expr { ($1, $3) }
 
 
 Project:

--- a/src/Terrabuild.Configuration/WorkspaceParser/Parser.fsy
+++ b/src/Terrabuild.Configuration/WorkspaceParser/Parser.fsy
@@ -119,7 +119,14 @@ ExtensionVariables:
 ExtensionScript:
     | SCRIPT EQUAL String { ExtensionComponents.Script $3 }
 ExtensionDefaults:
-    | DEFAULTS EQUAL ExprMap { ExtensionComponents.Defaults $3 }
+    | DEFAULTS LBRACE ExtensionDefaultsComponents RBRACE { ExtensionComponents.Defaults $3 }
+ExtensionDefaultsComponents:
+    | /* empty */ { [] }
+    | ExtensionDefaultsComponents ExtensionDefaultsComponentsVariable { $1 @ [$2] }
+ExtensionDefaultsComponentsVariable:
+    | IDENTIFIER EQUAL Expr { ($1, $3) }
+
+
 
 Expr:
     /* structures */

--- a/src/Terrabuild/PROJECT
+++ b/src/Terrabuild/PROJECT
@@ -5,8 +5,8 @@ project @dotnet {
 }
 
 extension @docker {
-  defaults = {
-    image: "ghcr.io/magnusopera/terrabuild"
+  defaults {
+    `image` = "ghcr.io/magnusopera/terrabuild"
   }
 }
 

--- a/tests/simple/WORKSPACE
+++ b/tests/simple/WORKSPACE
@@ -37,16 +37,16 @@ target deploy {
 extension @dotnet {
   container = "mcr.microsoft.com/dotnet/sdk:9.0.202"
   platform = "linux/amd64"
-  defaults = {
-    configuration: $configuration
+  defaults {
+    `configuration` = $configuration
   }
 }
 
 extension @terraform {
   container = "hashicorp/terraform:1.10"
   platform = "linux/amd64"
-  defaults = {
-    workspace: $workspace
+  defaults {
+    `workspace` = $workspace
   }
 }
 

--- a/tests/simple/projects/dotnet-app/PROJECT
+++ b/tests/simple/projects/dotnet-app/PROJECT
@@ -1,8 +1,8 @@
 
 extension @docker {
-    defaults = {
-        image: "ghcr.io/magnusopera/dotnet-app"
-        arguments: { configuration: $configuration }
+    defaults {
+        `image` = "ghcr.io/magnusopera/dotnet-app"
+        arguments = { configuration: $configuration }
     }
 }
 


### PR DESCRIPTION
simplify syntax for extension defaults.

old syntax:
```
extension @docker {
    defaults = {
        image: "ghcr.io/magnusopera/dotnet-app"
        arguments: { configuration: $configuration }
    }
}
```

new syntax:
```
extension @docker {
    defaults {
        `image` = "ghcr.io/magnusopera/dotnet-app"
        arguments = { configuration: $configuration }
    }
}
```