### PR TITLE
feat: add support for external cache policy

### DIFF
--- a/src/Terrabuild.Common/Collections.fs
+++ b/src/Terrabuild.Common/Collections.fs
@@ -35,5 +35,5 @@ module Set =
 
 module Seq =
     let maxDefault defaultValue s =
-        if s = Seq.empty then defaultValue
+        if s |> Seq.isEmpty then defaultValue
         else s |> Seq.max

--- a/src/Terrabuild.Common/Collections.fs
+++ b/src/Terrabuild.Common/Collections.fs
@@ -32,3 +32,8 @@ module Set =
 
     let collect f s =
         s |> Seq.collect f |> Set.ofSeq
+
+module Seq =
+    let maxDefault defaultValue s =
+        if s = Seq.empty then defaultValue
+        else s |> Seq.max

--- a/src/Terrabuild.Extensibility/Extensions.fs
+++ b/src/Terrabuild.Extensibility/Extensions.fs
@@ -47,6 +47,7 @@ type ShellOperations = ShellOperation list
 type Cacheability =
     | Never
     | Local
+    | External
     | Remote
 
 let shellOp(cmd, args) = 
@@ -62,6 +63,9 @@ type BatchableAttribute() =
 type CacheableAttribute(cacheability: Cacheability) =
     inherit Attribute()
     member _.Cacheability = cacheability
+
+type ExternalCacheAttribute() =
+    inherit CacheableAttribute(Cacheability.External)
 
 type RemoteCacheAttribute() =
     inherit CacheableAttribute(Cacheability.Remote)

--- a/src/Terrabuild.Extensions.Tests/Docker.fs
+++ b/src/Terrabuild.Extensions.Tests/Docker.fs
@@ -36,7 +36,7 @@ let ``__dispatch__ none``() =
 
 [<Test>]
 let ``build cacheability``() =
-    getCacheInfo<Docker> "build" |> should equal Cacheability.Remote
+    getCacheInfo<Docker> "build" |> should equal Cacheability.External
 
 [<Test>]
 let ``build some ci``() =
@@ -86,7 +86,7 @@ let ``build none``() =
 
 [<Test>]
 let ``push cacheability``() =
-    getCacheInfo<Docker> "push" |> should equal Cacheability.Remote
+    getCacheInfo<Docker> "push" |> should equal Cacheability.External
 
 
 [<Test>]

--- a/src/Terrabuild.Extensions/Docker.fs
+++ b/src/Terrabuild.Extensions/Docker.fs
@@ -31,7 +31,7 @@ type Docker() =
     /// <param name="platforms" required="false" example="&quot;linux/amd64&quot;">Target platform. Default is host.</param>
     /// <param name="build_args" example="{ configuration: &quot;Release&quot; }">Named arguments to build image (see Dockerfile [ARG](https://docs.docker.com/reference/dockerfile/#arg)).</param> 
     /// <param name="args" example="&quot;--debug&quot;">Arguments for command.</param>
-    [<RemoteCacheAttribute>]
+    [<ExternalCacheAttribute>]
     static member build (context: ActionContext)
                         (image: string)
                         (dockerfile: string option)
@@ -56,7 +56,7 @@ type Docker() =
     /// <param name="image" required="true" example="&quot;ghcr.io/example/project&quot;">Docker image to build.</param>
     /// <param name="tag" required="true" example="&quot;1.2.3-stable&quot;">Apply tag on image (use branch or tag otherwise).</param>
     /// <param name="args" example="&quot;--disable-content-trust&quot;">Arguments for command.</param>
-    [<RemoteCacheAttribute>]
+    [<ExternalCacheAttribute>]
     static member push (context: ActionContext)
                        (image: string)
                        (tag: string)

