### PR TITLE
rename for consistency with project.id.version

### DIFF
--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -375,7 +375,7 @@ let private finalizeProject projectDir evaluationContext (projectDef: LoadedProj
                     let terrabuildProjectVars =
                         Map [ "terrabuild.project", Value.String projectId
                               "terrabuild.target" , Value.String targetName
-                              "terrabuild.hash", Value.String projectHash ]
+                              "terrabuild.version", Value.String projectHash ]
 
                     let projectVars =
                         projectDependencies


### PR DESCRIPTION
Different syntax but same meaning for `terrabuild.hash` and `project.id.version`. This PR changes this.

`terrabuild.hash` ==> `terrabuild.version`
