### PR TITLE
feat: parallel downloads

### DIFF
--- a/src/Terrabuild.PubSub.Tests/Hub.fs
+++ b/src/Terrabuild.PubSub.Tests/Hub.fs
@@ -39,12 +39,12 @@ let successful() =
             hub.GetSignal<int>("computed1").Value |> should equal 42
             triggered3 <- true
 
-        hub.SubscribeTask "subscription3" [ value1; value2 ] callback3
+        hub.Subscribe "subscription3" [ value1; value2 ] callback3
 
 
-    hub.SubscribeTask "callback0" [] callback0
-    hub.SubscribeTask "callback1" [ value1 ] callback1
-    hub.SubscribeTask "callback2" [ value1; value2 ] callback2
+    hub.Subscribe "callback0" [] callback0
+    hub.Subscribe "callback1" [ value1 ] callback1
+    hub.Subscribe "callback2" [ value1; value2 ] callback2
 
     computed1.Value <- 42
 
@@ -83,8 +83,8 @@ let exception_in_callback_is_error() =
         triggered2 <- true
         failwith "Callback shall never be called"
 
-    hub.SubscribeTask "subscription1" [ value1; value2 ] callback
-    hub.SubscribeTask "subscription2" [ value3 ] neverCallback
+    hub.Subscribe "subscription1" [ value1; value2 ] callback
+    hub.Subscribe "subscription2" [ value3 ] neverCallback
 
     computed1.Value <- 42
     computed2.Value <- "tralala"
@@ -124,8 +124,8 @@ let unsignaled_subscription1_is_error() =
         triggered2 <- true
         failwith "Callback shall never be called"
 
-    hub.SubscribeTask "subscription1" [ value1; value2 ] callback
-    hub.SubscribeTask "subscription2" [ value3 ] neverCallback
+    hub.Subscribe "subscription1" [ value1; value2 ] callback
+    hub.Subscribe "subscription2" [ value3 ] neverCallback
 
     computed1.Value <- 42
     computed2.Value <- "tralala"
@@ -167,8 +167,8 @@ let unsignaled_subscription2_is_error() =
         triggered2 <- true
         failwith "Callback shall never be called"
 
-    hub.SubscribeTask "subscription1" [ value1 ] callback
-    hub.SubscribeTask "subscription2" [ value2; value3 ] neverCallback
+    hub.Subscribe "subscription1" [ value1 ] callback
+    hub.Subscribe "subscription2" [ value2; value3 ] neverCallback
 
     computed1.Value <- 42
 

--- a/src/Terrabuild.PubSub.Tests/Hub.fs
+++ b/src/Terrabuild.PubSub.Tests/Hub.fs
@@ -2,18 +2,17 @@ module Terrabuild.PubSub.Tests
 
 open NUnit.Framework
 open FsUnit
-open System
 
 
 [<Test>]
 let successful() =
     let hub = Hub.Create(1)
 
-    let value1 = hub.GetSignalTask<int> "computed1"
-    let computed2 = hub.GetSignalTask<string> "computed2"
+    let value1 = hub.GetSignal<int> "computed1"
+    let computed2 = hub.GetSignal<string> "computed2"
 
-    let computed1 = hub.GetSignalTask<int> "computed1"
-    let value2 = hub.GetSignalTask<string> "computed2"
+    let computed1 = hub.GetSignal<int> "computed1"
+    let value2 = hub.GetSignal<string> "computed2"
 
     let mutable triggered0 = false
     let callback0() =
@@ -37,7 +36,7 @@ let successful() =
             // getting another computed lead to same value
             value1.Value |> should equal 42
             value2.Value |> should equal "tralala"
-            hub.GetSignalTask<int>("computed1").Value |> should equal 42
+            hub.GetSignal<int>("computed1").Value |> should equal 42
             triggered3 <- true
 
         hub.SubscribeTask "subscription3" [ value1; value2 ] callback3
@@ -64,13 +63,13 @@ let successful() =
 let exception_in_callback_is_error() =
     let hub = Hub.Create(1)
 
-    let value1 = hub.GetSignalTask<int> "computed1"
-    let computed2 = hub.GetSignalTask<string> "computed2"
-    let value3 = hub.GetSignalTask<float> "computed3"
+    let value1 = hub.GetSignal<int> "computed1"
+    let computed2 = hub.GetSignal<string> "computed2"
+    let value3 = hub.GetSignal<float> "computed3"
 
