### PR TITLE
feat: add version check

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,9 @@
         <DebugType>embedded</DebugType>
         <Nullable>enable</Nullable>
         <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
+        <Version Condition=" '$(Version)' == '' ">0.0.0</Version>
+        <AssemblyVersion>$(Version)</AssemblyVersion>
+        <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Terrabuild.Configuration.Tests/Workspace.fs
+++ b/src/Terrabuild.Configuration.Tests/Workspace.fs
@@ -47,7 +47,8 @@ let parseWorkspace() =
               Defaults = None }
 
         { WorkspaceFile.Workspace = { Id = "d7528db2-83e0-4164-8c8e-1e0d6d6357ca" |> Some
-                                      Ignores = Set [ "**/node_modules" ] |> Some }
+                                      Ignores = Set [ "**/node_modules" ] |> Some
+                                      Version = None }
           WorkspaceFile.Targets = Map [ "build", targetBuild
                                         "dist", targetDist
                                         "dummy", targetDummy ]
@@ -98,7 +99,7 @@ let parseWorkspace2() =
               Script = None
               Defaults = None }
 
-        { WorkspaceFile.Workspace = { Id = None; Ignores = None }
+        { WorkspaceFile.Workspace = { Id = None; Ignores = None; Version = None }
           WorkspaceFile.Targets = Map [ "build", targetBuild
                                         "dist", targetDist
                                         "dummy", targetDummy ]

--- a/src/Terrabuild.Configuration/AST/Workspace.fs
+++ b/src/Terrabuild.Configuration/AST/Workspace.fs
@@ -7,7 +7,8 @@ open Terrabuild.Expressions
 [<RequireQualifiedAccess>]
 type WorkspaceBlock =
     { Id: string option
-      Ignores: Set<string> option }
+      Ignores: Set<string> option
+      Version: string option }
 
 [<RequireQualifiedAccess>]
 type TargetBlock =

--- a/src/Terrabuild.Configuration/Transpiler/Workspace.fs
+++ b/src/Terrabuild.Configuration/Transpiler/Workspace.fs
@@ -28,7 +28,7 @@ let (|Workspace|Target|Variable|Locals|Extension|UnknownBlock|) (block: Block) =
 
 let toWorkspace (block: Block) =
     block
-    |> checkAllowedAttributes ["id"; "ignores"]
+    |> checkAllowedAttributes ["id"; "ignores"; "version"]
     |> checkNoNestedBlocks
     |> ignore
 
@@ -38,9 +38,13 @@ let toWorkspace (block: Block) =
     let ignores =
         block |> tryFindAttribute "ignores"
         |> Option.bind (Eval.asStringSetOption << simpleEval)
+    let version =
+        block |> tryFindAttribute "version"
+        |> Option.bind (Eval.asStringOption << simpleEval)
 
     { WorkspaceBlock.Id = id
-      WorkspaceBlock.Ignores = ignores }
+      WorkspaceBlock.Ignores = ignores
+      WorkspaceBlock.Version = version }
 
 
 let toTarget (block: Block) =
@@ -96,7 +100,8 @@ let transpile (blocks: Block list) =
             let workspace =
                 match builder.Workspace with
                 | None -> { WorkspaceBlock.Id = None
-                            WorkspaceBlock.Ignores = None }
+                            WorkspaceBlock.Ignores = None
+                            WorkspaceBlock.Version = None }
                 | Some workspace -> workspace
 
             { WorkspaceFile.Workspace = workspace

--- a/src/Terrabuild.Tests/packages.lock.json
+++ b/src/Terrabuild.Tests/packages.lock.json
@@ -520,6 +520,11 @@
         "resolved": "4.3.2",
         "contentHash": "leXiwfiIkW7Gmn7cgnNcdtNAU70SjmKW3jxGj1iKHOvdn0zRWsgv/l2OJUO5zdGdiv2VRFnAsxxhDgMzofPdWg=="
       },
