### PR TITLE
feat: add machine-readable build result output

### DIFF
--- a/src/Terrabuild.Tests/Core/Program.fs
+++ b/src/Terrabuild.Tests/Core/Program.fs
@@ -57,12 +57,12 @@ let private withTempDir action =
             Directory.Delete(root, true)
 
 [<Test>]
-let ``CLI parses run-result argument`` () =
+let ``CLI parses result argument`` () =
     let parser = ArgumentParser.Create<CLI.TerrabuildArgs>(programName = "terrabuild")
-    let result = parser.ParseCommandLine([| "run"; "build"; "--run-result"; "out.json" |], raiseOnUsage = true)
+    let result = parser.ParseCommandLine([| "run"; "build"; "--result"; "out.json" |], raiseOnUsage = true)
     let runArgs = result.GetResult(TerrabuildArgs.Run)
 
-    runArgs.GetResult(RunArgs.Run_Result) |> should equal "out.json"
+    runArgs.GetResult(RunArgs.Result) |> should equal "out.json"
 
 [<Test>]
 let ``buildRunResult produces minimal jq friendly structure`` () =
@@ -82,9 +82,9 @@ let ``buildRunResult produces minimal jq friendly structure`` () =
 
     runResult.Status |> should equal "success"
     runResult.Targets |> should equal [ "build"; "test" ]
-    runResult.Results[".build"] |> should equal "success"
-    runResult.Results["src/Terrabuild.Common.build"] |> should equal "success"
-    runResult.Results["src/Terrabuild.Common.Tests.test"] |> should equal "success"
+    runResult.Results[".:build"] |> should equal "success"
+    runResult.Results["src/Terrabuild.Common:build"] |> should equal "success"
+    runResult.Results["src/Terrabuild.Common.Tests:test"] |> should equal "success"
 
 [<Test>]
 let ``buildRunResult collapses duplicate project target keys with failure dominance`` () =
@@ -104,8 +104,8 @@ let ``buildRunResult collapses duplicate project target keys with failure domina
 
     runResult.Status |> should equal "failure"
     runResult.Results.Count |> should equal 2
-    runResult.Results["src/App.build"] |> should equal "failure"
-    runResult.Results["src/Lib.build"] |> should equal "success"
+    runResult.Results["src/App:build"] |> should equal "failure"
+    runResult.Results["src/Lib:build"] |> should equal "success"
 
 [<Test>]
 let ``buildRunResult marks graph nodes without runtime results as ignored`` () =
@@ -123,9 +123,9 @@ let ``buildRunResult marks graph nodes without runtime results as ignored`` () =
     let runResult = global.Program.buildRunResult graph summary
 
     runResult.Status |> should equal "success"
-    runResult.Results[".build"] |> should equal "success"
-    runResult.Results["src/App.test"] |> should equal "ignored"
-    runResult.Results["src/Lib.build"] |> should equal "success"
+    runResult.Results[".:build"] |> should equal "success"
+    runResult.Results["src/App:test"] |> should equal "ignored"
+    runResult.Results["src/Lib:build"] |> should equal "success"
 
 [<Test>]
 let ``buildRunResult uses failure then success then ignored precedence for duplicate keys`` () =
@@ -142,7 +142,7 @@ let ``buildRunResult uses failure then success then ignored precedence for dupli
     let runResult = global.Program.buildRunResult graph summary
 
     runResult.Results.Count |> should equal 1
-    runResult.Results["src/App.build"] |> should equal "success"
+    runResult.Results["src/App:build"] |> should equal "success"
 
 [<Test>]
 let ``writeRunResultFile writes JSON for successful and ignored nodes`` () =
@@ -164,8 +164,8 @@ let ``writeRunResultFile writes JSON for successful and ignored nodes`` () =
         let json = doc.RootElement
         json.GetProperty("status").GetString() |> should equal "success"
         json.GetProperty("targets").EnumerateArray() |> Seq.map (fun item -> item.GetString()) |> Seq.toList |> should equal [ "build"; "test" ]
-        json.GetProperty("results").GetProperty(".build").GetString() |> should equal "success"
-        json.GetProperty("results").GetProperty("src/App.test").GetString() |> should equal "ignored")
+        json.GetProperty("results").GetProperty(".:build").GetString() |> should equal "success"
+        json.GetProperty("results").GetProperty("src/App:test").GetString() |> should equal "ignored")
 
 [<Test>]
 let ``writeRunResultFile writes JSON for failed summary and optional writer skips None`` () =
@@ -189,5 +189,5 @@ let ``writeRunResultFile writes JSON for failed summary and optional writer skip
         use doc = JsonDocument.Parse(File.ReadAllText(path))
         let json = doc.RootElement
         json.GetProperty("status").GetString() |> should equal "failure"
-        json.GetProperty("results").GetProperty(".build").GetString() |> should equal "failure"
-        json.GetProperty("results").GetProperty("src/App.test").GetString() |> should equal "ignored")
+        json.GetProperty("results").GetProperty(".:build").GetString() |> should equal "failure"
+        json.GetProperty("results").GetProperty("src/App:test").GetString() |> should equal "ignored")

--- a/src/Terrabuild.Tests/Core/Program.fs
+++ b/src/Terrabuild.Tests/Core/Program.fs
@@ -24,6 +24,29 @@ let private buildSummary isSuccess nodes =
       Runner.Summary.Targets = Set [ "build"; "test" ]
       Runner.Summary.Nodes = nodes |> Map.ofList }
 
+let private buildGraph (nodes: GraphDef.Node list) =
+    { GraphDef.Graph.Nodes = nodes |> List.map (fun node -> node.Id, node) |> Map.ofList
+      GraphDef.Graph.RootNodes = nodes |> List.map (fun node -> node.Id) |> Set.ofList
+      GraphDef.Graph.Batches = Map.empty }
+
+let private buildGraphNode id project target =
+    { GraphDef.Node.Id = id
+      GraphDef.Node.ProjectId = id
+      GraphDef.Node.ProjectName = None
+      GraphDef.Node.ProjectDir = project
+      GraphDef.Node.Target = target
+      GraphDef.Node.Dependencies = Set.empty
+      GraphDef.Node.Outputs = Set.empty
+      GraphDef.Node.ProjectHash = $"project-{id}"
+      GraphDef.Node.TargetHash = $"target-{id}"
+      GraphDef.Node.ClusterHash = None
+      GraphDef.Node.Operations = []
+      GraphDef.Node.Artifacts = GraphDef.ArtifactMode.Workspace
+      GraphDef.Node.Build = GraphDef.BuildMode.Auto
+      GraphDef.Node.Batch = GraphDef.BatchMode.Single
+      GraphDef.Node.Action = GraphDef.RunAction.Ignore
+      GraphDef.Node.Required = true }
+
 let private withTempDir action =
     let root = Path.Combine(Path.GetTempPath(), $"terrabuild-program-tests-{Guid.NewGuid():N}")
     Directory.CreateDirectory(root) |> ignore
