### PR TITLE
Separate runner engine formatting paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Terrabuild are documented in this file.
 
 ## [Unreleased]
 
+- Split Runner command formatting into explicit Docker, Podman, and host execution paths, and cache discovered container home directories per engine/image so Podman no longer reuses Docker-specific execution metadata.
+
 ## [0.193.1-next]
 
 

--- a/src/Terrabuild.Tests/Core/Runner.fs
+++ b/src/Terrabuild.Tests/Core/Runner.fs
@@ -2,6 +2,7 @@ module Terrabuild.Tests.Core.Runner
 open System
 open System.IO
 open System.Collections.Generic
+open System.Runtime.InteropServices
 open FsUnit
 open NUnit.Framework
 open Contracts
@@ -69,6 +70,46 @@ let private withTempWorkspace action =
         Environment.CurrentDirectory <- oldCurrentDir
         if Directory.Exists(root) then
             Directory.Delete(root, true)
+
+let private withEnvironmentVariable name value action =
+    let previous = Environment.GetEnvironmentVariable(name)
+    Environment.SetEnvironmentVariable(name, value)
+    try
+        action ()
+    finally
+        Environment.SetEnvironmentVariable(name, previous)
+
+let private writeExecutableScript (path: string) (content: string) =
+    File.WriteAllText(path, content)
+
+    if not (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) then
+        File.SetUnixFileMode(path, UnixFileMode.UserRead ||| UnixFileMode.UserWrite ||| UnixFileMode.UserExecute)
+
+let private withFakeEngine workspace engineName containerHome action =
+    let binDir = Path.Combine(workspace, "bin")
+    Directory.CreateDirectory(binDir) |> ignore
+    let enginePath = Path.Combine(binDir, engineName)
+    writeExecutableScript enginePath ("#!/bin/sh\nprintf '%s' '" + containerHome + "'\n")
+
+    let currentPath = Environment.GetEnvironmentVariable("PATH")
+    let nextPath =
+        [ Some binDir
+          currentPath |> Option.ofObj ]
+        |> List.choose id
+        |> String.concat (string Path.PathSeparator)
+
+    withEnvironmentVariable "PATH" nextPath action
+
+let private buildOperation command arguments image =
+    { GraphDef.ContaineredShellOperation.Image = image
+      GraphDef.ContaineredShellOperation.Platform = Some "linux/amd64"
+      GraphDef.ContaineredShellOperation.Cpus = Some 2
+      GraphDef.ContaineredShellOperation.Variables = Set [ "TB_SAMPLE" ]
+      GraphDef.ContaineredShellOperation.Envs = Map [ "FROM_ENV_MAP", "set-by-terrabuild" ]
+      GraphDef.ContaineredShellOperation.MetaCommand = "test"
+      GraphDef.ContaineredShellOperation.Command = command
+      GraphDef.ContaineredShellOperation.Arguments = arguments
+      GraphDef.ContaineredShellOperation.ErrorLevel = 0 }
 
 type private FakeEntry(root: string, id: string, completed: ResizeArray<string>) =
     let entryRoot = Path.Combine(root, id.Replace("/", "_"))
@@ -149,6 +190,87 @@ type private FakeApiClient() =
 
         member _.UseArtifact projectHash targetHash =
             useCalls.Add(projectHash, targetHash)