+      "SemanticVersioning": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "RR+8GbPQ/gjDqov/1QN1OPoUlbUruNwcL3WjWCeLw+MY7+od/ENhnkYxCfAC6rQLIu3QifaJt3kPYyP3RumqMQ=="
+      },
       "Sentry": {
         "type": "Transitive",
         "resolved": "5.12.0",
@@ -1333,6 +1338,7 @@
           "FSharp.Core": "[9.0.300, )",
           "FSharp.Data": "[6.6.0, )",
           "FSharp.SystemTextJson": "[1.4.36, )",
+          "SemanticVersioning": "[3.0.0, )",
           "Sentry": "[5.12.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
           "System.Text.Json": "[9.0.0, )",

--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -613,6 +613,18 @@ let read (options: ConfigOptions.Options) =
         with exn ->
             raiseParserError("Failed to read WORKSPACE configuration file", exn)
 
+    // check min version requirement
+    match workspaceConfig.Workspace.Version with
+    | Some range ->
+        match SemanticVersioning.Range.TryParse range with
+        | true, range ->
+            let version = Version.version()
+            let version = SemanticVersioning.Version.Parse version
+            if range.IsSatisfied version |> not then
+                raiseInvalidArg $"Your terrabuild version '{version}' is unexpected. Use version '{range}'."
+        | _ -> raiseInvalidArg $"Version requirement '{range}' is invalid."
+    | _ -> ()
+
     let evaluationContext = buildEvaluationContext options workspaceConfig
 
     let scripts = buildScripts options workspaceConfig evaluationContext

--- a/src/Terrabuild/Helpers/Version.fs
+++ b/src/Terrabuild/Helpers/Version.fs
@@ -1,0 +1,11 @@
+
+module Version
+open System.Reflection
+
+let informalVersion () =
+    match Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>() with
+    | null -> "0.0.0"
+    | fileVersion -> fileVersion.InformationalVersion
+
+let version () =
+    informalVersion().Split("+")[0]

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -62,6 +62,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
             else loggerBuilder
         Log.Logger <- loggerBuilder.CreateLogger()
         Log.Debug("===== [Execution Start] =====")
+        Log.Debug($"Terrabuild: {Version.informalVersion()}")
         Log.Debug($"Environment: {RuntimeInformation.OSDescription}, {RuntimeInformation.OSArchitecture}, {Environment.Version}")
 
     let runTarget (options: RunTargetOptions) =
@@ -295,10 +296,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         0
 
     let version () =
-        let version =
-            match Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>() with
-            | null -> "0.0.0"
-            | fileVersion -> fileVersion.InformationalVersion
+        let version = Version.informalVersion()
         printfn $"Terrabuild v{version}"
         0
  

--- a/src/Terrabuild/Terrabuild.fsproj
+++ b/src/Terrabuild/Terrabuild.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Helpers/Terminal.fs" />
     <Compile Include="Helpers/Progress.fs" />
     <Compile Include="Helpers/Extensions.fs" />
+    <Compile Include="Helpers/Version.fs" />
     <Compile Include="Api/Client.fs" />
     <Compile Include="Api/Factory.fs" />
     <Compile Include="Core/Cache.fs" />
@@ -54,6 +55,7 @@
     <PackageReference Include="FSharp.Data" Version="6.6.0" />
     <PackageReference Include="FSharp.SystemTextJson" Version="1.4.36" />
     <PackageReference Include="Argu" Version="6.2.5" />
+    <PackageReference Include="SemanticVersioning" Version="3.0.0" />
     <PackageReference Include="Sentry" Version="5.12.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <!-- <PackageReference Include="FSharp.Data" Version="6.2.0" /> -->

--- a/src/Terrabuild/packages.lock.json
+++ b/src/Terrabuild/packages.lock.json
@@ -67,6 +67,12 @@
           "System.Text.Json": "6.0.10"
         }
       },
+      "SemanticVersioning": {
+        "type": "Direct",
+        "requested": "[3.0.0, )",
+        "resolved": "3.0.0",
+        "contentHash": "RR+8GbPQ/gjDqov/1QN1OPoUlbUruNwcL3WjWCeLw+MY7+od/ENhnkYxCfAC6rQLIu3QifaJt3kPYyP3RumqMQ=="
+      },
       "Sentry": {
         "type": "Direct",
         "requested": "[5.12.0, )",


### PR DESCRIPTION
`version` is a new attribute on `workspace` block allowing to require a specific terrabuild version.

eg:
```
workspace {
    version = "~0.157.0"
}
```