@@ -43,13 +66,19 @@ let ``CLI parses run-result argument`` () =
 
 [<Test>]
 let ``buildRunResult produces minimal jq friendly structure`` () =
+    let graph =
+        buildGraph
+            [ buildGraphNode "node-a" "." "build"
+              buildGraphNode "node-b" "src/Terrabuild.Common" "build"
+              buildGraphNode "node-c" "src/Terrabuild.Common.Tests" "test" ]
+
     let summary =
         buildSummary true
             [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Success DateTime.UtcNow)
               "node-b", buildNodeInfo "src/Terrabuild.Common" "build" (Runner.TaskStatus.Success DateTime.UtcNow)
               "node-c", buildNodeInfo "src/Terrabuild.Common.Tests" "test" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-    let runResult = global.Program.buildRunResult summary
+    let runResult = global.Program.buildRunResult graph summary
 
     runResult.Status |> should equal "success"
     runResult.Targets |> should equal [ "build"; "test" ]
@@ -59,13 +88,19 @@ let ``buildRunResult produces minimal jq friendly structure`` () =
 
 [<Test>]
 let ``buildRunResult collapses duplicate project target keys with failure dominance`` () =
+    let graph =
+        buildGraph
+            [ buildGraphNode "node-a" "src/App" "build"
+              buildGraphNode "node-b" "src/App" "build"
+              buildGraphNode "node-c" "src/Lib" "build" ]
+
     let summary =
         buildSummary false
             [ "node-a", buildNodeInfo "src/App" "build" (Runner.TaskStatus.Success DateTime.UtcNow)
               "node-b", buildNodeInfo "src/App" "build" (Runner.TaskStatus.Failure (DateTime.UtcNow, "boom"))
               "node-c", buildNodeInfo "src/Lib" "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-    let runResult = global.Program.buildRunResult summary
+    let runResult = global.Program.buildRunResult graph summary
 
     runResult.Status |> should equal "failure"
     runResult.Results.Count |> should equal 2
@@ -73,14 +108,55 @@ let ``buildRunResult collapses duplicate project target keys with failure domina
     runResult.Results["src/Lib.build"] |> should equal "success"
 
 [<Test>]
-let ``writeRunResultFile writes JSON for successful summary`` () =
+let ``buildRunResult marks graph nodes without runtime results as ignored`` () =
+    let graph =
+        buildGraph
+            [ buildGraphNode "node-a" "." "build"
+              buildGraphNode "node-b" "src/App" "test"
+              buildGraphNode "node-c" "src/Lib" "build" ]
+
+    let summary =
+        buildSummary true
+            [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Success DateTime.UtcNow)
+              "node-c", buildNodeInfo "src/Lib" "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
+
+    let runResult = global.Program.buildRunResult graph summary
+
+    runResult.Status |> should equal "success"
+    runResult.Results[".build"] |> should equal "success"
+    runResult.Results["src/App.test"] |> should equal "ignored"
+    runResult.Results["src/Lib.build"] |> should equal "success"
+
+[<Test>]
+let ``buildRunResult uses failure then success then ignored precedence for duplicate keys`` () =
+    let graph =
+        buildGraph
+            [ buildGraphNode "node-a" "src/App" "build"
+              buildGraphNode "node-b" "src/App" "build"
+              buildGraphNode "node-c" "src/App" "build" ]
+
+    let summary =
+        buildSummary true
+            [ "node-b", buildNodeInfo "src/App" "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
+
+    let runResult = global.Program.buildRunResult graph summary
+
+    runResult.Results.Count |> should equal 1
+    runResult.Results["src/App.build"] |> should equal "success"
+
+[<Test>]
+let ``writeRunResultFile writes JSON for successful and ignored nodes`` () =
     withTempDir (fun root ->
         let path = Path.Combine(root, "nested", "run-result.json")
+        let graph =
+            buildGraph
+                [ buildGraphNode "node-a" "." "build"
+                  buildGraphNode "node-b" "src/App" "test" ]
         let summary =
             buildSummary true
                 [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-        global.Program.writeRunResultFile path summary
+        global.Program.writeRunResultFile path graph summary
 
         File.Exists(path) |> should equal true
 
@@ -88,19 +164,24 @@ let ``writeRunResultFile writes JSON for successful summary`` () =
         let json = doc.RootElement
         json.GetProperty("status").GetString() |> should equal "success"
         json.GetProperty("targets").EnumerateArray() |> Seq.map (fun item -> item.GetString()) |> Seq.toList |> should equal [ "build"; "test" ]
-        json.GetProperty("results").GetProperty(".build").GetString() |> should equal "success")
+        json.GetProperty("results").GetProperty(".build").GetString() |> should equal "success"
+        json.GetProperty("results").GetProperty("src/App.test").GetString() |> should equal "ignored")
 
 [<Test>]
 let ``writeRunResultFile writes JSON for failed summary and optional writer skips None`` () =
     withTempDir (fun root ->
         let path = Path.Combine(root, "run-result.json")
         let missingPath = Path.Combine(root, "missing.json")
+        let graph =
+            buildGraph
+                [ buildGraphNode "node-a" "." "build"
+                  buildGraphNode "node-b" "src/App" "test" ]
         let summary =
             buildSummary false
                 [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Failure (DateTime.UtcNow, "failed")) ]
 
-        global.Program.writeRunResultFile path summary
-        global.Program.tryWriteRunResultFile None summary
+        global.Program.writeRunResultFile path graph summary
+        global.Program.tryWriteRunResultFile None graph summary
 
         File.Exists(path) |> should equal true
         File.Exists(missingPath) |> should equal false
@@ -108,4 +189,5 @@ let ``writeRunResultFile writes JSON for failed summary and optional writer skip
         use doc = JsonDocument.Parse(File.ReadAllText(path))
         let json = doc.RootElement
         json.GetProperty("status").GetString() |> should equal "failure"
-        json.GetProperty("results").GetProperty(".build").GetString() |> should equal "failure")
+        json.GetProperty("results").GetProperty(".build").GetString() |> should equal "failure"
+        json.GetProperty("results").GetProperty("src/App.test").GetString() |> should equal "ignored")

