### PR TITLE
fix invalid optimization for nop nodes

### DIFF
--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -162,7 +162,6 @@ let private loadProjectDef (options: ConfigOptions.Options) (workspaceConfig: AS
         |> Set.union (Dependencies.reflectionFind projectConfig)
         |> Set.choose (fun dep -> if dep.StartsWith("project.") then Some dep else None)
 
-    let projectId = projectConfig.Project.Id
     let projectIgnores = projectConfig.Project.Ignores |> evalAsStringSet
     let projectOutputs = projectConfig.Project.Outputs |> evalAsStringSet
     let projectDependencies = projectConfig.Project.Dependencies |> evalAsStringSet
@@ -215,7 +214,7 @@ let private loadProjectDef (options: ConfigOptions.Options) (workspaceConfig: AS
             if projectConfig.Locals |> Map.containsKey name then raiseParseError $"Duplicated local: {name}")
         workspaceConfig.Locals |> Map.addMap projectConfig.Locals
 
-    { LoadedProject.Id = projectId
+    { LoadedProject.Id = projectConfig.Project.Id
       LoadedProject.DependsOn = dependsOn
       LoadedProject.Dependencies = projectDependencies
       LoadedProject.Includes = includes


### PR DESCRIPTION
Graph was invalid in some cases when trying to optimize nop nodes (nodes that just does nothing like empty targets).

If the builder decides not to create a node (because the node does nothing), it now store dependencies appart to reuse them. Previously, the builder was reporting nop nodes, leading to stronger dependencies as required (and sometimes wrong dependencies).