-    let computed1 = hub.GetSignalTask<int> "computed1"
-    let value2 = hub.GetSignalTask<string> "computed2"
-    let computed3 = hub.GetSignalTask<float> "computed3"
+    let computed1 = hub.GetSignal<int> "computed1"
+    let value2 = hub.GetSignal<string> "computed2"
+    let computed3 = hub.GetSignal<float> "computed3"
 
     let mutable triggered1 = false
     let callback() =
@@ -106,13 +105,13 @@ let exception_in_callback_is_error() =
 let unsignaled_subscription1_is_error() =
     let hub = Hub.Create(1)
 
-    let value1 = hub.GetSignalTask<int> "computed1"
-    let computed2 = hub.GetSignalTask<string> "computed2"
-    let value3 = hub.GetSignalTask<float> "computed3"
+    let value1 = hub.GetSignal<int> "computed1"
+    let computed2 = hub.GetSignal<string> "computed2"
+    let value3 = hub.GetSignal<float> "computed3"
 
-    let computed1 = hub.GetSignalTask<int> "computed1"
-    let value2 = hub.GetSignalTask<string> "computed2"
-    let computed3 = hub.GetSignalTask<float> "computed3"
+    let computed1 = hub.GetSignal<int> "computed1"
+    let value2 = hub.GetSignal<string> "computed2"
+    let computed3 = hub.GetSignal<float> "computed3"
 
     let mutable triggered1 = false
     let callback() =
@@ -150,13 +149,13 @@ let unsignaled_subscription1_is_error() =
 let unsignaled_subscription2_is_error() =
     let hub = Hub.Create(1)
 
-    let value1 = hub.GetSignalTask<int> "computed1"
-    let computed2 = hub.GetSignalTask<string> "computed2"
-    let value3 = hub.GetSignalTask<float> "computed3"
+    let value1 = hub.GetSignal<int> "computed1"
+    let computed2 = hub.GetSignal<string> "computed2"
+    let value3 = hub.GetSignal<float> "computed3"
 
-    let computed1 = hub.GetSignalTask<int> "computed1"
-    let value2 = hub.GetSignalTask<string> "computed2"
-    let computed3 = hub.GetSignalTask<float> "computed3"
+    let computed1 = hub.GetSignal<int> "computed1"
+    let value2 = hub.GetSignal<string> "computed2"
+    let computed3 = hub.GetSignal<float> "computed3"
 
     let mutable triggered1 = false
     let callback() =
@@ -192,19 +191,19 @@ let unsignaled_subscription2_is_error() =
 let computed_must_match_type() =
     let hub = Hub.Create(1)
 
-    let value1 = hub.GetSignalTask<int> "computed1"
-    (fun () -> hub.GetSignalTask<string> "computed1" |> ignore) |> should throw typeof<Errors.TerrabuildException>
+    let value1 = hub.GetSignal<int> "computed1"
+    (fun () -> hub.GetSignal<string> "computed1" |> ignore) |> should throw typeof<Errors.TerrabuildException>
 
-    let computed2 = hub.GetSignalTask<string> "computed2"
-    (fun () -> hub.GetSignalTask<int> "computed2" |> ignore) |> should throw typeof<Errors.TerrabuildException>
+    let computed2 = hub.GetSignal<string> "computed2"
+    (fun () -> hub.GetSignal<int> "computed2" |> ignore) |> should throw typeof<Errors.TerrabuildException>
 
 
 // Additional test for Download kind
 [<Test>]
 let download_subscription_priority() =
     let hub = Hub.Create(2)
-    let value1 = hub.GetSignalDownload<int> "download1"
-    let value2 = hub.GetSignalDownload<int> "download2"
+    let value1 = hub.GetSignal<int> "download1"
+    let value2 = hub.GetSignal<int> "download2"
     let mutable triggered = false
     let callback() =
         value1.Value |> should equal 99

--- a/src/Terrabuild.PubSub.Tests/Hub.fs
+++ b/src/Terrabuild.PubSub.Tests/Hub.fs
@@ -9,11 +9,11 @@ open System
 let successful() =
     let hub = Hub.Create(1)
 
-    let value1 = hub.GetSignal<int>("computed1")
-    let computed2 = hub.GetSignal<string>("computed2")
+    let value1 = hub.GetSignalTask<int> "computed1"
+    let computed2 = hub.GetSignalTask<string> "computed2"
 
-    let computed1 = hub.GetSignal<int>("computed1")
-    let value2 = hub.GetSignal<string>("computed2")
+    let computed1 = hub.GetSignalTask<int> "computed1"
+    let value2 = hub.GetSignalTask<string> "computed2"
 
     let mutable triggered0 = false
     let callback0() =