--- a/src/Terrabuild.Tests/Core/Program.fs
+++ b/src/Terrabuild.Tests/Core/Program.fs
@@ -1,0 +1,111 @@
+module Terrabuild.Tests.Core.Program
+open System
+open System.IO
+open System.Text.Json
+open Argu
+open CLI
+open FsUnit
+open NUnit.Framework
+
+let private buildNodeInfo project target status =
+    { Runner.NodeInfo.Request = Runner.TaskRequest.Exec
+      Runner.NodeInfo.Status = status
+      Runner.NodeInfo.Project = project
+      Runner.NodeInfo.Target = target
+      Runner.NodeInfo.ProjectHash = $"project-{project}"
+      Runner.NodeInfo.TargetHash = $"target-{target}" }
+
+let private buildSummary isSuccess nodes =
+    { Runner.Summary.Commit = "commit"
+      Runner.Summary.BranchOrTag = "main"
+      Runner.Summary.StartedAt = DateTime.Parse("2026-04-11T16:42:46.595161Z").ToUniversalTime()
+      Runner.Summary.EndedAt = DateTime.Parse("2026-04-11T16:43:28.917020Z").ToUniversalTime()
+      Runner.Summary.IsSuccess = isSuccess
+      Runner.Summary.Targets = Set [ "build"; "test" ]
+      Runner.Summary.Nodes = nodes |> Map.ofList }
+
+let private withTempDir action =
+    let root = Path.Combine(Path.GetTempPath(), $"terrabuild-program-tests-{Guid.NewGuid():N}")
+    Directory.CreateDirectory(root) |> ignore
+    try
+        action root
+    finally
+        if Directory.Exists(root) then
+            Directory.Delete(root, true)
+
+[<Test>]
+let ``CLI parses run-result argument`` () =
+    let parser = ArgumentParser.Create<CLI.TerrabuildArgs>(programName = "terrabuild")
+    let result = parser.ParseCommandLine([| "run"; "build"; "--run-result"; "out.json" |], raiseOnUsage = true)
+    let runArgs = result.GetResult(TerrabuildArgs.Run)
+
+    runArgs.GetResult(RunArgs.Run_Result) |> should equal "out.json"
+
+[<Test>]
+let ``buildRunResult produces minimal jq friendly structure`` () =
+    let summary =
+        buildSummary true
+            [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Success DateTime.UtcNow)
+              "node-b", buildNodeInfo "src/Terrabuild.Common" "build" (Runner.TaskStatus.Success DateTime.UtcNow)
+              "node-c", buildNodeInfo "src/Terrabuild.Common.Tests" "test" (Runner.TaskStatus.Success DateTime.UtcNow) ]
+
+    let runResult = global.Program.buildRunResult summary
+
+    runResult.Status |> should equal "success"
+    runResult.Targets |> should equal [ "build"; "test" ]
+    runResult.Results[".build"] |> should equal "success"
+    runResult.Results["src/Terrabuild.Common.build"] |> should equal "success"
+    runResult.Results["src/Terrabuild.Common.Tests.test"] |> should equal "success"
+
+[<Test>]
+let ``buildRunResult collapses duplicate project target keys with failure dominance`` () =
+    let summary =
+        buildSummary false
+            [ "node-a", buildNodeInfo "src/App" "build" (Runner.TaskStatus.Success DateTime.UtcNow)
+              "node-b", buildNodeInfo "src/App" "build" (Runner.TaskStatus.Failure (DateTime.UtcNow, "boom"))
+              "node-c", buildNodeInfo "src/Lib" "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
+
+    let runResult = global.Program.buildRunResult summary
+
+    runResult.Status |> should equal "failure"
+    runResult.Results.Count |> should equal 2
+    runResult.Results["src/App.build"] |> should equal "failure"
+    runResult.Results["src/Lib.build"] |> should equal "success"
+
+[<Test>]
+let ``writeRunResultFile writes JSON for successful summary`` () =
+    withTempDir (fun root ->
+        let path = Path.Combine(root, "nested", "run-result.json")
+        let summary =
+            buildSummary true
+                [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
+
+        global.Program.writeRunResultFile path summary
+
+        File.Exists(path) |> should equal true
+
+        use doc = JsonDocument.Parse(File.ReadAllText(path))
+        let json = doc.RootElement
+        json.GetProperty("status").GetString() |> should equal "success"
+        json.GetProperty("targets").EnumerateArray() |> Seq.map (fun item -> item.GetString()) |> Seq.toList |> should equal [ "build"; "test" ]
+        json.GetProperty("results").GetProperty(".build").GetString() |> should equal "success")
+
+[<Test>]
+let ``writeRunResultFile writes JSON for failed summary and optional writer skips None`` () =
+    withTempDir (fun root ->
+        let path = Path.Combine(root, "run-result.json")
+        let missingPath = Path.Combine(root, "missing.json")
+        let summary =
+            buildSummary false
+                [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Failure (DateTime.UtcNow, "failed")) ]
+
+        global.Program.writeRunResultFile path summary
+        global.Program.tryWriteRunResultFile None summary
+
+        File.Exists(path) |> should equal true
+        File.Exists(missingPath) |> should equal false
+
+        use doc = JsonDocument.Parse(File.ReadAllText(path))
+        let json = doc.RootElement
+        json.GetProperty("status").GetString() |> should equal "failure"
+        json.GetProperty("results").GetProperty(".build").GetString() |> should equal "failure")

--- a/src/Terrabuild.Tests/Core/Program.fs
+++ b/src/Terrabuild.Tests/Core/Program.fs
@@ -29,11 +29,11 @@ let private buildGraph (nodes: GraphDef.Node list) =
       GraphDef.Graph.RootNodes = nodes |> List.map (fun node -> node.Id) |> Set.ofList
       GraphDef.Graph.Batches = Map.empty }
 
-let private buildGraphNode id project target =
+let private buildGraphNode id projectName projectDir target =
     { GraphDef.Node.Id = id
       GraphDef.Node.ProjectId = id
-      GraphDef.Node.ProjectName = None
-      GraphDef.Node.ProjectDir = project
+      GraphDef.Node.ProjectName = projectName
+      GraphDef.Node.ProjectDir = projectDir
       GraphDef.Node.Target = target
       GraphDef.Node.Dependencies = Set.empty
       GraphDef.Node.Outputs = Set.empty
@@ -47,6 +47,9 @@ let private buildGraphNode id project target =
       GraphDef.Node.Action = GraphDef.RunAction.Ignore
       GraphDef.Node.Required = true }
 
+let private withAction action node =
+    { node with GraphDef.Node.Action = action }
+
 let private withTempDir action =
     let root = Path.Combine(Path.GetTempPath(), $"terrabuild-program-tests-{Guid.NewGuid():N}")
     Directory.CreateDirectory(root) |> ignore
@@ -55,6 +58,9 @@ let private withTempDir action =
     finally
         if Directory.Exists(root) then
             Directory.Delete(root, true)
+
+let private hasJsonProperty (json: JsonElement) propertyName =
+    json.EnumerateObject() |> Seq.exists (fun property -> property.Name = propertyName)
 
 [<Test>]
 let ``CLI parses result argument`` () =
@@ -68,9 +74,9 @@ let ``CLI parses result argument`` () =
 let ``buildRunResult produces minimal jq friendly structure`` () =
     let graph =
         buildGraph
-            [ buildGraphNode "node-a" "." "build"
-              buildGraphNode "node-b" "src/Terrabuild.Common" "build"
-              buildGraphNode "node-c" "src/Terrabuild.Common.Tests" "test" ]
+            [ buildGraphNode "node-a" (Some "root") "." "build" |> withAction GraphDef.RunAction.Exec
+              buildGraphNode "node-b" (Some "Terrabuild.Common") "src/Terrabuild.Common" "build" |> withAction GraphDef.RunAction.Restore
+              buildGraphNode "node-c" (Some "Terrabuild.Common.Tests") "src/Terrabuild.Common.Tests" "test" |> withAction GraphDef.RunAction.Summary ]
 
     let summary =
         buildSummary true