+
+[<Test>]
+let ``buildCommands formats docker container requests through docker path`` () =
+    withTempWorkspace (fun workspace ->
+        withFakeEngine workspace "docker" "/docker-home" (fun () ->
+            withEnvironmentVariable "TB_SAMPLE" "$TERRABUILD_HOME/cache" (fun () ->
+                let operation = buildOperation "dotnet" "build App.csproj" (Some "mcr.microsoft.com/dotnet/sdk:8.0")
+                let node = buildNode "node-docker" "src/App" "build" GraphDef.RunAction.Exec [ operation ]
+                let options = { baseOptions workspace with Engine = Some "docker" }
+
+                let commands = Runner.buildCommands node options "src/App" workspace workspace
+                commands.Length |> should equal 1
+
+                let metaCommand, workDir, cmd, args, image, errorLevel, envs = commands[0]
+                metaCommand |> should equal "test"
+                workDir |> should equal workspace
+                cmd |> should equal "docker"
+                image |> should equal operation.Image
+                errorLevel |> should equal 0
+                envs |> should equal operation.Envs
+                args |> should contain "--entrypoint dotnet"
+                args |> should contain "--platform=linux/amd64"
+                args |> should contain "--cpus=2"
+                args |> should contain "-v /var/run/docker.sock:/var/run/docker.sock"
+                args |> should contain $"-v {workspace}:/docker-home"
+                args |> should contain "-e TB_SAMPLE=/docker-home/cache"
+                args |> should contain "-e FROM_ENV_MAP"
+                args |> should contain "mcr.microsoft.com/dotnet/sdk:8.0"
+                args |> should contain "build App.csproj"))
+        )
+
+[<Test>]
+let ``buildCommands formats podman container requests through podman path`` () =
+    withTempWorkspace (fun workspace ->
+        withFakeEngine workspace "podman" "/podman-home" (fun () ->
+            let operation = buildOperation "dotnet" "restore App.csproj" (Some "mcr.microsoft.com/dotnet/sdk:8.0")
+            let node = buildNode "node-podman" "src/App" "build" GraphDef.RunAction.Exec [ operation ]
+            let options = { baseOptions workspace with Engine = Some "podman" }
+
+            let commands = Runner.buildCommands node options "src/App" workspace workspace
+            commands.Length |> should equal 1
+
+            let _, workDir, cmd, args, _, _, _ = commands[0]
+            workDir |> should equal workspace
+            cmd |> should equal "podman"
+            args |> should contain "--entrypoint dotnet"
+            args |> should contain "-v /var/run/docker.sock:/var/run/docker.sock"
+            args |> should contain $"-v {workspace}:/podman-home"
+            args |> should contain "restore App.csproj"))
+
+[<Test>]
+let ``buildCommands uses explicit host path when engine is none even with image`` () =
+    withTempWorkspace (fun workspace ->
+        let operation = buildOperation "/usr/bin/env" "printenv" (Some "ignored:latest")
+        let node = buildNode "node-host" "src/App" "build" GraphDef.RunAction.Exec [ operation ]
+
+        let commands = Runner.buildCommands node (baseOptions workspace) "src/App" workspace workspace
+        commands.Length |> should equal 1
+
+        let _, workDir, cmd, args, image, _, _ = commands[0]
+        workDir |> should equal "src/App"
+        cmd |> should equal "/usr/bin/env"
+        args |> should equal "printenv"
+        image |> should equal operation.Image)
+
+[<Test>]
+let ``buildCommands uses host path when operation has no image regardless of engine`` () =
+    withTempWorkspace (fun workspace ->
+        withFakeEngine workspace "docker" "/docker-home" (fun () ->
+            let operation = buildOperation "/usr/bin/true" "--flag" None
+            let node = buildNode "node-no-image" "src/App" "build" GraphDef.RunAction.Exec [ operation ]
+            let options = { baseOptions workspace with Engine = Some "docker" }
+
+            let commands = Runner.buildCommands node options "src/App" workspace workspace
+            commands.Length |> should equal 1
+
+            let _, workDir, cmd, args, image, _, _ = commands[0]
+            workDir |> should equal "src/App"
+            cmd |> should equal "/usr/bin/true"
+            args |> should equal "--flag"
+            image |> should equal None))
 
 [<Test>]
 let ``buildBatchSchedule flattens member labels in GitHub mode`` () =

