### PR TITLE
feat: add local cache pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Terrabuild are documented in this file.
 
 ## [Unreleased]
 
+- Add `terrabuild prune <days>` to remove stale local cache entries from `~/.terrabuild/cache`, refresh cache-entry access timestamps on local reads, and document the new cache-retention workflow.
+
 ## [0.194.5]
 
 - Fail fast with a user-facing invalid-argument error when Terrabuild runs in a workspace that is not a git repository, instead of surfacing that source-control initialization failure to Sentry.

--- a/src/Terrabuild.Tests/Core/Cache.fs
+++ b/src/Terrabuild.Tests/Core/Cache.fs
@@ -3,6 +3,7 @@ open System
 open System.IO
 open FsUnit
 open NUnit.Framework
+open Collections
 
 type private FakeStorage() =
     let uploads = ResizeArray<string>()
@@ -24,6 +25,14 @@ let private withTempDir action =
         if Directory.Exists(root) then
             Directory.Delete(root, true)
 
+let private withHomeDir root action =
+    let previousHome = Environment.GetEnvironmentVariable("HOME")
+    Environment.SetEnvironmentVariable("HOME", root)
+    try
+        action ()
+    finally
+        Environment.SetEnvironmentVariable("HOME", previousHome)
+
 let private summary outputsDir =
     { Cache.TargetSummary.Project = "."
       Cache.TargetSummary.Target = "build"
@@ -34,6 +43,14 @@ let private summary outputsDir =
       Cache.TargetSummary.EndedAt = DateTime.UtcNow
       Cache.TargetSummary.Duration = TimeSpan.FromSeconds(1.0)
       Cache.TargetSummary.Cache = GraphDef.ArtifactMode.Workspace }
+
+let private createLocalCacheEntry (root: string) (id: string) entrySummary =
+    let entryDir = Path.Combine(root, ".terrabuild", "cache", id.Replace('/', Path.DirectorySeparatorChar))
+    let logsDir = Path.Combine(entryDir, "logs")
+    Directory.CreateDirectory(logsDir) |> ignore
+    File.WriteAllText(Path.Combine(logsDir, "summary.json"), entrySummary |> Json.Serialize)
+    File.WriteAllText(Path.Combine(entryDir, "origin"), Cache.Origin.Local |> Json.Serialize)
+    entryDir
 
 [<Test>]
 let ``cache completion returns logs when outputs do not exist`` () =
@@ -80,3 +97,88 @@ let ``cache completion omits summary outputs marker when outputs are not materia
             |> Json.Deserialize<Cache.TargetSummary>
 
         writtenSummary.Outputs |> should equal None)