@@ -78,21 +84,24 @@ let ``buildRunResult produces minimal jq friendly structure`` () =
               "node-b", buildNodeInfo "src/Terrabuild.Common" "build" (Runner.TaskStatus.Success DateTime.UtcNow)
               "node-c", buildNodeInfo "src/Terrabuild.Common.Tests" "test" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-    let runResult = global.Program.buildRunResult graph summary
+    let runResult = global.Program.buildRunResult graph (Some summary) summary.StartedAt summary.EndedAt
 
     runResult.Status |> should equal "success"
     runResult.Targets |> should equal [ "build"; "test" ]
-    runResult.Results[".:build"] |> should equal "success"
-    runResult.Results["src/Terrabuild.Common:build"] |> should equal "success"
-    runResult.Results["src/Terrabuild.Common.Tests:test"] |> should equal "success"
+    runResult.Impacts["root:build"] |> should equal "build"
+    runResult.Impacts["terrabuild.common:build"] |> should equal "restore"
+    runResult.Impacts["terrabuild.common.tests:test"] |> should equal "report"
+    runResult.Results.Value["root:build"] |> should equal "success"
+    runResult.Results.Value["terrabuild.common:build"] |> should equal "success"
+    runResult.Results.Value["terrabuild.common.tests:test"] |> should equal "success"
 
 [<Test>]
 let ``buildRunResult collapses duplicate project target keys with failure dominance`` () =
     let graph =
         buildGraph
-            [ buildGraphNode "node-a" "src/App" "build"
-              buildGraphNode "node-b" "src/App" "build"
-              buildGraphNode "node-c" "src/Lib" "build" ]
+            [ buildGraphNode "node-a" (Some "App") "src/App" "build" |> withAction GraphDef.RunAction.Exec
+              buildGraphNode "node-b" (Some "App") "src/App" "build" |> withAction GraphDef.RunAction.Exec
+              buildGraphNode "node-c" (Some "Lib") "src/Lib" "build" |> withAction GraphDef.RunAction.Restore ]
 
     let summary =
         buildSummary false
@@ -100,49 +109,75 @@ let ``buildRunResult collapses duplicate project target keys with failure domina
               "node-b", buildNodeInfo "src/App" "build" (Runner.TaskStatus.Failure (DateTime.UtcNow, "boom"))
               "node-c", buildNodeInfo "src/Lib" "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-    let runResult = global.Program.buildRunResult graph summary
+    let runResult = global.Program.buildRunResult graph (Some summary) summary.StartedAt summary.EndedAt
 
     runResult.Status |> should equal "failure"
-    runResult.Results.Count |> should equal 2
-    runResult.Results["src/App:build"] |> should equal "failure"
-    runResult.Results["src/Lib:build"] |> should equal "success"
+    runResult.Impacts["app:build"] |> should equal "build"
+    runResult.Impacts["lib:build"] |> should equal "restore"
+    runResult.Results.Value.Count |> should equal 2
+    runResult.Results.Value["app:build"] |> should equal "failure"
+    runResult.Results.Value["lib:build"] |> should equal "success"
 
 [<Test>]
-let ``buildRunResult marks graph nodes without runtime results as ignored`` () =
+let ``buildRunResult marks named graph nodes without runtime results as ignored and skips unnamed nodes`` () =
     let graph =
         buildGraph
-            [ buildGraphNode "node-a" "." "build"
-              buildGraphNode "node-b" "src/App" "test"
-              buildGraphNode "node-c" "src/Lib" "build" ]
+            [ buildGraphNode "node-a" (Some "Root") "." "build" |> withAction GraphDef.RunAction.Exec
+              buildGraphNode "node-b" (Some "App") "src/App" "test" |> withAction GraphDef.RunAction.Ignore
+              buildGraphNode "node-c" (Some "Lib") "src/Lib" "build" |> withAction GraphDef.RunAction.Restore
+              buildGraphNode "node-d" None "src/Unnamed" "build" |> withAction GraphDef.RunAction.Exec ]
 
     let summary =
         buildSummary true
             [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Success DateTime.UtcNow)
               "node-c", buildNodeInfo "src/Lib" "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-    let runResult = global.Program.buildRunResult graph summary
+    let runResult = global.Program.buildRunResult graph (Some summary) summary.StartedAt summary.EndedAt
 
     runResult.Status |> should equal "success"
-    runResult.Results[".:build"] |> should equal "success"
-    runResult.Results["src/App:test"] |> should equal "ignored"
-    runResult.Results["src/Lib:build"] |> should equal "success"
+    runResult.Impacts["root:build"] |> should equal "build"
+    runResult.Impacts["app:test"] |> should equal "ignore"
+    runResult.Impacts["lib:build"] |> should equal "restore"
+    runResult.Results.Value.Count |> should equal 3
+    runResult.Results.Value["root:build"] |> should equal "success"
+    runResult.Results.Value["app:test"] |> should equal "ignored"
+    runResult.Results.Value["lib:build"] |> should equal "success"
 
 [<Test>]
 let ``buildRunResult uses failure then success then ignored precedence for duplicate keys`` () =
     let graph =
         buildGraph