--- a/src/Terrabuild/Core/Runner.fs
+++ b/src/Terrabuild/Core/Runner.fs
@@ -41,61 +41,99 @@ type Summary = {
 
 let private containerInfos = Concurrent.ConcurrentDictionary<string, string>()
 
+type private BuiltCommand = string * string * string * string * string option * int * Map<string, string>
+
+[<RequireQualifiedAccess>]
+type private EngineRequestPath =
+    | Docker
+    | Podman
+    | Host
+
+let private resolveEngineRequestPath (engine: string option) =
+    match engine with
+    | Some "docker" -> EngineRequestPath.Docker
+    | Some "podman" -> EngineRequestPath.Podman
+    | _ -> EngineRequestPath.Host
+
+let private formatPlatform (operation: GraphDef.ContaineredShellOperation) =
+    operation.Platform |> Option.map (fun platform -> $"--platform={platform}") |> Option.defaultValue ""
+
+let private formatCpus (operation: GraphDef.ContaineredShellOperation) =
+    match operation.Cpus with
+    | Some cpus -> $"--cpus={cpus}"
+    | _ -> ""
+
+let private resolveContainerHome engineCommand workspace nodeTargetHash platform image =
+    let cacheKey = $"{engineCommand}:{image}"
+
+    match containerInfos.TryGetValue(cacheKey) with
+    | true, containerHome ->
+        Log.Debug("Reusing USER '{ContainerHome}' for '{Container}' with '{Engine}'", containerHome, image, engineCommand)
+        containerHome
+    | _ ->
+        let args = $"run --rm --name {nodeTargetHash} {platform} --entrypoint sh {image} -c \"echo -n $HOME\""
+        let containerHome =
+            match Exec.execCaptureOutput workspace engineCommand args Map.empty with
+            | Exec.Success (containerHome, _) -> containerHome.Trim()
+            | Exec.Error (errMsg, code) ->
+                Log.Debug("USER identification failed for '{Container}' with error '{ErrorMsg}' and code {Code}, using root instead", image, errMsg, code)
+                "/root"
+
+        Log.Debug("Using USER '{ContainerHome}' for '{Container}' with '{Engine}'", containerHome, image, engineCommand)
+        containerInfos.TryAdd(cacheKey, containerHome) |> ignore
+        containerHome
+
+let private formatContainerEnvs (operation: GraphDef.ContaineredShellOperation) containerHome =
+    let matcher = Matcher()
+    matcher.AddIncludePatterns(operation.Variables)
+    envVars()
+    |> Seq.choose (fun entry ->
+        let key = entry.Key
+        let value = entry.Value
+        if matcher.Match([ key ]).HasMatches then
+            let expandedValue = value |> expandTerrabuildHome containerHome
+            if value = expandedValue then Some $"-e {key}"
+            else Some $"-e {key}={expandedValue}"
+        else None)
+    |> Seq.append (operation.Envs.Keys |> Seq.map (fun key -> $"-e {key}"))
+    |> String.join " "
+
+let private buildHostCommand (operation: GraphDef.ContaineredShellOperation) projectDirectory : BuiltCommand =
+    operation.MetaCommand, projectDirectory, operation.Command, operation.Arguments, operation.Image, operation.ErrorLevel, operation.Envs
+
+let private buildContainerCommand engineCommand extraArgs (node: GraphDef.Node) (operation: GraphDef.ContaineredShellOperation) (options: ConfigOptions.Options) projectDirectory homeDir tmpDir : BuiltCommand =
+    let wsDir = currentDir()
+    let platform = formatPlatform operation
+    let cpus = formatCpus operation
+    let image = operation.Image.Value
+    let containerHome = resolveContainerHome engineCommand options.Workspace node.TargetHash platform image
+    let envs = formatContainerEnvs operation containerHome
+    let args =
+        $"run --rm --name {node.TargetHash} {cpus} {extraArgs} -v {homeDir}:{containerHome} -v {tmpDir}:/tmp -v {wsDir}:/terrabuild -w /terrabuild/{projectDirectory} {platform} --entrypoint {operation.Command} {envs} {image} {operation.Arguments}"
+
+    operation.MetaCommand, options.Workspace, engineCommand, args, operation.Image, operation.ErrorLevel, operation.Envs
+
+let private buildDockerCommand node operation options projectDirectory homeDir tmpDir =
+    let dockerArgs = "--net=host --pid=host --ipc=host -v /var/run/docker.sock:/var/run/docker.sock"
+    buildContainerCommand "docker" dockerArgs node operation options projectDirectory homeDir tmpDir
+
+let private buildPodmanCommand node operation options projectDirectory homeDir tmpDir =
+    let podmanArgs = "--net=host --pid=host --ipc=host -v /var/run/docker.sock:/var/run/docker.sock"
+    buildContainerCommand "podman" podmanArgs node operation options projectDirectory homeDir tmpDir
+
 let buildCommands (node: GraphDef.Node) (options: ConfigOptions.Options) projectDirectory homeDir tmpDir =
-    node.Operations |> List.map (fun operation ->
-        let metaCommand = operation.MetaCommand
-        match options.Engine, operation.Image with
-        | Some cmd, Some image ->
-            let wsDir = currentDir()
+    let enginePath = resolveEngineRequestPath options.Engine
 
-            // add platform
-            let platform = operation.Platform |> Option.map (fun platform -> $"--platform={platform}") |> Option.defaultValue ""
-
-            let containerHome =
-                match containerInfos.TryGetValue(image) with
-                | true, containerHome ->
-                    Log.Debug("Reusing USER '{ContainerHome}' for '{Container}'", containerHome, image)
-                    containerHome
-                | _ ->
-                    // discover USER
-                    let args = $"run --rm --name {node.TargetHash} {platform} --entrypoint sh {image} -c \"echo -n $HOME\""
-                    let containerHome =
-                        match Exec.execCaptureOutput options.Workspace cmd args Map.empty with
-                        | Exec.Success (containerHome, _) -> containerHome.Trim()
-                        | Exec.Error (errMsg, code) ->
-                            Log.Debug("USER identification failed for '{Container}' with error '{ErrorMsg}' and code {Code}, using root instead", image, errMsg, code)
-                            "/root"
-
-                    Log.Debug("Using USER '{ContainerHome}' for '{Container}'", containerHome, image)
-                    containerInfos.TryAdd(image, containerHome) |> ignore
-                    containerHome
-
-            let envs =
-                let matcher = Matcher()
-                matcher.AddIncludePatterns(operation.Variables)
-                envVars()
-                |> Seq.choose (fun entry ->
-                    let key = entry.Key
-                    let value = entry.Value
-                    if matcher.Match([ key ]).HasMatches then
-                        let expandedValue = value |> expandTerrabuildHome containerHome
-                        if value = expandedValue then Some $"-e {key}"
-                        else Some $"-e {key}={expandedValue}"
-                    else None)
-                |> Seq.append (operation.Envs.Keys |> Seq.map (fun key -> $"-e {key}"))
-                |> String.join " "
-
-            let cpus =
-                match operation.Cpus with
-                | Some cpus -> $"--cpus={cpus}"
-                | _ -> ""
-
-            let args =
-                $"run --rm --name {node.TargetHash} {cpus} --net=host --pid=host --ipc=host -v /var/run/docker.sock:/var/run/docker.sock -v {homeDir}:{containerHome} -v {tmpDir}:/tmp -v {wsDir}:/terrabuild -w /terrabuild/{projectDirectory} {platform} --entrypoint {operation.Command} {envs} {image} {operation.Arguments}"
-            metaCommand, options.Workspace, cmd, args, operation.Image, operation.ErrorLevel, operation.Envs
-        | _ ->
-            metaCommand, projectDirectory, operation.Command, operation.Arguments, operation.Image, operation.ErrorLevel, operation.Envs
-    )
+    node.Operations
+    |> List.map (fun operation ->
+        match enginePath, operation.Image with
+        | EngineRequestPath.Docker, Some _ ->
+            buildDockerCommand node operation options projectDirectory homeDir tmpDir
+        | EngineRequestPath.Podman, Some _ ->
+            buildPodmanCommand node operation options projectDirectory homeDir tmpDir
+        | EngineRequestPath.Host, _
+        | _, None ->
+            buildHostCommand operation projectDirectory)
 
 let execCommands (node: GraphDef.Node) (cacheEntry: Cache.IEntry) (options: ConfigOptions.Options) projectDirectory homeDir tmpDir =
     let stepLogs = List<Cache.OperationSummary>()


### PR DESCRIPTION
## Summary
- split runner command construction into explicit Docker, Podman, and host execution paths
- extract shared container formatting helpers while keeping current command behavior intact
- add runner tests for docker, podman, engine=none, and image-less host execution
- cache discovered container homes per engine/image so Podman does not reuse Docker metadata

## Validation
- make test