+
+[<Test>]
+let ``prune cache deletes stale entries and preserves fresh siblings`` () =
+    withTempDir (fun root ->
+        let staleEntry = createLocalCacheEntry root "project-hash/build/stale-target" (summary None)
+        let freshEntry = createLocalCacheEntry root "project-hash/build/fresh-target" (summary None)
+        let malformedEntry =
+            Path.Combine(root, ".terrabuild", "cache", "project-hash", "build", "malformed-target")
+        Directory.CreateDirectory(malformedEntry) |> ignore
+
+        File.SetLastWriteTimeUtc(Path.Combine(staleEntry, "origin"), DateTime.UtcNow.AddDays(-10.0))
+        File.SetLastWriteTimeUtc(Path.Combine(freshEntry, "origin"), DateTime.UtcNow.AddDays(-2.0))
+
+        let pruneSummary =
+            Cache.pruneCacheEntries (Path.Combine(root, ".terrabuild", "cache")) (DateTime.UtcNow.AddDays(-7.0))
+
+        pruneSummary.Scanned |> should equal 3
+        pruneSummary.Pruned |> should equal 1
+        pruneSummary.Skipped |> should equal 2
+        Directory.Exists(staleEntry) |> should equal false
+        Directory.Exists(freshEntry) |> should equal true
+        Directory.Exists(malformedEntry) |> should equal true
+        Directory.Exists(Path.Combine(root, ".terrabuild", "cache", "project-hash", "build")) |> should equal true)
+
+[<Test>]
+let ``prune cache skips entries without touching home or tmp`` () =
+    withTempDir (fun root ->
+        let cacheRoot = Path.Combine(root, ".terrabuild", "cache")
+        let homeRoot = Path.Combine(root, ".terrabuild", "home")
+        let tmpRoot = Path.Combine(root, ".terrabuild", "tmp")
+        let staleEntry = createLocalCacheEntry root "project-hash/build/stale-target" (summary None)
+
+        Directory.CreateDirectory(homeRoot) |> ignore
+        Directory.CreateDirectory(tmpRoot) |> ignore
+        File.WriteAllText(Path.Combine(homeRoot, "keep.txt"), "home")
+        File.WriteAllText(Path.Combine(tmpRoot, "keep.txt"), "tmp")
+        File.SetLastWriteTimeUtc(Path.Combine(staleEntry, "origin"), DateTime.UtcNow.AddDays(-10.0))
+
+        Cache.pruneCacheEntries cacheRoot (DateTime.UtcNow.AddDays(-7.0)) |> ignore
+
+        Directory.Exists(staleEntry) |> should equal false
+        File.Exists(Path.Combine(homeRoot, "keep.txt")) |> should equal true
+        File.Exists(Path.Combine(tmpRoot, "keep.txt")) |> should equal true)
+
+[<Test>]
+let ``try get summary only refreshes origin timestamp for local cache entries`` () =
+    withTempDir (fun root ->
+        withHomeDir root (fun () ->
+            let entryDir = createLocalCacheEntry root "project-hash/build/target-hash" (summary None)
+            let originFile = Path.Combine(entryDir, "origin")
+            let oldTimestamp = DateTime.UtcNow.AddDays(-10.0)
+            File.SetLastWriteTimeUtc(originFile, oldTimestamp)
+
+            let cache = Cache.Cache(FakeStorage(), None) :> Cache.ICache
+            let result = cache.TryGetSummaryOnly false "project-hash/build/target-hash"
+            let refreshedTimestamp = File.GetLastWriteTimeUtc(originFile)
+
+            result |> should not' (equal None)
+            refreshedTimestamp |> should be (greaterThan oldTimestamp)
+        )
+    )
+
+[<Test>]
+let ``try get summary only does not refresh origin timestamp when summary load fails`` () =
+    withTempDir (fun root ->
+        withHomeDir root (fun () ->
+            let entryDir = Path.Combine(root, ".terrabuild", "cache", "project-hash", "build", "target-hash")
+            let logsDir = Path.Combine(entryDir, "logs")
+            let originFile = Path.Combine(entryDir, "origin")
+
+            Directory.CreateDirectory(logsDir) |> ignore
+            File.WriteAllText(Path.Combine(logsDir, "summary.json"), "{ invalid json")
+            File.WriteAllText(originFile, Cache.Origin.Local |> Json.Serialize)
+
+            let oldTimestamp = DateTime.UtcNow.AddDays(-10.0)
+            File.SetLastWriteTimeUtc(originFile, oldTimestamp)
+
+            let cache = Cache.Cache(FakeStorage(), None) :> Cache.ICache
+            let result = cache.TryGetSummaryOnly false "project-hash/build/target-hash"
+            let refreshedTimestamp = File.GetLastWriteTimeUtc(originFile)
+
+            result |> should equal None
+            refreshedTimestamp |> should equal oldTimestamp
+        )
+    )

--- a/src/Terrabuild/CLI.fs
+++ b/src/Terrabuild/CLI.fs
@@ -121,6 +121,7 @@ with
 type ClearArgs =
     | [<Unique>] Cache
     | [<Unique>] Home
+    | [<Unique>] Temporary
     | [<Unique>] All
 with
     interface IArgParserTemplate with
@@ -128,6 +129,7 @@ with
             match this with
             | Cache -> "Clear build cache."
             | Home -> "Clear home cache."
+            | Temporary -> "Clear tmp cache."
             | All -> "Clear all caches."
 
 [<RequireQualifiedAccess>]

--- a/src/Terrabuild/CLI.fs
+++ b/src/Terrabuild/CLI.fs
@@ -133,6 +133,15 @@ with
             | All -> "Clear all caches."
 
 [<RequireQualifiedAccess>]
+type PruneArgs =
+    | [<ExactlyOnce; MainCommand; First>] Days of days:int
+with
+    interface IArgParserTemplate with
+        member this.Usage =
+            match this with
+            | Days _ -> "Prune local build cache entries not accessed for more than <days> days."
+
+[<RequireQualifiedAccess>]
 type LoginArgs =
     | [<ExactlyOnce>] Workspace of id:string
     | [<ExactlyOnce>] Token of token:string
@@ -162,6 +171,7 @@ type TerrabuildArgs =
     | [<CliPrefix(CliPrefix.None)>] Serve of ParseResults<ServeArgs>
     | [<CliPrefix(CliPrefix.None)>] Console of ParseResults<ConsoleArgs>
     | [<CliPrefix(CliPrefix.None)>] Clear of ParseResults<ClearArgs>
+    | [<CliPrefix(CliPrefix.None)>] Prune of ParseResults<PruneArgs>
     | [<CliPrefix(CliPrefix.None)>] Login of ParseResults<LoginArgs>
     | [<CliPrefix(CliPrefix.None)>] Logout of ParseResults<LogoutArgs>
     | [<CliPrefix(CliPrefix.None)>] Version