-            [ buildGraphNode "node-a" "src/App" "build"
-              buildGraphNode "node-b" "src/App" "build"
-              buildGraphNode "node-c" "src/App" "build" ]
+            [ buildGraphNode "node-a" (Some "App") "src/App" "build" |> withAction GraphDef.RunAction.Ignore
+              buildGraphNode "node-b" (Some "App") "src/App" "build" |> withAction GraphDef.RunAction.Restore
+              buildGraphNode "node-c" (Some "App") "src/App" "build" |> withAction GraphDef.RunAction.Exec ]
 
     let summary =
         buildSummary true
             [ "node-b", buildNodeInfo "src/App" "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-    let runResult = global.Program.buildRunResult graph summary
+    let runResult = global.Program.buildRunResult graph (Some summary) summary.StartedAt summary.EndedAt
 
-    runResult.Results.Count |> should equal 1
-    runResult.Results["src/App:build"] |> should equal "success"
+    runResult.Impacts["app:build"] |> should equal "build"
+    runResult.Results.Value.Count |> should equal 1
+    runResult.Results.Value["app:build"] |> should equal "success"
+
+[<Test>]
+let ``buildRunResult omits results for what-if and still reports impacts`` () =
+    let startedAt = DateTime.Parse("2026-04-11T16:42:46.595161Z").ToUniversalTime()
+    let endedAt = DateTime.Parse("2026-04-11T16:42:50.000000Z").ToUniversalTime()
+    let graph =
+        buildGraph
+            [ buildGraphNode "node-a" (Some "App") "src/App" "build" |> withAction GraphDef.RunAction.Exec
+              buildGraphNode "node-b" (Some "Lib") "src/Lib" "test" |> withAction GraphDef.RunAction.Restore
+              buildGraphNode "node-c" None "src/Unnamed" "build" |> withAction GraphDef.RunAction.Exec ]
+
+    let runResult = global.Program.buildRunResult graph None startedAt endedAt
+
+    runResult.Status |> should equal "what-if"
+    runResult.Impacts.Count |> should equal 2
+    runResult.Impacts["app:build"] |> should equal "build"
+    runResult.Impacts["lib:test"] |> should equal "restore"
+    runResult.Results |> should equal None
 
 [<Test>]
 let ``writeRunResultFile writes JSON for successful and ignored nodes`` () =
@@ -150,13 +185,14 @@ let ``writeRunResultFile writes JSON for successful and ignored nodes`` () =
         let path = Path.Combine(root, "nested", "run-result.json")
         let graph =
             buildGraph
-                [ buildGraphNode "node-a" "." "build"
-                  buildGraphNode "node-b" "src/App" "test" ]
+                [ buildGraphNode "node-a" (Some "Root") "." "build"
+                  buildGraphNode "node-b" (Some "App") "src/App" "test"
+                  buildGraphNode "node-c" None "src/Unnamed" "build" ]
         let summary =
             buildSummary true
                 [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-        global.Program.writeRunResultFile path graph summary
+        global.Program.writeRunResultFile path graph (Some summary) summary.StartedAt summary.EndedAt
 
         File.Exists(path) |> should equal true
 
@@ -164,8 +200,13 @@ let ``writeRunResultFile writes JSON for successful and ignored nodes`` () =
         let json = doc.RootElement
         json.GetProperty("status").GetString() |> should equal "success"
         json.GetProperty("targets").EnumerateArray() |> Seq.map (fun item -> item.GetString()) |> Seq.toList |> should equal [ "build"; "test" ]
-        json.GetProperty("results").GetProperty(".:build").GetString() |> should equal "success"
-        json.GetProperty("results").GetProperty("src/App:test").GetString() |> should equal "ignored")
+        let impacts = json.GetProperty("impacts")
+        let results = json.GetProperty("results")
+        impacts.GetProperty("root:build").GetString() |> should equal "ignore"
+        impacts.GetProperty("app:test").GetString() |> should equal "ignore"
+        results.GetProperty("root:build").GetString() |> should equal "success"
+        results.GetProperty("app:test").GetString() |> should equal "ignored"
+        hasJsonProperty results "unnamed:build" |> should equal false)
 
 [<Test>]
 let ``writeRunResultFile writes JSON for failed summary and optional writer skips None`` () =
@@ -174,14 +215,15 @@ let ``writeRunResultFile writes JSON for failed summary and optional writer skip
         let missingPath = Path.Combine(root, "missing.json")
         let graph =
             buildGraph
-                [ buildGraphNode "node-a" "." "build"
-                  buildGraphNode "node-b" "src/App" "test" ]
+                [ buildGraphNode "node-a" (Some "Root") "." "build"
+                  buildGraphNode "node-b" (Some "App") "src/App" "test"
+                  buildGraphNode "node-c" None "src/Unnamed" "build" ]
         let summary =
             buildSummary false
                 [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Failure (DateTime.UtcNow, "failed")) ]
 
-        global.Program.writeRunResultFile path graph summary
-        global.Program.tryWriteRunResultFile None graph summary
+        global.Program.writeRunResultFile path graph (Some summary) summary.StartedAt summary.EndedAt
+        global.Program.tryWriteRunResultFile None graph (Some summary) summary.StartedAt summary.EndedAt
 
         File.Exists(path) |> should equal true
         File.Exists(missingPath) |> should equal false
@@ -189,5 +231,31 @@ let ``writeRunResultFile writes JSON for failed summary and optional writer skip
         use doc = JsonDocument.Parse(File.ReadAllText(path))
         let json = doc.RootElement
         json.GetProperty("status").GetString() |> should equal "failure"
-        json.GetProperty("results").GetProperty(".:build").GetString() |> should equal "failure"
-        json.GetProperty("results").GetProperty("src/App:test").GetString() |> should equal "ignored")
+        let impacts = json.GetProperty("impacts")
+        let results = json.GetProperty("results")
+        impacts.GetProperty("root:build").GetString() |> should equal "ignore"
+        impacts.GetProperty("app:test").GetString() |> should equal "ignore"
+        results.GetProperty("root:build").GetString() |> should equal "failure"
+        results.GetProperty("app:test").GetString() |> should equal "ignored"
+        hasJsonProperty results "unnamed:build" |> should equal false)
+
+[<Test>]
+let ``writeRunResultFile omits results node for what-if`` () =
+    withTempDir (fun root ->
+        let path = Path.Combine(root, "what-if.json")
+        let startedAt = DateTime.Parse("2026-04-11T16:42:46.595161Z").ToUniversalTime()
+        let endedAt = DateTime.Parse("2026-04-11T16:42:50.000000Z").ToUniversalTime()
+        let graph =
+            buildGraph
+                [ buildGraphNode "node-a" (Some "App") "src/App" "build" |> withAction GraphDef.RunAction.Exec
+                  buildGraphNode "node-b" (Some "Lib") "src/Lib" "test" |> withAction GraphDef.RunAction.Restore ]
+
+        global.Program.writeRunResultFile path graph None startedAt endedAt
+
+        use doc = JsonDocument.Parse(File.ReadAllText(path))
+        let json = doc.RootElement
+        json.GetProperty("status").GetString() |> should equal "what-if"
+        let impacts = json.GetProperty("impacts")
+        impacts.GetProperty("app:build").GetString() |> should equal "build"
+        impacts.GetProperty("lib:test").GetString() |> should equal "restore"
+        hasJsonProperty json "results" |> should equal false)

--- a/src/Terrabuild.Tests/Terrabuild.Tests.fsproj
+++ b/src/Terrabuild.Tests/Terrabuild.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Core/Cache.fs" />
     <Compile Include="Core/DotnetRemoteCache.fs" />
     <Compile Include="Core/Logs.fs" />
+    <Compile Include="Core/Program.fs" />
     <Compile Include="Core/Runner.fs" />
     <Compile Include="Core/GraphPipeline/Batch.fs" />
   </ItemGroup>

--- a/src/Terrabuild/CLI.fs
+++ b/src/Terrabuild/CLI.fs
@@ -47,6 +47,7 @@ with
 type RunArgs =
     | [<ExactlyOnce; MainCommand; First>] Target of target:string list
     | [<Unique; AltCommandLine("-w")>] Workspace of path:string
+    | [<Unique>] Run_Result of path:string
     | [<Unique; AltCommandLine("-c")>] Configuration of name:string
     | [<Unique; AltCommandLine("-e")>] Environment of name:string
     | [<EqualsAssignment; AltCommandLine("-v")>] Variable of variable:string * value:string