@@ -37,15 +37,15 @@ let successful() =
             // getting another computed lead to same value
             value1.Value |> should equal 42
             value2.Value |> should equal "tralala"
-            hub.GetSignal<int>("computed1").Value |> should equal 42
+            hub.GetSignalTask<int>("computed1").Value |> should equal 42
             triggered3 <- true
 
-        hub.Subscribe "subscription3" [ value1; value2 ] callback3
+        hub.SubscribeTask "subscription3" [ value1; value2 ] callback3
 
 
-    hub.Subscribe "callback0" [] callback0
-    hub.Subscribe "callback1" [ value1 ] callback1
-    hub.Subscribe "callback2" [ value1; value2 ] callback2
+    hub.SubscribeTask "callback0" [] callback0
+    hub.SubscribeTask "callback1" [ value1 ] callback1
+    hub.SubscribeTask "callback2" [ value1; value2 ] callback2
 
     computed1.Value <- 42
 
@@ -64,13 +64,13 @@ let successful() =
 let exception_in_callback_is_error() =
     let hub = Hub.Create(1)
 
-    let value1 = hub.GetSignal<int>("computed1")
-    let computed2 = hub.GetSignal<string>("computed2")
-    let value3 = hub.GetSignal<float>("computed3")
+    let value1 = hub.GetSignalTask<int> "computed1"
+    let computed2 = hub.GetSignalTask<string> "computed2"
+    let value3 = hub.GetSignalTask<float> "computed3"
 
-    let computed1 = hub.GetSignal<int>("computed1")
-    let value2 = hub.GetSignal<string>("computed2")
-    let computed3 = hub.GetSignal<float>("computed3")
+    let computed1 = hub.GetSignalTask<int> "computed1"
+    let value2 = hub.GetSignalTask<string> "computed2"
+    let computed3 = hub.GetSignalTask<float> "computed3"
 
     let mutable triggered1 = false
     let callback() =
@@ -84,8 +84,8 @@ let exception_in_callback_is_error() =
         triggered2 <- true
         failwith "Callback shall never be called"
 
-    hub.Subscribe "subscription1" [ value1; value2 ] callback
-    hub.Subscribe "subscription2" [ value3 ] neverCallback
+    hub.SubscribeTask "subscription1" [ value1; value2 ] callback
+    hub.SubscribeTask "subscription2" [ value3 ] neverCallback
 
     computed1.Value <- 42
     computed2.Value <- "tralala"
@@ -106,13 +106,13 @@ let exception_in_callback_is_error() =
 let unsignaled_subscription1_is_error() =
     let hub = Hub.Create(1)
 
-    let value1 = hub.GetSignal<int>("computed1")
-    let computed2 = hub.GetSignal<string>("computed2")
-    let value3 = hub.GetSignal<float>("computed3")
+    let value1 = hub.GetSignalTask<int> "computed1"
+    let computed2 = hub.GetSignalTask<string> "computed2"
+    let value3 = hub.GetSignalTask<float> "computed3"
 
-    let computed1 = hub.GetSignal<int>("computed1")
-    let value2 = hub.GetSignal<string>("computed2")
-    let computed3 = hub.GetSignal<float>("computed3")
+    let computed1 = hub.GetSignalTask<int> "computed1"
+    let value2 = hub.GetSignalTask<string> "computed2"
+    let computed3 = hub.GetSignalTask<float> "computed3"
 
     let mutable triggered1 = false
     let callback() =
@@ -125,8 +125,8 @@ let unsignaled_subscription1_is_error() =
         triggered2 <- true
         failwith "Callback shall never be called"
 
-    hub.Subscribe "subscription1" [ value1; value2 ] callback
-    hub.Subscribe "subscription2" [ value3 ] neverCallback
+    hub.SubscribeTask "subscription1" [ value1; value2 ] callback
+    hub.SubscribeTask "subscription2" [ value3 ] neverCallback
 
     computed1.Value <- 42
     computed2.Value <- "tralala"
@@ -150,13 +150,13 @@ let unsignaled_subscription1_is_error() =
 let unsignaled_subscription2_is_error() =
     let hub = Hub.Create(1)
 
-    let value1 = hub.GetSignal<int>("computed1")
-    let computed2 = hub.GetSignal<string>("computed2")
-    let value3 = hub.GetSignal<float>("computed3")
+    let value1 = hub.GetSignalTask<int> "computed1"
+    let computed2 = hub.GetSignalTask<string> "computed2"
+    let value3 = hub.GetSignalTask<float> "computed3"
 