--- a/src/Terrabuild/Core/ActionBuilder.fs
+++ b/src/Terrabuild/Core/ActionBuilder.fs
@@ -35,7 +35,7 @@ let build (options: ConfigOptions.Options) (cache: Cache.ICache) (graph: GraphDe
 
                 // task is cached
                 elif node.Cache = Terrabuild.Extensibility.Cacheability.External then
-                    Log.Debug("{NodeId} is restorable {Date}", node.Id, summary.EndedAt)
+                    Log.Debug("{NodeId} is external {Date}", node.Id, summary.EndedAt)
                     (GraphDef.NodeAction.Ignore, summary.EndedAt)
                 else
                     Log.Debug("{NodeId} is restorable {Date}", node.Id, summary.EndedAt)
@@ -55,16 +55,10 @@ let build (options: ConfigOptions.Options) (cache: Cache.ICache) (graph: GraphDe
             let node = graph.Nodes[nodeId]
 
             // get the status of dependencies
-            let dependencyStatus =
-                node.Dependencies
-                |> Seq.map (fun projectId -> getNodeStatus projectId)
-                |> List.ofSeq
-
-            // now decide what to do
             let maxCompletionChildren =
-                match dependencyStatus with
-                | [ ] -> DateTime.MinValue
-                | _ -> dependencyStatus |> Seq.map snd |> Seq.max
+                node.Dependencies
+                |> Seq.map (fun projectId -> getNodeStatus projectId |> snd)
+                |> Seq.maxDefault DateTime.MinValue
             let (buildRequest, buildDate) = computeNodeAction node maxCompletionChildren
 
             nodes <- nodes |> Map.add nodeId { node with Action = buildRequest }

--- a/src/Terrabuild/Core/ActionBuilder.fs
+++ b/src/Terrabuild/Core/ActionBuilder.fs
@@ -5,15 +5,12 @@ module ActionBuilder
 open System
 open Collections
 open Serilog
-open Terrabuild.PubSub
-open Errors
 
 
 let build (options: ConfigOptions.Options) (cache: Cache.ICache) (graph: GraphDef.Graph) =
     let allowRemoteCache = options.LocalOnly |> not
-    let nodeResults = Concurrent.ConcurrentDictionary<string, GraphDef.NodeAction>()
-    let scheduledNodeStatus = Concurrent.ConcurrentDictionary<string, bool>()
-    let hub = Hub.Create(options.MaxConcurrency)
+    let mutable nodeResults = Map.empty
+    let mutable nodes = Map.empty
 
     let computeNodeAction (node: GraphDef.Node) maxCompletionChildren =
         if node.Action = GraphDef.NodeAction.Build then
@@ -37,6 +34,9 @@ let build (options: ConfigOptions.Options) (cache: Cache.ICache) (graph: GraphDe
                     (GraphDef.NodeAction.Build, DateTime.MaxValue)
 
                 // task is cached
+                elif node.Cache = Terrabuild.Extensibility.Cacheability.External then
+                    Log.Debug("{NodeId} is restorable {Date}", node.Id, summary.EndedAt)
+                    (GraphDef.NodeAction.Ignore, summary.EndedAt)
                 else
                     Log.Debug("{NodeId} is restorable {Date}", node.Id, summary.EndedAt)
                     (GraphDef.NodeAction.Restore, summary.EndedAt)
@@ -48,51 +48,32 @@ let build (options: ConfigOptions.Options) (cache: Cache.ICache) (graph: GraphDe
             (GraphDef.NodeAction.Build, DateTime.MaxValue)
 
 
-    let rec scheduleNodeStatus lineage nodeId =
-        if scheduledNodeStatus.TryAdd(nodeId, true) then
+    let rec getNodeStatus nodeId =
+        match nodeResults |> Map.tryFind nodeId with
+        | Some result -> result
+        | _ ->
             let node = graph.Nodes[nodeId]
 
             // get the status of dependencies
             let dependencyStatus =
                 node.Dependencies
-                |> Seq.map (fun projectId ->
-                    scheduleNodeStatus (Some node.ClusterHash) projectId
-                    hub.GetSignal<DateTime> projectId)
+                |> Seq.map (fun projectId -> getNodeStatus projectId)
                 |> List.ofSeq
-            hub.SubscribeBackground $"{nodeId} status" dependencyStatus (fun () ->
-                // now decide what to do
-                let maxCompletionChildren =
-                    match dependencyStatus with
-                    | [ ] -> DateTime.MinValue
-                    | _ -> dependencyStatus |> Seq.map (fun dep -> dep.Get<DateTime>()) |> Seq.max
-                let (buildRequest, buildDate) = computeNodeAction node maxCompletionChildren
 
-                // only keep action with a side effect
-                match lineage, buildRequest with
-                | _, GraphDef.NodeAction.Ignore
-                | None, GraphDef.NodeAction.Restore -> ()
-                | _ -> nodeResults[nodeId] <- buildRequest
+            // now decide what to do
+            let maxCompletionChildren =
+                match dependencyStatus with
+                | [ ] -> DateTime.MinValue
+                | _ -> dependencyStatus |> Seq.map snd |> Seq.max
+            let (buildRequest, buildDate) = computeNodeAction node maxCompletionChildren
 
-                let nodeStatusSignal = hub.GetSignal<DateTime> nodeId
-                nodeStatusSignal.Set buildDate)
+            nodes <- nodes |> Map.add nodeId { node with Action = buildRequest }
+            let result = (buildRequest, buildDate)
+            nodeResults <- nodeResults |> Map.add nodeId result
+            result
 
-    graph.RootNodes |> Seq.iter (scheduleNodeStatus None)
+    graph.RootNodes |> Seq.iter (ignore << getNodeStatus)
 
-
-    let status = hub.WaitCompletion()
-    match status with
-    | Status.Ok ->
-        Log.Debug("NodeStateEvaluator successful")
-    | Status.UnfulfilledSubscription (subscription, signals) ->
-        let unraisedSignals = signals |> String.join ","
-        Log.Fatal($"NodeStateEvaluator '{subscription}' has pending operations on '{unraisedSignals}'")
-    | Status.SubscriptionError edi ->
-        forwardExternalError("BuiNodeStateEvaluatorld failed", edi.SourceException)
-
-    let nodes =
-        nodeResults |> Seq.fold (fun (acc: Map<string, GraphDef.Node>) (KeyValue(nodeId, nodeAction)) ->
-            let node = { acc[nodeId] with GraphDef.Node.Action = nodeAction }
-            acc |> Map.add nodeId node) graph.Nodes
     let rootNodes =
         graph.RootNodes
         |> Set.filter (fun nodeId -> nodes[nodeId].Action = GraphDef.NodeAction.Build)

--- a/src/Terrabuild/Core/Configuration.fs
+++ b/src/Terrabuild/Core/Configuration.fs
@@ -535,6 +535,7 @@ let private finalizeProject workspaceDir projectDir evaluationContext (projectDe
                 | Some "never" -> Some Cacheability.Never
                 | Some "local" -> Some Cacheability.Local
                 | Some "remote" -> Some Cacheability.Remote
+                | Some "external" -> Some Cacheability.External
                 | None -> None
                 | _ -> raiseParseError "invalid cache value"
 

--- a/src/Terrabuild/Core/NodeBuilder.fs
+++ b/src/Terrabuild/Core/NodeBuilder.fs
@@ -124,6 +124,7 @@ let build (options: ConfigOptions.Options) (configuration: Configuration.Workspa
                         match cacheability, options.LocalOnly with
                         | Cacheability.Never, _ -> Cacheability.Never
                         | Cacheability.Local, _ -> Cacheability.Local
+                        | Cacheability.External, _ -> Cacheability.External
                         | Cacheability.Remote, true -> Cacheability.Local
                         | Cacheability.Remote, false -> Cacheability.Remote
 

--- a/tools/DocGen/Program.fs
+++ b/tools/DocGen/Program.fs
@@ -133,7 +133,8 @@ let writeCommand extensionDir (command: Command) (batchCommand: Command option) 
         | None -> "never"
         | Some Cacheability.Never -> "never"
         | Some Cacheability.Local -> "local"
-        | Some Cacheability.Remote -> "global"
+        | Some Cacheability.Remote -> "remote"
+        | Some Cacheability.External -> "external"
 
     let batchInfo =
         if command.Batchability then "yes"


### PR DESCRIPTION
Targets generating docker image for example do not need to be restored because they are externally managed.
So this PR introduces the notion of externally managed artifacts:
- no outputs saved
- no restore
- ignored if shall be restored
- still contribute to graph consistency