@@ -67,6 +68,7 @@ with
             match this with
             | Target _ -> "Specify build target."
             | Workspace _ -> "Root of workspace. If not specified, current directory is used."
+            | Run_Result _ -> "Write machine-readable run result JSON to file."
             | Configuration _ -> "Configuration to use."
             | Environment _ -> "Environment to use."
             | Variable _ -> "Set variable."

--- a/src/Terrabuild/CLI.fs
+++ b/src/Terrabuild/CLI.fs
@@ -47,7 +47,7 @@ with
 type RunArgs =
     | [<ExactlyOnce; MainCommand; First>] Target of target:string list
     | [<Unique; AltCommandLine("-w")>] Workspace of path:string
-    | [<Unique>] Run_Result of path:string
+    | [<Unique>] Result of path:string
     | [<Unique; AltCommandLine("-c")>] Configuration of name:string
     | [<Unique; AltCommandLine("-e")>] Environment of name:string
     | [<EqualsAssignment; AltCommandLine("-v")>] Variable of variable:string * value:string
@@ -68,7 +68,7 @@ with
             match this with
             | Target _ -> "Specify build target."
             | Workspace _ -> "Root of workspace. If not specified, current directory is used."
-            | Run_Result _ -> "Write machine-readable run result JSON to file."
+            | Result _ -> "Write machine-readable result JSON to file."
             | Configuration _ -> "Configuration to use."
             | Environment _ -> "Environment to use."
             | Variable _ -> "Set variable."

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -47,8 +47,7 @@ type RunResult = {
 }
 
 let private buildResultKey (project: string) (target: string) =
-    if project.EndsWith(".") then $"{project}{target}"
-    else $"{project}.{target}"
+    $"{project}:{target}"
 
 let private mergeRunResultStatus currentStatus nextStatus =
     let priority status =
@@ -339,7 +338,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let configuration = runArgs.TryGetResult(RunArgs.Configuration)
         let environment = runArgs.TryGetResult(RunArgs.Environment)
         let note = runArgs.TryGetResult(RunArgs.Note)
-        let runResultFile = runArgs.TryGetResult(RunArgs.Run_Result)
+        let runResultFile = runArgs.TryGetResult(RunArgs.Result)
         let types = runArgs.TryGetResult(RunArgs.Type) |> Option.map (fun types -> types |> Seq.map String.toLower |> Set)
         let labels = runArgs.TryGetResult(RunArgs.Label) |> Option.map (fun labels -> labels |> Seq.map String.toLower |> Set)
         let projects = runArgs.TryGetResult(RunArgs.Project) |> Option.map (fun projects -> projects |> Seq.map String.toLower |> Set)

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -43,11 +43,12 @@ type RunResult = {
     Targets: string list
     StartedAt: DateTime
     EndedAt: DateTime
-    Results: Map<string, string>
+    Impacts: Map<string, string>
+    Results: Map<string, string> option
 }
 
-let private buildResultKey (project: string) (target: string) =
-    $"{project}:{target}"
+let private buildResultKey (projectName: string) (target: string) =
+    $"{projectName |> String.toLower}:{target}"
 
 let private mergeRunResultStatus currentStatus nextStatus =
     let priority status =
@@ -59,45 +60,92 @@ let private mergeRunResultStatus currentStatus nextStatus =
     if priority nextStatus > priority currentStatus then nextStatus
     else currentStatus
 
-let buildRunResult (graph: GraphDef.Graph) (summary: Runner.Summary) =
-    let results =
+let private buildImpactAction action =
+    match action with
+    | GraphDef.RunAction.Exec -> "build"
+    | GraphDef.RunAction.Restore -> "restore"
+    | GraphDef.RunAction.Summary -> "report"
+    | GraphDef.RunAction.Ignore -> "ignore"
+
+let private mergeImpactAction currentAction nextAction =
+    let priority action =
+        match action with
+        | "build" -> 3
+        | "restore" -> 2
+        | "report" -> 1
+        | _ -> 0
+
+    if priority nextAction > priority currentAction then nextAction
+    else currentAction
+
+let buildRunResult (graph: GraphDef.Graph) (summary: Runner.Summary option) startedAt endedAt =
+    let impacts =
         graph.Nodes
         |> Map.values
         |> Seq.fold (fun state node ->
-            let key = buildResultKey node.ProjectDir node.Target
-            let status =
-                match summary.Nodes |> Map.tryFind node.Id with
-                | Some nodeSummary when nodeSummary.Status.IsSuccess -> "success"
-                | Some _ -> "failure"
-                | None -> "ignored"
-
-            let aggregated =
-                match state |> Map.tryFind key with
-                | Some existing -> mergeRunResultStatus existing status
-                | None -> status
-
-            state |> Map.add key aggregated
+            match node.ProjectName with
+            | Some projectName ->
+                let key = buildResultKey projectName node.Target
+                let impact = buildImpactAction node.Action
+                let aggregated =
+                    match state |> Map.tryFind key with
+                    | Some existing -> mergeImpactAction existing impact
+                    | None -> impact
+                state |> Map.add key aggregated
+            | None -> state
         ) Map.empty
 