-    let computed1 = hub.GetSignal<int>("computed1")
-    let value2 = hub.GetSignal<string>("computed2")
-    let computed3 = hub.GetSignal<float>("computed3")
+    let computed1 = hub.GetSignalTask<int> "computed1"
+    let value2 = hub.GetSignalTask<string> "computed2"
+    let computed3 = hub.GetSignalTask<float> "computed3"
 
     let mutable triggered1 = false
     let callback() =
@@ -168,8 +168,8 @@ let unsignaled_subscription2_is_error() =
         triggered2 <- true
         failwith "Callback shall never be called"
 
-    hub.Subscribe "subscription1" [ value1 ] callback
-    hub.Subscribe "subscription2" [ value2; value3 ] neverCallback
+    hub.SubscribeTask "subscription1" [ value1 ] callback
+    hub.SubscribeTask "subscription2" [ value2; value3 ] neverCallback
 
     computed1.Value <- 42
 
@@ -192,8 +192,27 @@ let unsignaled_subscription2_is_error() =
 let computed_must_match_type() =
     let hub = Hub.Create(1)
 
-    let value1 = hub.GetSignal<int>("computed1")
-    (fun () -> hub.GetSignal<string>("computed1") |> ignore) |> should throw typeof<Errors.TerrabuildException>
+    let value1 = hub.GetSignalTask<int> "computed1"
+    (fun () -> hub.GetSignalTask<string> "computed1" |> ignore) |> should throw typeof<Errors.TerrabuildException>
 
-    let computed2 = hub.GetSignal<string>("computed2")
-    (fun () -> hub.GetSignal<int>("computed2") |> ignore) |> should throw typeof<Errors.TerrabuildException>
+    let computed2 = hub.GetSignalTask<string> "computed2"
+    (fun () -> hub.GetSignalTask<int> "computed2" |> ignore) |> should throw typeof<Errors.TerrabuildException>
+
+
+// Additional test for Download kind
+[<Test>]
+let download_subscription_priority() =
+    let hub = Hub.Create(2)
+    let value1 = hub.GetSignalDownload<int> "download1"
+    let value2 = hub.GetSignalDownload<int> "download2"
+    let mutable triggered = false
+    let callback() =
+        value1.Value |> should equal 99
+        value2.Value |> should equal 100
+        triggered <- true
+    hub.SubscribeDownload "downloadSub" [ value1; value2 ] callback
+    value1.Value <- 99
+    value2.Value <- 100
+    let status = hub.WaitCompletion()
+    status |> should equal Status.Ok
+    triggered |> should equal true

--- a/src/Terrabuild.PubSub.Tests/Hub.fs
+++ b/src/Terrabuild.PubSub.Tests/Hub.fs
@@ -20,23 +20,23 @@ let successful() =
 
     let mutable triggered1 = false
     let callback1() =
-        value1.Value |> should equal 42
-        computed2.Value <- "tralala"
+        value1.Get<int>() |> should equal 42
+        computed2.Set("tralala")
         triggered1 <- true
 
     let mutable triggered2 = false
     let mutable triggered3 = false
     let callback2() =
-        value1.Value |> should equal 42
-        value2.Value |> should equal "tralala"
+        value1.Get<int>() |> should equal 42
+        value2.Get<string>() |> should equal "tralala"
         triggered2 <- true
 
         // callback3 must be immediately triggered as computed1/2 are immediately available
         let callback3() =
             // getting another computed lead to same value
-            value1.Value |> should equal 42
-            value2.Value |> should equal "tralala"
-            hub.GetSignal<int>("computed1").Value |> should equal 42
+            value1.Get<int>() |> should equal 42
+            value2.Get<string>() |> should equal "tralala"
+            hub.GetSignal<int>("computed1").Get<int>() |> should equal 42
             triggered3 <- true
 
         hub.Subscribe "subscription3" [ value1; value2 ] callback3
@@ -46,13 +46,13 @@ let successful() =
     hub.Subscribe "callback1" [ value1 ] callback1
     hub.Subscribe "callback2" [ value1; value2 ] callback2
 
-    computed1.Value <- 42
+    computed1.Set(42)
 
     let status = hub.WaitCompletion()
 
     status |> should equal Status.Ok
-    value1.Value |> should equal 42
-    value2.Value |> should equal "tralala"
+    value1.Get<int>() |> should equal 42
+    value2.Get<string>() |> should equal "tralala"
     triggered0 |> should equal true
     triggered1 |> should equal true
     triggered2 |> should equal true
@@ -73,8 +73,8 @@ let exception_in_callback_is_error() =
 
     let mutable triggered1 = false
     let callback() =
