### PR TITLE
chore: upgrade FScript to 0.72.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Terrabuild are documented in this file.
 
 ## [Unreleased]
 
+- Upgrade embedded FScript runtime/language packages to `0.72.0`.
 - Remove macOS Intel (`darwin-x64` / `osx-x64`) build and release artifacts from the Make publish flow, release automation, Homebrew tap metadata, scaffold lockfiles, and install documentation so Terrabuild ships only the supported macOS arm64 binary.
 - Add `terrabuild prune <days>` to remove stale local cache entries from `~/.terrabuild/cache`, refresh cache-entry access timestamps on local reads, and document the new cache-retention workflow.
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.201" />
+    <PackageReference Update="FSharp.Core" Version="10.1.300" />
   </ItemGroup>
 </Project>

--- a/src/Terrabuild.Scripting/Terrabuild.Scripting.fsproj
+++ b/src/Terrabuild.Scripting/Terrabuild.Scripting.fsproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalFScript)' != 'true'">
-    <PackageReference Include="MagnusOpera.FScript.Language" Version="0.71.0" />
-    <PackageReference Include="MagnusOpera.FScript.Runtime" Version="0.71.0" />
+    <PackageReference Include="MagnusOpera.FScript.Language" Version="0.72.0" />
+    <PackageReference Include="MagnusOpera.FScript.Runtime" Version="0.72.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalFScript)' == 'true'">


### PR DESCRIPTION
## Summary
- upgrade `MagnusOpera.FScript.Language` and `MagnusOpera.FScript.Runtime` to `0.72.0`
- align the repo-wide `FSharp.Core` pin to `10.1.300` to satisfy the new transitive minimum

## Validation
- `dotnet test -c Debug src/Terrabuild.Scripting.Tests/Terrabuild.Scripting.Tests.fsproj`
- `make try-docs`
- `make test`
