### PR TITLE
chore: upgrade FScript to 0.72.0

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.201" />
+    <PackageReference Update="FSharp.Core" Version="10.1.300" />
   </ItemGroup>
 </Project>

--- a/src/Terrabuild.Scripting/Terrabuild.Scripting.fsproj
+++ b/src/Terrabuild.Scripting/Terrabuild.Scripting.fsproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalFScript)' != 'true'">
-    <PackageReference Include="MagnusOpera.FScript.Language" Version="0.71.0" />
-    <PackageReference Include="MagnusOpera.FScript.Runtime" Version="0.71.0" />
+    <PackageReference Include="MagnusOpera.FScript.Language" Version="0.72.0" />
+    <PackageReference Include="MagnusOpera.FScript.Runtime" Version="0.72.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalFScript)' == 'true'">


### PR DESCRIPTION
## Summary
- upgrade `MagnusOpera.FScript.Language` and `MagnusOpera.FScript.Runtime` to `0.72.0`
- align the repo-wide `FSharp.Core` pin to `10.1.300` to satisfy the new transitive minimum
- keep the change isolated from the separate remote-cache regression investigation

## Validation
- `dotnet test -c Debug src/Terrabuild.Scripting.Tests/Terrabuild.Scripting.Tests.fsproj`
- `make try-docs`
- `make test` *(fails in unrelated existing regression: `dotnet remote cache restores project reference with empty local caches` in `src/Terrabuild.Tests/Core/DotnetRemoteCache.fs` with `Task execution not yet completed`)*