-        value1.Value |> should equal 42
-        value2.Value |> should equal "tralala"
+        value1.Get<int>() |> should equal 42
+        value2.Get<string>() |> should equal "tralala"
         triggered1 <- true
         failwith "workflow failed"
 
@@ -86,8 +86,8 @@ let exception_in_callback_is_error() =
     hub.Subscribe "subscription1" [ value1; value2 ] callback
     hub.Subscribe "subscription2" [ value3 ] neverCallback
 
-    computed1.Value <- 42
-    computed2.Value <- "tralala"
+    computed1.Set(42)
+    computed2.Set("tralala")
 
     // callback fails
     let status = hub.WaitCompletion()
@@ -95,8 +95,8 @@ let exception_in_callback_is_error() =
     match status with
     | Status.SubscriptionError exn -> exn.Message |> should equal "workflow failed"
     | _ -> Assert.Fail()
-    value1.Value |> should equal 42
-    value2.Value |> should equal "tralala"
+    value1.Get<int>() |> should equal 42
+    value2.Get<string>() |> should equal "tralala"
     triggered1 |> should equal true
     triggered2 |> should equal false
 
@@ -115,8 +115,8 @@ let unsignaled_subscription1_is_error() =
 
     let mutable triggered1 = false
     let callback() =
-        value1.Value |> should equal 42
-        value2.Value |> should equal "tralala"
+        value1.Get<int>() |> should equal 42
+        value2.Get<string>() |> should equal "tralala"
         triggered1 <- true
 
     let mutable triggered2 = false
@@ -127,8 +127,8 @@ let unsignaled_subscription1_is_error() =
     hub.Subscribe "subscription1" [ value1; value2 ] callback
     hub.Subscribe "subscription2" [ value3 ] neverCallback
 
-    computed1.Value <- 42
-    computed2.Value <- "tralala"
+    computed1.Set(42)
+    computed2.Set("tralala")
 
     // computed3 is never triggered
     let status = hub.WaitCompletion()
@@ -140,9 +140,9 @@ let unsignaled_subscription1_is_error() =
     | _ -> Assert.Fail()
     triggered1 |> should equal true
     triggered2 |> should equal false
-    value1.Value |> should equal 42
-    value2.Value |> should equal "tralala"
-    (fun () -> value3.Value |> ignore) |> should throw typeof<Errors.TerrabuildException>
+    value1.Get<int>() |> should equal 42
+    value2.Get<string>() |> should equal "tralala"
+    (fun () -> value3.Get() |> ignore) |> should throw typeof<Errors.TerrabuildException>
 
 
 [<Test>]
@@ -159,7 +159,7 @@ let unsignaled_subscription2_is_error() =
 
     let mutable triggered1 = false
     let callback() =
-        value1.Value |> should equal 42
+        value1.Get<int>() |> should equal 42
         triggered1 <- true
 
     let mutable triggered2 = false
@@ -170,7 +170,7 @@ let unsignaled_subscription2_is_error() =
     hub.Subscribe "subscription1" [ value1 ] callback
     hub.Subscribe "subscription2" [ value2; value3 ] neverCallback
 
-    computed1.Value <- 42
+    computed1.Set(42)
 
     // computed3 is never triggered
     let status = hub.WaitCompletion()
@@ -182,8 +182,8 @@ let unsignaled_subscription2_is_error() =
     | _ -> Assert.Fail()
     triggered1 |> should equal true
     triggered2 |> should equal false
-    value1.Value |> should equal 42
-    (fun () -> value3.Value |> ignore) |> should throw typeof<Errors.TerrabuildException>
+    value1.Get<int>() |> should equal 42
+    (fun () -> value3.Get<float>() |> ignore) |> should throw typeof<Errors.TerrabuildException>
 
 
 
@@ -206,12 +206,12 @@ let download_subscription_priority() =
     let value2 = hub.GetSignal<int> "download2"
     let mutable triggered = false
     let callback() =
-        value1.Value |> should equal 99
-        value2.Value |> should equal 100
+        value1.Get<int>() |> should equal 99
+        value2.Get<int>() |> should equal 100
         triggered <- true
     hub.SubscribeBackground "downloadSub" [ value1; value2 ] callback
-    value1.Value <- 99
-    value2.Value <- 100
+    value1.Set(99)
+    value2.Set(100)
     let status = hub.WaitCompletion()
     status |> should equal Status.Ok
     triggered |> should equal true

--- a/src/Terrabuild.PubSub.Tests/Hub.fs
+++ b/src/Terrabuild.PubSub.Tests/Hub.fs
@@ -209,7 +209,7 @@ let download_subscription_priority() =
         value1.Value |> should equal 99
         value2.Value |> should equal 100
         triggered <- true