@@ -177,6 +187,7 @@ with
             | Serve _ -> "Serve specified targets."
             | Console _ -> "Launch web console."
             | Clear _ -> "Clear specified caches."
+            | Prune _ -> "Prune stale local build cache entries."
             | Login _ -> "Connect to backend."
             | Logout _ -> "Disconnect from backend."
             | Version -> "Show current Terrabuild version."

--- a/src/Terrabuild/Core/Cache.fs
+++ b/src/Terrabuild/Core/Cache.fs
@@ -89,10 +89,12 @@ let private getOrigin entryDir =
 
 let clearCache () =
     IO.deleteAny (createCache())
-    IO.deleteAny (createTmp())
 
 let clearHomeCache () =
     IO.deleteAny (createHome())
+
+let clearTemp () =
+    IO.deleteAny (createTmp())
 
 let createDirectories() =
     createTerrabuildProfile() |> ignore

--- a/src/Terrabuild/Core/Cache.fs
+++ b/src/Terrabuild/Core/Cache.fs
@@ -41,6 +41,13 @@ type ArtifactInfo = {
     Size: int
 }
 
+[<RequireQualifiedAccess>]
+type PruneSummary = {
+    Scanned: int
+    Pruned: int
+    Skipped: int
+}
+
 
 type IEntry =
     abstract NextLogFile: unit -> string
@@ -87,6 +94,11 @@ let private getOrigin entryDir =
     let originFile = FS.combinePath entryDir originFilename
     originFile |> IO.readTextFile |> Json.Deserialize<Origin>
 
+let private touchOrigin entryDir =
+    let originFile = FS.combinePath entryDir originFilename
+    if File.Exists originFile then
+        File.SetLastWriteTimeUtc(originFile, DateTime.UtcNow)
+
 let clearCache () =
     IO.deleteAny (createCache())
 
@@ -101,6 +113,45 @@ let createDirectories() =
     createCache() |> ignore
     createHome() |> ignore
     createTmp() |> ignore
+
+let pruneCacheEntries cacheDir cutoff =
+    let emptySummary: PruneSummary = {
+        Scanned = 0
+        Pruned = 0
+        Skipped = 0
+    }
+
+    if Directory.Exists cacheDir |> not then
+        emptySummary
+    else
+        let pruneEntry (summary: PruneSummary) entryDir =
+            let originFile = FS.combinePath entryDir originFilename
+            let summary =
+                { summary with
+                    Scanned = summary.Scanned + 1 }
+
+            if File.Exists originFile |> not then
+                { summary with Skipped = summary.Skipped + 1 }
+            else
+                let lastAccessedAt = File.GetLastWriteTimeUtc(originFile)
+                if lastAccessedAt > cutoff then
+                    { summary with Skipped = summary.Skipped + 1 }
+                else
+                    try
+                        Directory.Delete(entryDir, true)
+                        { summary with Pruned = summary.Pruned + 1 }
+                    with exn ->
+                        Log.Warning(exn, "Failed to prune cache entry {EntryDir}", entryDir)
+                        { summary with Skipped = summary.Skipped + 1 }
+
+        IO.enumerateDirs cacheDir
+        |> Seq.collect IO.enumerateDirs
+        |> Seq.collect IO.enumerateDirs
+        |> Seq.fold pruneEntry emptySummary
+
+let pruneCache days =
+    let cutoff = DateTime.UtcNow - TimeSpan.FromDays(days |> float)
+    pruneCacheEntries (createCache()) cutoff
 
 
 type NewEntry(entryDir: string, useRemote: bool, id: string, storage: Contracts.IStorage, masterKey: byte[] option) =
@@ -253,10 +304,13 @@ type Cache(storage: Contracts.IStorage, masterKey: byte[] option) =
     interface ICache with
         // NOTE: do not use when building - only use for graph building
         member _.TryGetSummaryOnly useRemote id : (Origin * TargetSummary) option =
+            let entryDir = FS.combinePath (createCache()) id
             match cachedSummaries.TryGetValue(id) with
+            | true, (Some _ as originSummary) ->
+                touchOrigin entryDir
+                originSummary
             | true, originSummary -> originSummary
             | false, _ ->
-                let entryDir = FS.combinePath (createCache()) id
                 let logsDir = FS.combinePath entryDir "logs"
                 let outputsDir = FS.combinePath entryDir "outputs"
                 let summaryFile = FS.combinePath logsDir summaryFilename
@@ -268,6 +322,7 @@ type Cache(storage: Contracts.IStorage, masterKey: byte[] option) =
                     match tryLoadSummary logsDir outputsDir summaryFile with
                     | Some summary ->
                         let origin = getOrigin entryDir