-    { RunResult.Status = if summary.IsSuccess then "success" else "failure"
-      RunResult.Targets = summary.Targets |> Set.toList
-      RunResult.StartedAt = summary.StartedAt
-      RunResult.EndedAt = summary.EndedAt
+    let results =
+        summary
+        |> Option.map (fun summary ->
+            graph.Nodes
+            |> Map.values
+            |> Seq.fold (fun state node ->
+                match node.ProjectName with
+                | Some projectName ->
+                    let key = buildResultKey projectName node.Target
+                    let status =
+                        match summary.Nodes |> Map.tryFind node.Id with
+                        | Some nodeSummary when nodeSummary.Status.IsSuccess -> "success"
+                        | Some _ -> "failure"
+                        | None -> "ignored"
+
+                    let aggregated =
+                        match state |> Map.tryFind key with
+                        | Some existing -> mergeRunResultStatus existing status
+                        | None -> status
+
+                    state |> Map.add key aggregated
+                | None -> state
+            ) Map.empty
+        )
+
+    { RunResult.Status =
+        match summary with
+        | Some summary when summary.IsSuccess -> "success"
+        | Some _ -> "failure"
+        | None -> "what-if"
+      RunResult.Targets =
+        match summary with
+        | Some summary -> summary.Targets |> Set.toList
+        | None -> graph.RootNodes |> Seq.map (fun nodeId -> graph.Nodes[nodeId].Target) |> Set.ofSeq |> Set.toList
+      RunResult.StartedAt = startedAt
+      RunResult.EndedAt = endedAt
+      RunResult.Impacts = impacts
       RunResult.Results = results }
 
-let writeRunResultFile (filePath: string) (graph: GraphDef.Graph) (summary: Runner.Summary) =
+let writeRunResultFile (filePath: string) (graph: GraphDef.Graph) (summary: Runner.Summary option) startedAt endedAt =
     match Path.GetDirectoryName(filePath) with
     | null -> ()
     | outputDir when String.IsNullOrWhiteSpace(outputDir) -> ()
     | outputDir -> IO.createDirectory outputDir
 
-    summary
-    |> buildRunResult graph
+    buildRunResult graph summary startedAt endedAt
     |> Json.Serialize
     |> IO.writeTextFile filePath
 
-let tryWriteRunResultFile (filePath: string option) (graph: GraphDef.Graph) (summary: Runner.Summary) =
-    filePath |> Option.iter (fun path -> writeRunResultFile path graph summary)
+let tryWriteRunResultFile (filePath: string option) (graph: GraphDef.Graph) (summary: Runner.Summary option) startedAt endedAt =
+    filePath |> Option.iter (fun path -> writeRunResultFile path graph summary startedAt endedAt)
 
 
 let launchDir = currentDir()
@@ -266,7 +314,9 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
             markdown |> IO.writeLines (logFile "info.md")
 
         let errCode =
-            if options.WhatIf then 0
+            if options.WhatIf then
+                tryWriteRunResultFile runResultFile graph None options.StartedAt DateTime.UtcNow
+                0
             else
                 Log.Debug("====[ Runner ]========================================================")
                 let summary = runPhase "runner" (fun () -> Runner.run options cache api graph)
@@ -275,7 +325,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
                 if options.Debug then
                     let jsonBuild = Json.Serialize summary
                     jsonBuild |> IO.writeTextFile (logFile "build-result.json")
-                tryWriteRunResultFile runResultFile graph summary
+                tryWriteRunResultFile runResultFile graph (Some summary) summary.StartedAt summary.EndedAt
 
                 if log || not summary.IsSuccess then
                     Logs.dumpLogs runId options cache graph summary

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -46,23 +46,35 @@ type RunResult = {
     Results: Map<string, string>
 }
 
-let buildRunResult (summary: Runner.Summary) =
-    let buildResultKey (project: string) (target: string) =
-        if project.EndsWith(".") then $"{project}{target}"
-        else $"{project}.{target}"
+let private buildResultKey (project: string) (target: string) =
+    if project.EndsWith(".") then $"{project}{target}"
+    else $"{project}.{target}"
 
+let private mergeRunResultStatus currentStatus nextStatus =
+    let priority status =
+        match status with
+        | "failure" -> 2
+        | "success" -> 1
+        | _ -> 0
+
+    if priority nextStatus > priority currentStatus then nextStatus
+    else currentStatus
+
+let buildRunResult (graph: GraphDef.Graph) (summary: Runner.Summary) =
     let results =
-        summary.Nodes
+        graph.Nodes
         |> Map.values
         |> Seq.fold (fun state node ->
-            let key = buildResultKey node.Project node.Target
-            let status = if node.Status.IsSuccess then "success" else "failure"
+            let key = buildResultKey node.ProjectDir node.Target
+            let status =
+                match summary.Nodes |> Map.tryFind node.Id with
+                | Some nodeSummary when nodeSummary.Status.IsSuccess -> "success"
+                | Some _ -> "failure"
+                | None -> "ignored"
 
             let aggregated =
                 match state |> Map.tryFind key with
-                | Some "failure" -> "failure"
-                | Some _ when status = "failure" -> "failure"
-                | Some existing -> existing
+                | Some existing -> mergeRunResultStatus existing status
                 | None -> status
 
             state |> Map.add key aggregated
@@ -74,19 +86,19 @@ let buildRunResult (summary: Runner.Summary) =
       RunResult.EndedAt = summary.EndedAt
       RunResult.Results = results }
 
-let writeRunResultFile (filePath: string) (summary: Runner.Summary) =
+let writeRunResultFile (filePath: string) (graph: GraphDef.Graph) (summary: Runner.Summary) =
     match Path.GetDirectoryName(filePath) with
     | null -> ()
     | outputDir when String.IsNullOrWhiteSpace(outputDir) -> ()
     | outputDir -> IO.createDirectory outputDir
 
     summary
-    |> buildRunResult
+    |> buildRunResult graph
     |> Json.Serialize
     |> IO.writeTextFile filePath
 
-let tryWriteRunResultFile (filePath: string option) (summary: Runner.Summary) =
-    filePath |> Option.iter (fun path -> writeRunResultFile path summary)
+let tryWriteRunResultFile (filePath: string option) (graph: GraphDef.Graph) (summary: Runner.Summary) =
+    filePath |> Option.iter (fun path -> writeRunResultFile path graph summary)
 
 
 let launchDir = currentDir()
@@ -264,7 +276,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
                 if options.Debug then
                     let jsonBuild = Json.Serialize summary
                     jsonBuild |> IO.writeTextFile (logFile "build-result.json")
-                tryWriteRunResultFile runResultFile summary
+                tryWriteRunResultFile runResultFile graph summary
 
                 if log || not summary.IsSuccess then
                     Logs.dumpLogs runId options cache graph summary

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -5,6 +5,7 @@ open Serilog
 open Errors
 open Collections
 open Environment
+open System.IO
 open System.Runtime.InteropServices
 open Humanizer
 
@@ -15,6 +16,7 @@ open Humanizer
 [<RequireQualifiedAccess>]
 type RunTargetOptions = {
     Workspace: string
+    RunResultFile: string option
     WhatIf: bool
     Debug: bool
     MaxConcurrency: int
@@ -34,6 +36,57 @@ type RunTargetOptions = {
     Variables: Map<string, string>
     Engine: Engine option
 }
+
+[<RequireQualifiedAccess>]
+type RunResult = {
+    Status: string
+    Targets: string list
+    StartedAt: DateTime
+    EndedAt: DateTime
+    Results: Map<string, string>
+}
+
+let buildRunResult (summary: Runner.Summary) =
+    let buildResultKey (project: string) (target: string) =
+        if project.EndsWith(".") then $"{project}{target}"
+        else $"{project}.{target}"
+
+    let results =
+        summary.Nodes
+        |> Map.values
+        |> Seq.fold (fun state node ->
+            let key = buildResultKey node.Project node.Target
+            let status = if node.Status.IsSuccess then "success" else "failure"
+
+            let aggregated =
+                match state |> Map.tryFind key with
+                | Some "failure" -> "failure"
+                | Some _ when status = "failure" -> "failure"
+                | Some existing -> existing
+                | None -> status
+
+            state |> Map.add key aggregated
+        ) Map.empty
+
+    { RunResult.Status = if summary.IsSuccess then "success" else "failure"
+      RunResult.Targets = summary.Targets |> Set.toList
+      RunResult.StartedAt = summary.StartedAt
+      RunResult.EndedAt = summary.EndedAt
+      RunResult.Results = results }
+
+let writeRunResultFile (filePath: string) (summary: Runner.Summary) =
+    match Path.GetDirectoryName(filePath) with
+    | null -> ()
+    | outputDir when String.IsNullOrWhiteSpace(outputDir) -> ()
+    | outputDir -> IO.createDirectory outputDir
+
+    summary
+    |> buildRunResult
+    |> Json.Serialize
+    |> IO.writeTextFile filePath
+
+let tryWriteRunResultFile (filePath: string option) (summary: Runner.Summary) =
+    filePath |> Option.iter (fun path -> writeRunResultFile path summary)
 
 
 let launchDir = currentDir()
@@ -77,6 +130,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         Log.Debug("Changing current directory to {directory}", options.Workspace)
         Log.Debug("ProcessorCount = {procCount}", Environment.ProcessorCount)
         Terrabuild.Scripting.resetPerformanceMetrics()
+        let runResultFile = options.RunResultFile
 
         let homeDir = Cache.createHome()
         let tmpDir = Cache.createTmp()
@@ -210,6 +264,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
                 if options.Debug then
                     let jsonBuild = Json.Serialize summary
                     jsonBuild |> IO.writeTextFile (logFile "build-result.json")
+                tryWriteRunResultFile runResultFile summary
 
                 if log || not summary.IsSuccess then
                     Logs.dumpLogs runId options cache graph summary
@@ -272,6 +327,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let configuration = runArgs.TryGetResult(RunArgs.Configuration)
         let environment = runArgs.TryGetResult(RunArgs.Environment)
         let note = runArgs.TryGetResult(RunArgs.Note)
+        let runResultFile = runArgs.TryGetResult(RunArgs.Run_Result)
         let types = runArgs.TryGetResult(RunArgs.Type) |> Option.map (fun types -> types |> Seq.map String.toLower |> Set)
         let labels = runArgs.TryGetResult(RunArgs.Label) |> Option.map (fun labels -> labels |> Seq.map String.toLower |> Set)
         let projects = runArgs.TryGetResult(RunArgs.Project) |> Option.map (fun projects -> projects |> Seq.map String.toLower |> Set)
@@ -283,6 +339,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let engine = runArgs.TryGetResult(RunArgs.Engine)
 
         let options = { RunTargetOptions.Workspace = wsDir |> FS.fullPath
+                        RunTargetOptions.RunResultFile = runResultFile |> Option.map FS.fullPath
                         RunTargetOptions.WhatIf = whatIf
                         RunTargetOptions.Debug = debug
                         RunTargetOptions.Force = runArgs.Contains(RunArgs.Force)
@@ -318,6 +375,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let projects = serveArgs.TryGetResult(ServeArgs.Project) |> Option.map (fun projects -> projects |> Seq.map String.toLower |> Set)
         let variables = serveArgs.GetResults(ServeArgs.Variable) |> Seq.map (fun (k, v) -> (k |> String.toLower, v)) |> Map
         let options = { RunTargetOptions.Workspace = wsDir |> FS.fullPath
+                        RunTargetOptions.RunResultFile = None
                         RunTargetOptions.WhatIf = false
                         RunTargetOptions.Debug = debug
                         RunTargetOptions.Force = false
@@ -373,6 +431,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let variables = logsArgs.GetResults(LogsArgs.Variable) |> Seq.map (fun (k, v) -> (k |> String.toLower, v)) |> Map
 
         let options = { RunTargetOptions.Workspace = wsDir |> FS.fullPath
+                        RunTargetOptions.RunResultFile = None
                         RunTargetOptions.WhatIf = true
                         RunTargetOptions.Debug = debug
                         RunTargetOptions.Force = false

--- a/website/site-docs/usage.md
+++ b/website/site-docs/usage.md
@@ -32,7 +32,7 @@ Command to run one or more targets. This is the primary command for building you
 ```
 > terrabuild run --help
 USAGE: terrabuild run [--help] [--workspace <path>] [--configuration <name>] [--environment <name>] [--variable <variable>=<value>] [--label [<labels>...]] [--type [<types>...]]
-                      [--project [<projects>...]] [--force] [--retry] [--parallel <max>] [--local-only] [--note <note>] [--tag <tag>] [--engine <engine>] [--what-if] <target>...
+                      [--project [<projects>...]] [--force] [--retry] [--parallel <max>] [--local-only] [--note <note>] [--tag <tag>] [--engine <engine>] [--what-if] [--result <path>] <target>...
 
 TARGET:
 
@@ -62,7 +62,76 @@ OPTIONS:
     --tag <tag>           Tag for build.
     --engine <engine>     Container engine to use (docker, podman or none).
     --what-if             Prepare the action but do not apply.
+    --result <path>       Write machine-readable result JSON to file.
     --help                display this list of options.
+```
+
+### Machine-readable Result Report
+
+Use `--result <path>` to write a JSON report describing the planned impacts of the run and, for normal executions, the final outcomes.
+
+Example:
+
+```bash
+terrabuild run build --result artifacts/run-result.json
+```
+
+Example with `--what-if`:
+
+```bash
+terrabuild run build --what-if --result artifacts/run-result.json
+```
+
+The report uses `lowercase(ProjectName):target` as the public identifier.
+Projects without an assigned `name` are intentionally omitted from the report.
+
+Normal runs produce both `impacts` and `results`:
+
+```json
+{
+  "status": "success",
+  "targets": ["build"],
+  "startedAt": "2026-04-11T16:42:46.595161Z",
+  "endedAt": "2026-04-11T16:43:28.917020Z",
+  "impacts": {
+    "app:build": "build",
+    "lib:test": "restore"
+  },
+  "results": {
+    "app:build": "success",
+    "lib:test": "ignored"
+  }
+}
+```
+
+`impacts` is computed before the runner executes and is always present when `--result` is used.
+Possible impact values are:
+
+- `build`: Terrabuild will execute the target.
+- `restore`: Terrabuild will restore artifacts from cache.
+- `report`: Terrabuild will surface an existing failed state without rebuilding.
+- `ignore`: The node exists in the computed graph but no action is planned.
+
+`results` is written only for non-`--what-if` runs.
+Possible result values are:
+
+- `success`: At least one matching node completed successfully and none failed.
+- `failure`: At least one matching node failed.
+- `ignored`: The named node existed in the graph but produced no runner result.
+
+When `--what-if` is used, the report still includes `impacts` but omits `results`:
+
+```json
+{
+  "status": "what-if",
+  "targets": ["build"],
+  "startedAt": "2026-04-11T16:42:46.595161Z",
+  "endedAt": "2026-04-11T16:42:50.000000Z",
+  "impacts": {
+    "app:build": "build",
+    "lib:test": "restore"
+  }
+}
 ```
 
 ## Clear Local Cache


### PR DESCRIPTION
## Summary
- add `--result <file>` to write a machine-readable run report JSON file
- add `impacts` so callers can inspect planned actions before the runner executes
- include `results` for normal runs, omit `results` for `--what-if`, and keep named projects only in the public identifier surface
- use `lowercase(ProjectName):target` keys and report `ignored` for named projects with no runner result

## Testing
- dotnet test src/Terrabuild.Tests/Terrabuild.Tests.fsproj --filter "FullyQualifiedName~Terrabuild.Tests.Core.Program"
- make test