-    hub.SubscribeDownload "downloadSub" [ value1; value2 ] callback
+    hub.SubscribeBackground "downloadSub" [ value1; value2 ] callback
     value1.Value <- 99
     value2.Value <- 100
     let status = hub.WaitCompletion()

--- a/src/Terrabuild.PubSub.Tests/Hub.fs
+++ b/src/Terrabuild.PubSub.Tests/Hub.fs
@@ -198,7 +198,7 @@ let computed_must_match_type() =
     (fun () -> hub.GetSignal<int> "computed2" |> ignore) |> should throw typeof<Errors.TerrabuildException>
 
 
-// Additional test for Download kind
+
 [<Test>]
 let download_subscription_priority() =
     let hub = Hub.Create(2)

--- a/src/Terrabuild.PubSub/Hub.fs
+++ b/src/Terrabuild.PubSub/Hub.fs
@@ -150,7 +150,7 @@ type Status =
 
 type IHub =
     abstract GetSignal<'T>: name:string -> ISignal<'T>
-    abstract SubscribeTask: label:string -> signals:ISignal list -> handler:SignalCompleted -> unit
+    abstract Subscribe: label:string -> signals:ISignal list -> handler:SignalCompleted -> unit
     abstract SubscribeDownload: label:string -> signals:ISignal list -> handler:SignalCompleted -> unit
     abstract WaitCompletion: unit -> Status
 
@@ -176,7 +176,7 @@ type Hub(maxConcurrency) =
 
     interface IHub with
         member this.GetSignal<'T>(name) = this.GetSignal<'T> name
-        member this.SubscribeTask label signals handler = this.Subscribe label signals Normal handler
+        member this.Subscribe label signals handler = this.Subscribe label signals Normal handler
         member this.SubscribeDownload label signals handler = this.Subscribe label signals Background handler
         member _.WaitCompletion() =
             match eventQueue.WaitCompletion() with

--- a/src/Terrabuild.PubSub/Hub.fs
+++ b/src/Terrabuild.PubSub/Hub.fs
@@ -161,7 +161,7 @@ type Hub(maxConcurrency) =
     let subscriptions = ConcurrentDictionary<string, Subscription>()
 
     member private _.GetSignal<'T> name =
-        let getOrAdd _ = Signal<'T>(name, eventQueue, Normal) :> ISignal // Default kind for signal creation
+        let getOrAdd _ = Signal<'T>(name, eventQueue, Normal) :> ISignal
         let signal = signals.GetOrAdd(name, getOrAdd)
         match signal with
         | :? Signal<'T> as signal -> signal