+                        touchOrigin entryDir
                         cachedSummaries.TryAdd(id, Some (origin, summary)) |> ignore
                         Some (origin, summary)
                     | _ -> None

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -399,6 +399,15 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         if clearArgs.Contains(ClearArgs.Temporary) || clearArgs.Contains(ClearArgs.All) then Cache.clearTemp()
         0
 
+    let prune (pruneArgs: ParseResults<PruneArgs>) =
+        let days = pruneArgs.GetResult(PruneArgs.Days)
+        if days < 0 then
+            raiseInvalidArg "Prune threshold must be zero or greater."
+
+        let summary = Cache.pruneCache days
+        $"Pruned local cache entries: scanned={summary.Scanned}, pruned={summary.Pruned}, skipped={summary.Skipped}" |> Terminal.writeLine
+        0
+
     let login (loginArgs: ParseResults<LoginArgs>) =
         let workspaceId = loginArgs.GetResult(LoginArgs.Workspace)
         let token = loginArgs.GetResult(LoginArgs.Token)
@@ -425,6 +434,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
     | p when p.Contains(TerrabuildArgs.Serve) -> p.GetResult(TerrabuildArgs.Serve) |> serve
     | p when p.Contains(TerrabuildArgs.Console) -> p.GetResult(TerrabuildArgs.Console) |> console
     | p when p.Contains(TerrabuildArgs.Clear) -> p.GetResult(TerrabuildArgs.Clear) |> clear
+    | p when p.Contains(TerrabuildArgs.Prune) -> p.GetResult(TerrabuildArgs.Prune) |> prune
     | p when p.Contains(TerrabuildArgs.Login) -> p.GetResult(TerrabuildArgs.Login) |> login
     | p when p.Contains(TerrabuildArgs.Logout) -> p.GetResult(TerrabuildArgs.Logout) |> logout
     | p when p.Contains(TerrabuildArgs.Version) -> version()

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -396,6 +396,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
     let clear (clearArgs: ParseResults<ClearArgs>) =
         if clearArgs.Contains(ClearArgs.Cache) || clearArgs.Contains(ClearArgs.All) then Cache.clearCache()
         if clearArgs.Contains(ClearArgs.Home) || clearArgs.Contains(ClearArgs.All) then Cache.clearHomeCache()
+        if clearArgs.Contains(ClearArgs.Temporary) || clearArgs.Contains(ClearArgs.All) then Cache.clearTemp()
         0
 
     let login (loginArgs: ParseResults<LoginArgs>) =

--- a/website/site-docs/usage.md
+++ b/website/site-docs/usage.md
@@ -15,6 +15,7 @@ SUBCOMMANDS:
     run <options>         Run specified targets.
     serve <options>       Serve specified targets.
     clear <options>       Clear specified caches.
+    prune <options>       Prune stale local build cache entries.
     login <options>       Connect to backend.
     logout <options>      Disconnect from backend.
 
@@ -68,15 +69,38 @@ OPTIONS:
 Command `clear` allows you to clear local cache. This is useful when you want to force a complete build or free up disk space:
 ```
 > terrabuild clear --help
-USAGE: terrabuild clear [--help] [--cache] [--home] [--all]
+USAGE: terrabuild clear [--help] [--cache] [--home] [--temporary] [--all]
 
 OPTIONS:
 
     --cache               Clear build cache.
     --home                Clear home cache.
+    --temporary           Clear tmp cache.
     --all                 Clear all caches.
     --help                display this list of options.
 ```
+
+## Prune Local Cache
+Command `prune` removes stale entries from `~/.terrabuild/cache` while leaving `~/.terrabuild/home` and `~/.terrabuild/tmp` untouched:
+```
+> terrabuild prune --help
+USAGE: terrabuild prune [--help] <days>
+
+TARGET:
+
+    <days>                Prune local build cache entries not accessed for more than <days> days.
+
+OPTIONS:
+
+    --help                display this list of options.
+```
+
+Example:
+```
+> terrabuild prune 7
+```
+
+Freshness is based on Terrabuild-managed access timestamps on each cache entry `origin` file, not filesystem last-access (`atime`) behavior.
 
 ## Connect to a Shared Cache
 The `login` command lets you connect to a shared cache (Insights workspace), enabling faster builds by sharing artifacts between machines and CI/CD pipelines. All artifacts are encrypted on the client side and never stored unencrypted.


### PR DESCRIPTION
## Summary
- add `terrabuild prune <days>` to prune stale local cache entries under `~/.terrabuild/cache`
- refresh local cache entry `origin` timestamps on successful local reads so pruning uses Terrabuild-managed access time
- add cache tests and usage docs for the new command

## Validation
- make test
- make self