--- a/src/Terrabuild/Core/Build.fs
+++ b/src/Terrabuild/Core/Build.fs
@@ -342,6 +342,7 @@ let run (options: ConfigOptions.Options) (cache: Cache.ICache) (api: Contracts.I
                         | _ -> []
 
                     let onDownloadsAvailable() =
+                        Log.Debug("Downloads for {NodeId} completed", node.Id)
                         let buildAction = 
                             match buildRequest with
                             | TaskRequest.Build -> buildNode

--- a/src/Terrabuild/Core/Build.fs
+++ b/src/Terrabuild/Core/Build.fs
@@ -10,8 +10,8 @@ open Microsoft.Extensions.FileSystemGlobbing
 
 [<RequireQualifiedAccess>]
 type TaskRequest =
-    | Build
     | Restore
+    | Build
 
 [<RequireQualifiedAccess>]
 type TaskStatus =

--- a/src/Terrabuild/Core/Build.fs
+++ b/src/Terrabuild/Core/Build.fs
@@ -264,10 +264,6 @@ let run (options: ConfigOptions.Options) (cache: Cache.ICache) (api: Contracts.I
 
             restorables.TryAdd(node.Id, restorable) |> ignore
 
-            // invoke callback immediately if node must be restored
-            // TODO: restore but await completion
-            // if node.Restore then restorable.Restore()
-
             if summary.IsSuccessful then TaskStatus.Success summary.EndedAt
             else TaskStatus.Failure (summary.EndedAt, $"Restored node {node.Id} with a build in failure state")
         | _ ->

--- a/src/Terrabuild/Core/Build.fs
+++ b/src/Terrabuild/Core/Build.fs
@@ -231,7 +231,7 @@ let run (options: ConfigOptions.Options) (cache: Cache.ICache) (api: Contracts.I
             let restorableId = $"{node.Id}-download"
             let callback() =
                 notification.NodeDownloading node
-                let restorableSignal = hub.GetSignalTask<DateTime> restorableId
+                let restorableSignal = hub.GetSignal<DateTime> restorableId
 
                 match cache.TryGetSummary allowRemoteCache cacheEntryId with
                 | Some summary ->
@@ -308,14 +308,14 @@ let run (options: ConfigOptions.Options) (cache: Cache.ICache) (api: Contracts.I
     let rec schedule nodeId =
         if nodeResults.TryAdd(nodeId, (TaskRequest.Build, TaskStatus.Pending)) then
             let node = graph.Nodes[nodeId]
-            let nodeComputed = hub.GetSignalTask<DateTime> nodeId
+            let nodeComputed = hub.GetSignal<DateTime> nodeId
 
             // await dependencies
             let awaitedDependencies =
                 node.Dependencies
                 |> Seq.map (fun awaitedProjectId ->
                     schedule awaitedProjectId
-                    hub.GetSignalTask<DateTime> awaitedProjectId)
+                    hub.GetSignal<DateTime> awaitedProjectId)
                 |> List.ofSeq
 
             let onDependenciesAvailable () =
@@ -333,7 +333,7 @@ let run (options: ConfigOptions.Options) (cache: Cache.ICache) (api: Contracts.I
                         | TaskRequest.Restore when node.Restore ->
                             match restorables.TryGetValue nodeId with
                             | true, restorable ->
-                                restorable.Value |> List.map (fun entry -> hub.GetSignalTask<DateTime> entry)
+                                restorable.Value |> List.map (fun entry -> hub.GetSignal<DateTime> entry)
                             | _ -> []
                         | _ -> []
 

--- a/src/Terrabuild/Core/Build.fs
+++ b/src/Terrabuild/Core/Build.fs
@@ -356,7 +356,7 @@ let run (options: ConfigOptions.Options) (cache: Cache.ICache) (api: Contracts.I
                         if success then nodeComputed.Value <- completionDate
 
                     let awaitedSignals = awaitedDownloads |> List.map (fun entry -> entry :> ISignal)
-                    hub.SubscribeTask nodeId awaitedSignals onDownloadsAvailable
+                    hub.Subscribe nodeId awaitedSignals onDownloadsAvailable
 
                 with
                     exn ->
@@ -366,7 +366,7 @@ let run (options: ConfigOptions.Options) (cache: Cache.ICache) (api: Contracts.I
                         reraise()
 
             let awaitedSignals = awaitedDependencies |> List.map (fun entry -> entry :> ISignal)
-            hub.SubscribeTask nodeId awaitedSignals onDependenciesAvailable
+            hub.Subscribe nodeId awaitedSignals onDependenciesAvailable
 
     graph.RootNodes |> Seq.iter schedule
 

--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -423,8 +423,8 @@ let private finalizeProject projectDir evaluationContext (projectDef: LoadedProj
 
                 // bootstrap
                 for (KeyValue(name, value)) in evaluationContext.Data do
-                    localsHub.Subscribe name [] (fun () ->
-                        let varSignal = localsHub.GetSignal<Value> name
+                    localsHub.SubscribeTask name [] (fun () ->
+                        let varSignal = localsHub.GetSignalTask<Value> name
                         varSignal.Value <- value)
 
                 for (KeyValue(name, localExpr)) in projectDef.Locals do
@@ -432,12 +432,12 @@ let private finalizeProject projectDir evaluationContext (projectDef: LoadedProj
                     let deps = Dependencies.find localExpr
                     let signalDeps =
                         deps
-                        |> Seq.map (fun dep -> localsHub.GetSignal<Value> dep :> ISignal)
+                        |> Seq.map (fun dep -> localsHub.GetSignalTask<Value> dep :> ISignal)
                         |> List.ofSeq
-                    localsHub.Subscribe localName signalDeps (fun () ->
+                    localsHub.SubscribeTask localName signalDeps (fun () ->
                         let localValue = Eval.eval evaluationContext localExpr
                         evaluationContext <- { evaluationContext with Data = evaluationContext.Data |> Map.add localName localValue }
-                        let localSignal = localsHub.GetSignal<Value> localName
+                        let localSignal = localsHub.GetSignalTask<Value> localName
                         localSignal.Value <- localValue)
 
                 match localsHub.WaitCompletion() with
@@ -643,7 +643,7 @@ let read (options: ConfigOptions.Options) =
             let projectPathId = projectDir |> String.toLower
             if projectLoading.TryAdd(projectPathId, true) then
                 // parallel load of projects
-                hub.Subscribe projectDir [] (fun () ->
+                hub.SubscribeTask projectDir [] (fun () ->
                     let loadedProject =
                         try
                             // load project and force loading all dependencies as well
@@ -666,17 +666,17 @@ let read (options: ConfigOptions.Options) =
                     let projectPathSignals =
                         loadedProject.Dependencies
                         |> Set.map String.toLower
-                        |> Seq.map (fun awaitedProjectId -> hub.GetSignal<Project> awaitedProjectId)
+                        |> Seq.map (fun awaitedProjectId -> hub.GetSignalTask<Project> awaitedProjectId)
                         |> List.ofSeq
 
                     let dependsOnSignals =
                         loadedProject.DependsOn
-                        |> Seq.map (fun awaitedProjectId -> hub.GetSignal<Project> awaitedProjectId)
+                        |> Seq.map (fun awaitedProjectId -> hub.GetSignalTask<Project> awaitedProjectId)
                         |> List.ofSeq
 
                     let awaitedProjectSignals = projectPathSignals @ dependsOnSignals
                     let awaitedSignals = awaitedProjectSignals |> List.map (fun entry -> entry :> ISignal)
-                    hub.Subscribe projectDir awaitedSignals (fun () ->
+                    hub.SubscribeTask projectDir awaitedSignals (fun () ->
                         try
                             // build task & code & notify
                             let dependsOnProjects = 
@@ -688,13 +688,13 @@ let read (options: ConfigOptions.Options) =
                             if projects.TryAdd(projectPathId, project) |> not then raiseBugError "Unexpected error"
 
                             Log.Debug($"Signaling projectPath '{projectPathId}")
-                            let loadedProjectPathIdSignal = hub.GetSignal<Project> projectPathId
+                            let loadedProjectPathIdSignal = hub.GetSignalTask<Project> projectPathId
                             loadedProjectPathIdSignal.Value <- project
 
                             match loadedProject.Id with
                             | Some projectId ->
                                 Log.Debug($"Signaling projectId '{projectId}")
-                                let loadedProjectIdSignal = hub.GetSignal<Project> $"project.{projectId}"
+                                let loadedProjectIdSignal = hub.GetSignalTask<Project> $"project.{projectId}"
                                 loadedProjectIdSignal.Value <- project
                             | _ -> ()
                         with exn -> forwardExternalError($"Error while parsing project '{projectDir}'", exn)))

--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -423,7 +423,7 @@ let private finalizeProject projectDir evaluationContext (projectDef: LoadedProj
 
                 // bootstrap
                 for (KeyValue(name, value)) in evaluationContext.Data do
-                    localsHub.SubscribeTask name [] (fun () ->
+                    localsHub.Subscribe name [] (fun () ->
                         let varSignal = localsHub.GetSignal<Value> name
                         varSignal.Value <- value)
 
@@ -434,7 +434,7 @@ let private finalizeProject projectDir evaluationContext (projectDef: LoadedProj
                         deps
                         |> Seq.map (fun dep -> localsHub.GetSignal<Value> dep :> ISignal)
                         |> List.ofSeq
-                    localsHub.SubscribeTask localName signalDeps (fun () ->
+                    localsHub.Subscribe localName signalDeps (fun () ->
                         let localValue = Eval.eval evaluationContext localExpr
                         evaluationContext <- { evaluationContext with Data = evaluationContext.Data |> Map.add localName localValue }
                         let localSignal = localsHub.GetSignal<Value> localName
@@ -643,7 +643,7 @@ let read (options: ConfigOptions.Options) =
             let projectPathId = projectDir |> String.toLower
             if projectLoading.TryAdd(projectPathId, true) then
                 // parallel load of projects
-                hub.SubscribeTask projectDir [] (fun () ->
+                hub.Subscribe projectDir [] (fun () ->
                     let loadedProject =
                         try
                             // load project and force loading all dependencies as well
@@ -676,7 +676,7 @@ let read (options: ConfigOptions.Options) =
 
                     let awaitedProjectSignals = projectPathSignals @ dependsOnSignals
                     let awaitedSignals = awaitedProjectSignals |> List.map (fun entry -> entry :> ISignal)
-                    hub.SubscribeTask projectDir awaitedSignals (fun () ->
+                    hub.Subscribe projectDir awaitedSignals (fun () ->
                         try
                             // build task & code & notify
                             let dependsOnProjects = 


### PR DESCRIPTION
This PR:
- downloads can now be parallelized
- downloads are running in background and can run up 2 * maxConcurrency
- fix Hub concurrency bug in startup
- update PubSub interface, no more ISignal cast
