### PR TITLE
feat: add impact command and JSON output files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to Terrabuild are documented in this file.
 
 ## [Unreleased]
 
+- Add `terrabuild run --out <path>` and `terrabuild impact --base <sha> --out <path>` for machine-readable JSON reports.
+
 ## [0.195.0-next]
 
 
-- Add `terrabuild run --result <path>` to export a machine-readable run report.
+- Add `terrabuild run --out <path>` to export a machine-readable run report.
 - Upgrade embedded FScript runtime/language packages to `0.72.0`.
 - Remove macOS Intel (`darwin-x64` / `osx-x64`) build and release artifacts from the Make publish flow, release automation, Homebrew tap metadata, scaffold lockfiles, and install documentation so Terrabuild ships only the supported macOS arm64 binary.
 - Add `terrabuild prune <days>` to remove stale local cache entries from `~/.terrabuild/cache`, refresh cache-entry access timestamps on local reads, and document the new cache-retention workflow.

--- a/src/Terrabuild.Tests/Core/ConfigurationGraph.fs
+++ b/src/Terrabuild.Tests/Core/ConfigurationGraph.fs
@@ -35,11 +35,11 @@ let private baseOptions workspace targets =
       ConfigOptions.Options.BranchOrTag = "main"
       ConfigOptions.Options.Repository = "acme/repo"
       ConfigOptions.Options.HeadCommit =
-        { Contracts.Commit.Sha = "deadbeef"
-          Contracts.Commit.Author = "test"
-          Contracts.Commit.Email = "test@example.com"
-          Contracts.Commit.Message = "test"
-          Contracts.Commit.Timestamp = DateTime.UtcNow }
+        { Sha = "deadbeef"
+          Author = "test"
+          Email = "test@example.com"
+          Message = "test"
+          Timestamp = DateTime.UtcNow }
       ConfigOptions.Options.CommitLog = []
       ConfigOptions.Options.Run = None }
 

--- a/src/Terrabuild.Tests/Core/DotnetRemoteCache.fs
+++ b/src/Terrabuild.Tests/Core/DotnetRemoteCache.fs
@@ -41,6 +41,7 @@ type private RecordingCache(inner: Cache.ICache) =
 
 type private PhaseResult =
     { GraphNode: Graph
+      GraphSelection: Graph
       GraphAction: Graph
       GraphCascade: Graph
       GraphBatch: Graph
@@ -72,6 +73,12 @@ and private RecordingApiClient() =
 
         member _.GetArtifact _path =
             Uri("https://example.invalid/artifact")
+
+        member _.GetCommitGraph _repository _commit =
+            { Contracts.CommitGraph.Repository = "acme/repo"
+              Contracts.CommitGraph.Commit = "base"
+              Contracts.CommitGraph.GraphHash = "graph"
+              Contracts.CommitGraph.Nodes = [] }
 
         member _.AddArtifact project projectName target projectHash targetHash files success _startedAt _endedAt =
             addCalls.Enqueue(
@@ -391,12 +398,14 @@ let private runPhase (storage: FolderStorage) workspace homeRoot variables =
             let options = createOptions workspace variables
             let options, config = Configuration.read options
             let graphNode = GraphPipeline.Node.build options config
-            let graphAction = GraphPipeline.Action.build options (cache :> Cache.ICache) graphNode
+            let graphSelection = GraphPipeline.Selection.build options config graphNode
+            let graphAction = GraphPipeline.Action.build options (cache :> Cache.ICache) graphSelection
             let graphCascade = GraphPipeline.Cascade.build graphAction
             let graphBatch = GraphPipeline.Batch.build options config graphCascade
-            let summary = Runner.run options (cache :> Cache.ICache) (Some (api :> IApiClient)) graphBatch
+            let summary = Runner.run options (cache :> Cache.ICache) (Some (api :> IApiClient)) graphNode graphBatch
 
             { GraphNode = graphNode
+              GraphSelection = graphSelection
               GraphAction = graphAction
               GraphCascade = graphCascade
               GraphBatch = graphBatch

--- a/src/Terrabuild.Tests/Core/Logs.fs
+++ b/src/Terrabuild.Tests/Core/Logs.fs
@@ -33,11 +33,11 @@ let private buildOptions (markdownFile: string) =
       ConfigOptions.Options.BranchOrTag = "main"
       ConfigOptions.Options.Repository = "acme/repo"
       ConfigOptions.Options.HeadCommit =
-        { Contracts.Commit.Sha = "sha"
-          Contracts.Commit.Message = "msg"
-          Contracts.Commit.Author = "author"
-          Contracts.Commit.Email = "mail"
-          Contracts.Commit.Timestamp = DateTime.UtcNow }
+        { Sha = "sha"
+          Message = "msg"
+          Author = "author"
+          Email = "mail"
+          Timestamp = DateTime.UtcNow }
       ConfigOptions.Options.CommitLog = []
       ConfigOptions.Options.Run = None }
 

--- a/src/Terrabuild.Tests/Core/Program.fs
+++ b/src/Terrabuild.Tests/Core/Program.fs
@@ -84,16 +84,13 @@ let ``buildRunResult produces minimal jq friendly structure`` () =
               "node-b", buildNodeInfo "src/Terrabuild.Common" "build" (Runner.TaskStatus.Success DateTime.UtcNow)
               "node-c", buildNodeInfo "src/Terrabuild.Common.Tests" "test" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-    let runResult = global.Program.buildRunResult graph (Some summary) summary.StartedAt summary.EndedAt
+    let runResult = global.Program.buildRunResult graph summary
 
     runResult.Status |> should equal "success"
     runResult.Targets |> should equal [ "build"; "test" ]
-    runResult.Impacts["root:build"] |> should equal "build"
-    runResult.Impacts["terrabuild.common:build"] |> should equal "restore"
-    runResult.Impacts["terrabuild.common.tests:test"] |> should equal "report"
-    runResult.Results.Value["root:build"] |> should equal "success"
-    runResult.Results.Value["terrabuild.common:build"] |> should equal "success"
-    runResult.Results.Value["terrabuild.common.tests:test"] |> should equal "success"
+    runResult.Results["root:build"] |> should equal "success"
+    runResult.Results["terrabuild.common:build"] |> should equal "success"
+    runResult.Results["terrabuild.common.tests:test"] |> should equal "success"
 
 [<Test>]
 let ``buildRunResult collapses duplicate project target keys with failure dominance`` () =
@@ -109,14 +106,12 @@ let ``buildRunResult collapses duplicate project target keys with failure domina
               "node-b", buildNodeInfo "src/App" "build" (Runner.TaskStatus.Failure (DateTime.UtcNow, "boom"))
               "node-c", buildNodeInfo "src/Lib" "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-    let runResult = global.Program.buildRunResult graph (Some summary) summary.StartedAt summary.EndedAt
+    let runResult = global.Program.buildRunResult graph summary
 
     runResult.Status |> should equal "failure"
-    runResult.Impacts["app:build"] |> should equal "build"
-    runResult.Impacts["lib:build"] |> should equal "restore"
-    runResult.Results.Value.Count |> should equal 2
-    runResult.Results.Value["app:build"] |> should equal "failure"
-    runResult.Results.Value["lib:build"] |> should equal "success"
+    runResult.Results.Count |> should equal 2
+    runResult.Results["app:build"] |> should equal "failure"
+    runResult.Results["lib:build"] |> should equal "success"
 
 [<Test>]
 let ``buildRunResult marks named graph nodes without runtime results as ignored and skips unnamed nodes`` () =
@@ -132,16 +127,13 @@ let ``buildRunResult marks named graph nodes without runtime results as ignored 
             [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Success DateTime.UtcNow)
               "node-c", buildNodeInfo "src/Lib" "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-    let runResult = global.Program.buildRunResult graph (Some summary) summary.StartedAt summary.EndedAt
+    let runResult = global.Program.buildRunResult graph summary
 
     runResult.Status |> should equal "success"
-    runResult.Impacts["root:build"] |> should equal "build"
-    runResult.Impacts["app:test"] |> should equal "ignore"
-    runResult.Impacts["lib:build"] |> should equal "restore"
-    runResult.Results.Value.Count |> should equal 3
-    runResult.Results.Value["root:build"] |> should equal "success"
-    runResult.Results.Value["app:test"] |> should equal "ignored"
-    runResult.Results.Value["lib:build"] |> should equal "success"
+    runResult.Results.Count |> should equal 3
+    runResult.Results["root:build"] |> should equal "success"
+    runResult.Results["app:test"] |> should equal "ignored"
+    runResult.Results["lib:build"] |> should equal "success"
 
 [<Test>]
 let ``buildRunResult uses failure then success then ignored precedence for duplicate keys`` () =
@@ -155,29 +147,10 @@ let ``buildRunResult uses failure then success then ignored precedence for dupli
         buildSummary true
             [ "node-b", buildNodeInfo "src/App" "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-    let runResult = global.Program.buildRunResult graph (Some summary) summary.StartedAt summary.EndedAt
+    let runResult = global.Program.buildRunResult graph summary
 
-    runResult.Impacts["app:build"] |> should equal "build"
-    runResult.Results.Value.Count |> should equal 1
-    runResult.Results.Value["app:build"] |> should equal "success"
-
-[<Test>]
-let ``buildRunResult omits results for what-if and still reports impacts`` () =
-    let startedAt = DateTime.Parse("2026-04-11T16:42:46.595161Z").ToUniversalTime()
-    let endedAt = DateTime.Parse("2026-04-11T16:42:50.000000Z").ToUniversalTime()
-    let graph =
-        buildGraph
-            [ buildGraphNode "node-a" (Some "App") "src/App" "build" |> withAction GraphDef.RunAction.Exec
-              buildGraphNode "node-b" (Some "Lib") "src/Lib" "test" |> withAction GraphDef.RunAction.Restore
-              buildGraphNode "node-c" None "src/Unnamed" "build" |> withAction GraphDef.RunAction.Exec ]
-
-    let runResult = global.Program.buildRunResult graph None startedAt endedAt
-
-    runResult.Status |> should equal "what-if"
-    runResult.Impacts.Count |> should equal 2
-    runResult.Impacts["app:build"] |> should equal "build"
-    runResult.Impacts["lib:test"] |> should equal "restore"
-    runResult.Results |> should equal None
+    runResult.Results.Count |> should equal 1
+    runResult.Results["app:build"] |> should equal "success"
 
 [<Test>]
 let ``writeRunResultFile writes JSON for successful and ignored nodes`` () =
@@ -192,7 +165,7 @@ let ``writeRunResultFile writes JSON for successful and ignored nodes`` () =
             buildSummary true
                 [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Success DateTime.UtcNow) ]
 
-        global.Program.writeRunResultFile path graph (Some summary) summary.StartedAt summary.EndedAt
+        global.Program.writeRunResultFile path graph summary
 
         File.Exists(path) |> should equal true
 
@@ -200,10 +173,7 @@ let ``writeRunResultFile writes JSON for successful and ignored nodes`` () =
         let json = doc.RootElement
         json.GetProperty("status").GetString() |> should equal "success"
         json.GetProperty("targets").EnumerateArray() |> Seq.map (fun item -> item.GetString()) |> Seq.toList |> should equal [ "build"; "test" ]
-        let impacts = json.GetProperty("impacts")
         let results = json.GetProperty("results")
-        impacts.GetProperty("root:build").GetString() |> should equal "ignore"
-        impacts.GetProperty("app:test").GetString() |> should equal "ignore"
         results.GetProperty("root:build").GetString() |> should equal "success"
         results.GetProperty("app:test").GetString() |> should equal "ignored"
         hasJsonProperty results "unnamed:build" |> should equal false)
@@ -222,8 +192,8 @@ let ``writeRunResultFile writes JSON for failed summary and optional writer skip
             buildSummary false
                 [ "node-a", buildNodeInfo "." "build" (Runner.TaskStatus.Failure (DateTime.UtcNow, "failed")) ]
 
-        global.Program.writeRunResultFile path graph (Some summary) summary.StartedAt summary.EndedAt
-        global.Program.tryWriteRunResultFile None graph (Some summary) summary.StartedAt summary.EndedAt
+        global.Program.writeRunResultFile path graph summary
+        global.Program.tryWriteRunResultFile None graph summary
 
         File.Exists(path) |> should equal true
         File.Exists(missingPath) |> should equal false
@@ -231,31 +201,7 @@ let ``writeRunResultFile writes JSON for failed summary and optional writer skip
         use doc = JsonDocument.Parse(File.ReadAllText(path))
         let json = doc.RootElement
         json.GetProperty("status").GetString() |> should equal "failure"
-        let impacts = json.GetProperty("impacts")
         let results = json.GetProperty("results")
-        impacts.GetProperty("root:build").GetString() |> should equal "ignore"
-        impacts.GetProperty("app:test").GetString() |> should equal "ignore"
         results.GetProperty("root:build").GetString() |> should equal "failure"
         results.GetProperty("app:test").GetString() |> should equal "ignored"
         hasJsonProperty results "unnamed:build" |> should equal false)
-
-[<Test>]
-let ``writeRunResultFile omits results node for what-if`` () =
-    withTempDir (fun root ->
-        let path = Path.Combine(root, "what-if.json")
-        let startedAt = DateTime.Parse("2026-04-11T16:42:46.595161Z").ToUniversalTime()
-        let endedAt = DateTime.Parse("2026-04-11T16:42:50.000000Z").ToUniversalTime()
-        let graph =
-            buildGraph
-                [ buildGraphNode "node-a" (Some "App") "src/App" "build" |> withAction GraphDef.RunAction.Exec
-                  buildGraphNode "node-b" (Some "Lib") "src/Lib" "test" |> withAction GraphDef.RunAction.Restore ]
-
-        global.Program.writeRunResultFile path graph None startedAt endedAt
-
-        use doc = JsonDocument.Parse(File.ReadAllText(path))
-        let json = doc.RootElement
-        json.GetProperty("status").GetString() |> should equal "what-if"
-        let impacts = json.GetProperty("impacts")
-        impacts.GetProperty("app:build").GetString() |> should equal "build"
-        impacts.GetProperty("lib:test").GetString() |> should equal "restore"
-        hasJsonProperty json "results" |> should equal false)

--- a/src/Terrabuild.Tests/Core/Program.fs
+++ b/src/Terrabuild.Tests/Core/Program.fs
@@ -63,12 +63,21 @@ let private hasJsonProperty (json: JsonElement) propertyName =
     json.EnumerateObject() |> Seq.exists (fun property -> property.Name = propertyName)
 
 [<Test>]
-let ``CLI parses result argument`` () =
+let ``CLI parses out argument for run`` () =
     let parser = ArgumentParser.Create<CLI.TerrabuildArgs>(programName = "terrabuild")
-    let result = parser.ParseCommandLine([| "run"; "build"; "--result"; "out.json" |], raiseOnUsage = true)
+    let result = parser.ParseCommandLine([| "run"; "build"; "--out"; "out.json" |], raiseOnUsage = true)
     let runArgs = result.GetResult(TerrabuildArgs.Run)
 
-    runArgs.GetResult(RunArgs.Result) |> should equal "out.json"
+    runArgs.GetResult(RunArgs.Out) |> should equal "out.json"
+
+[<Test>]
+let ``CLI parses impact base and out arguments`` () =
+    let parser = ArgumentParser.Create<CLI.TerrabuildArgs>(programName = "terrabuild")
+    let result = parser.ParseCommandLine([| "impact"; "build"; "--base"; "abc123"; "--out"; "impact.json" |], raiseOnUsage = true)
+    let impactArgs = result.GetResult(TerrabuildArgs.Impact)
+
+    impactArgs.GetResult(ImpactArgs.Base) |> should equal "abc123"
+    impactArgs.GetResult(ImpactArgs.Out) |> should equal "impact.json"
 
 [<Test>]
 let ``buildRunResult produces minimal jq friendly structure`` () =
@@ -205,3 +214,112 @@ let ``writeRunResultFile writes JSON for failed summary and optional writer skip
         results.GetProperty("root:build").GetString() |> should equal "failure"
         results.GetProperty("app:test").GetString() |> should equal "ignored"
         hasJsonProperty results "unnamed:build" |> should equal false)
+
+[<Test>]
+let ``writeImpactResultFile writes JSON`` () =
+    withTempDir (fun root ->
+        let path = Path.Combine(root, "impact", "impact-result.json")
+        let impactResult: global.Program.ImpactResult =
+            { Base = "base-sha"
+              Head = "head-sha"
+              Targets = [ "build" ]
+              Impacts = Map [ "app:build", "changed" ] }
+
+        global.Program.writeImpactResultFile path impactResult
+
+        File.Exists(path) |> should equal true
+
+        use doc = JsonDocument.Parse(File.ReadAllText(path))
+        let json = doc.RootElement
+        json.GetProperty("base").GetString() |> should equal "base-sha"
+        json.GetProperty("head").GetString() |> should equal "head-sha"
+        json.GetProperty("impacts").GetProperty("app:build").GetString() |> should equal "changed")
+
+[<Test>]
+let ``buildImpactResult reports changed and dependency impacts from target hashes`` () =
+    let currentGraph =
+        buildGraph
+            [ { buildGraphNode "lib-build" (Some "Lib") "src/Lib" "build" with
+                    GraphDef.Node.TargetHash = "hash-lib-current" }
+              { buildGraphNode "app-build" (Some "App") "src/App" "build" with
+                    GraphDef.Node.TargetHash = "hash-app"
+                    GraphDef.Node.Dependencies = Set [ "lib-build" ] }
+              { buildGraphNode "batch" None ".terrabuild" "build" with
+                    GraphDef.Node.Dependencies = Set [ "app-build" ] } ]
+
+    let baseGraph =
+        { Contracts.CommitGraph.Repository = "acme/repo"
+          Contracts.CommitGraph.Commit = "base-sha"
+          Contracts.CommitGraph.GraphHash = "graph-base"
+          Contracts.CommitGraph.Nodes =
+            [ { Contracts.BuildGraphNode.Id = "lib-build"
+                ProjectId = "lib"
+                ProjectName = Some "Lib"
+                ProjectDir = "src/Lib"
+                Target = "build"
+                ProjectHash = "project-lib"
+                TargetHash = "hash-lib-base"
+                Dependencies = []
+                Artifacts = "Workspace"
+                Build = "Auto"
+                Batch = "Single"
+                Action = "Exec"
+                Required = true
+                IsBatchNode = false }
+              { Contracts.BuildGraphNode.Id = "app-build"
+                ProjectId = "app"
+                ProjectName = Some "App"
+                ProjectDir = "src/App"
+                Target = "build"
+                ProjectHash = "project-app"
+                TargetHash = "hash-app"
+                Dependencies = [ "lib-build" ]
+                Artifacts = "Workspace"
+                Build = "Auto"
+                Batch = "Single"
+                Action = "Exec"
+                Required = true
+                IsBatchNode = false } ] }
+
+    let impactResult =
+        global.Program.buildImpactResult "base-sha"
+                                         { Sha = "head-sha"
+                                           Message = "head"
+                                           Author = "dev"
+                                           Email = "dev@example.com"
+                                           Timestamp = DateTime.UtcNow }
+                                         (Set [ "build" ])
+                                         currentGraph
+                                         baseGraph
+
+    impactResult.Base |> should equal "base-sha"
+    impactResult.Head |> should equal "head-sha"
+    impactResult.Impacts["lib:build"] |> should equal "changed"
+    impactResult.Impacts["app:build"] |> should equal "dependency"
+
+[<Test>]
+let ``buildImpactResult marks missing base nodes as changed and skips unnamed nodes`` () =
+    let currentGraph =
+        buildGraph
+            [ buildGraphNode "root-build" (Some "Root") "." "build"
+              buildGraphNode "unnamed-build" None "src/Generated" "build" ]
+
+    let baseGraph =
+        { Contracts.CommitGraph.Repository = "acme/repo"
+          Contracts.CommitGraph.Commit = "base-sha"
+          Contracts.CommitGraph.GraphHash = "graph-base"
+          Contracts.CommitGraph.Nodes = [] }
+
+    let impactResult =
+        global.Program.buildImpactResult "base-sha"
+                                         { Sha = "head-sha"
+                                           Message = "head"
+                                           Author = "dev"
+                                           Email = "dev@example.com"
+                                           Timestamp = DateTime.UtcNow }
+                                         (Set [ "build" ])
+                                         currentGraph
+                                         baseGraph
+
+    impactResult.Impacts.Count |> should equal 1
+    impactResult.Impacts["root:build"] |> should equal "changed"

--- a/src/Terrabuild.Tests/Core/Runner.fs
+++ b/src/Terrabuild.Tests/Core/Runner.fs
@@ -178,6 +178,12 @@ type private FakeApiClient() =
         member _.CompleteBuild(_success) =
             lifecycle.Add("complete")
 
+        member _.GetCommitGraph _repository _commit =
+            { Contracts.CommitGraph.Repository = "acme/repo"
+              Contracts.CommitGraph.Commit = "base"
+              Contracts.CommitGraph.GraphHash = "graph"
+              Contracts.CommitGraph.Nodes = [] }
+
         member _.GetArtifact(_path) = Uri("https://example.invalid/artifact")
 
         member _.AddArtifact project projectName target projectHash targetHash files success startedAt endedAt =
@@ -362,7 +368,7 @@ let ``run keeps restored batch members as artifact reuses`` command expectedSucc
 
         let cache = FakeCache(workspace)
         let api = FakeApiClient()
-        let summary = Runner.run (baseOptions workspace) (cache :> Cache.ICache) (Some (api :> Contracts.IApiClient)) graph
+        let summary = Runner.run (baseOptions workspace) (cache :> Cache.ICache) (Some (api :> Contracts.IApiClient)) graph graph
 
         cache.Completed |> should equal [ GraphDef.buildCacheKey execMember ]
         api.AddCalls.Length |> should equal 1
@@ -440,7 +446,7 @@ let ``run includes repository in uploaded graph hash`` () =
             let options =
                 { baseOptions workspace with
                     ConfigOptions.Options.Repository = repository }
-            Runner.run options (cache :> Cache.ICache) (Some (api :> Contracts.IApiClient)) graph |> ignore
+            Runner.run options (cache :> Cache.ICache) (Some (api :> Contracts.IApiClient)) graph graph |> ignore
             let (graphHash, _) = api.GraphUploads |> List.exactlyOne
             graphHash
 
@@ -478,7 +484,7 @@ let ``run normalizes equivalent repository identities in uploaded graph hash`` (
             let options =
                 { baseOptions workspace with
                     ConfigOptions.Options.Repository = repository }
-            Runner.run options (cache :> Cache.ICache) (Some (api :> Contracts.IApiClient)) graph |> ignore
+            Runner.run options (cache :> Cache.ICache) (Some (api :> Contracts.IApiClient)) graph graph |> ignore
             let (graphHash, _) = api.GraphUploads |> List.exactlyOne
             graphHash
 
@@ -541,7 +547,7 @@ let ``run restores cached lazy dependencies pulled by executable roots`` () =
               Cache.TargetSummary.Cache = node.Artifacts }
 
         cache.SetSummary(GraphDef.buildCacheKey genNode, makeSummary genNode "generated.txt" "gen-output")
-        let summary = Runner.run (baseOptions workspace) (cache :> Cache.ICache) (Some (api :> Contracts.IApiClient)) graph
+        let summary = Runner.run (baseOptions workspace) (cache :> Cache.ICache) (Some (api :> Contracts.IApiClient)) graph graph
 
         File.ReadAllText(Path.Combine(genProjectDir, "generated.txt")) |> should equal "gen-output"
         cache.Completed |> should equal [ GraphDef.buildCacheKey buildNode ]

--- a/src/Terrabuild/Api/Client.fs
+++ b/src/Terrabuild/Api/Client.fs
@@ -166,6 +166,13 @@ module private Build =
         { GraphHash: string
           Nodes: BuildGraphNodeInput list }
 
+    [<RequireQualifiedAccess>]
+    type CommitGraphOutput =
+        { Repository: string
+          Commit: string
+          GraphHash: string
+          Nodes: BuildGraphNodeInput list }
+
     let startBuild headers branchOrTag headCommit commitLog run context : StartBuildOutput =
         { StartBuildInput.BranchOrTag = branchOrTag
           StartBuildInput.Commit = headCommit
@@ -217,6 +224,11 @@ module private Build =
                     BuildGraphNodeInput.IsBatchNode = node.IsBatchNode
                 }) }
         payload |> Http.post<UploadBuildGraphInput, Unit> headers $"/builds/{buildId}/graph"
+
+    let getCommitGraph headers (repository: string) (commit: string) : CommitGraphOutput =
+        let repository = Uri.EscapeDataString(repository)
+        let commit = Uri.EscapeDataString(commit)
+        Http.get<Unit, CommitGraphOutput> headers $"/builds/graph?repository={repository}&commit={commit}" ()
 
 
 module private Artifact =
@@ -299,3 +311,27 @@ type Client(workspaceId: string, token: string, options: ConfigOptions.Options) 
         member _.GetArtifact path =
             let resp = Artifact.getArtifact headers path
             Uri(resp.Uri)
+
+        member _.GetCommitGraph repository commit =
+            let resp = Build.getCommitGraph headers repository commit
+            { Contracts.CommitGraph.Repository = resp.Repository
+              Commit = resp.Commit
+              GraphHash = resp.GraphHash
+              Nodes =
+                resp.Nodes
+                |> List.map (fun node -> {
+                    Contracts.BuildGraphNode.Id = node.Id
+                    ProjectId = node.ProjectId
+                    ProjectName = node.ProjectName
+                    ProjectDir = node.ProjectDir
+                    Target = node.Target
+                    ProjectHash = node.ProjectHash
+                    TargetHash = node.TargetHash
+                    Dependencies = node.Dependencies
+                    Artifacts = node.Artifacts
+                    Build = node.Build
+                    Batch = node.Batch
+                    Action = node.Action
+                    Required = node.Required
+                    IsBatchNode = node.IsBatchNode
+                }) }

--- a/src/Terrabuild/CLI.fs
+++ b/src/Terrabuild/CLI.fs
@@ -47,7 +47,7 @@ with
 type RunArgs =
     | [<ExactlyOnce; MainCommand; First>] Target of target:string list
     | [<Unique; AltCommandLine("-w")>] Workspace of path:string
-    | [<Unique>] Result of path:string
+    | [<Unique>] Out of path:string
     | [<Unique; AltCommandLine("-c")>] Configuration of name:string
     | [<Unique; AltCommandLine("-e")>] Environment of name:string
     | [<EqualsAssignment; AltCommandLine("-v")>] Variable of variable:string * value:string
@@ -68,7 +68,7 @@ with
             match this with
             | Target _ -> "Specify build target."
             | Workspace _ -> "Root of workspace. If not specified, current directory is used."
-            | Result _ -> "Write machine-readable result JSON to file."
+            | Out _ -> "Write machine-readable JSON to file."
             | Configuration _ -> "Configuration to use."
             | Environment _ -> "Environment to use."
             | Variable _ -> "Set variable."
@@ -83,6 +83,33 @@ with
             | Tag _ -> "Tag for build."
             | Engine _ -> "Container engine to use (docker, podman or host)."
             | What_If -> "Prepare the action but do not apply."
+
+[<RequireQualifiedAccess>]
+type ImpactArgs =
+    | [<ExactlyOnce; MainCommand; First>] Target of target:string list
+    | [<ExactlyOnce; Unique>] Base of sha:string
+    | [<ExactlyOnce; Unique>] Out of path:string
+    | [<Unique; AltCommandLine("-w")>] Workspace of path:string
+    | [<Unique; AltCommandLine("-c")>] Configuration of name:string
+    | [<Unique; AltCommandLine("-e")>] Environment of name:string
+    | [<EqualsAssignment; AltCommandLine("-v")>] Variable of variable:string * value:string
+    | [<Unique; AltCommandLine("-l")>] Label of labels:string list
+    | [<Unique; AltCommandLine("-t")>] Type of types:string list
+    | [<Unique; AltCommandLine("-p")>] Project of projects:string list
+with
+    interface IArgParserTemplate with
+        member this.Usage =
+            match this with
+            | Target _ -> "Specify build target."
+            | Base _ -> "Base commit to compare against."
+            | Out _ -> "Write machine-readable JSON to file."
+            | Workspace _ -> "Root of workspace. If not specified, current directory is used."
+            | Configuration _ -> "Configuration to use."
+            | Environment _ -> "Environment to use."
+            | Variable _ -> "Set variable."
+            | Label _ -> "Select projects based on labels."
+            | Type _ -> "Select projects based on extension types."
+            | Project _ -> "Select projets base on id."
 
 [<RequireQualifiedAccess>]
 type ServeArgs =
@@ -170,6 +197,7 @@ type TerrabuildArgs =
     | [<CliPrefix(CliPrefix.None)>] Scaffold of ParseResults<ScaffoldArgs>
     | [<CliPrefix(CliPrefix.None)>] Logs of ParseResults<LogsArgs>
     | [<CliPrefix(CliPrefix.None)>] Run of ParseResults<RunArgs>
+    | [<CliPrefix(CliPrefix.None)>] Impact of ParseResults<ImpactArgs>
     | [<CliPrefix(CliPrefix.None)>] Serve of ParseResults<ServeArgs>
     | [<CliPrefix(CliPrefix.None)>] Console of ParseResults<ConsoleArgs>
     | [<CliPrefix(CliPrefix.None)>] Clear of ParseResults<ClearArgs>
@@ -186,6 +214,7 @@ with
             | Scaffold _ -> "Scaffold workspace."
             | Logs _ -> "dump logs."
             | Run _ -> "Run specified targets."
+            | Impact _ -> "Report impacted targets compared to a base commit."
             | Serve _ -> "Serve specified targets."
             | Console _ -> "Launch web console."
             | Clear _ -> "Clear specified caches."

--- a/src/Terrabuild/Contracts/Api.fs
+++ b/src/Terrabuild/Contracts/Api.fs
@@ -18,6 +18,14 @@ type BuildGraphNode = {
     IsBatchNode: bool
 }
 
+[<RequireQualifiedAccess>]
+type CommitGraph = {
+    Repository: string
+    Commit: string
+    GraphHash: string
+    Nodes: BuildGraphNode list
+}
+
 type IApiClient =
     abstract StartBuild: Unit -> Unit
     abstract UploadBuildGraph: graphHash:string -> nodes:BuildGraphNode list -> Unit
@@ -25,3 +33,4 @@ type IApiClient =
     abstract AddArtifact: project:string -> projectName:string option -> target:string -> projectHash:string -> targetHash:string  -> files:string list -> success:bool -> startedAt:DateTime -> endedAt:DateTime -> Unit
     abstract UseArtifact: projectHash:string -> hash:string -> Unit
     abstract GetArtifact: path:string -> Uri
+    abstract GetCommitGraph: repository:string -> commit:string -> CommitGraph

--- a/src/Terrabuild/Core/GraphPipeline/Node.fs
+++ b/src/Terrabuild/Core/GraphPipeline/Node.fs
@@ -175,11 +175,11 @@ let build (options: ConfigOptions.Options) (configuration: Configuration.Workspa
   
         if processedNodes.TryAdd(nodeId, true) then processNode()
 
-    configuration.SelectedProjects |> Seq.iter (fun project ->
-        options.Targets |> Seq.iter (fun target ->
-            configuration.Projects
-            |> Map.tryFind project
-            |> Option.iter (fun projectConfig -> if projectConfig.Targets |> Map.containsKey target then buildNode project target)))
+    configuration.Projects
+    |> Map.iter (fun projectId projectConfig ->
+        projectConfig.Targets
+        |> Map.keys
+        |> Seq.iter (fun target -> buildNode projectId target))
 
     let rootNodes =
         let allNodeIds = allNodes.Keys |> Set

--- a/src/Terrabuild/Core/GraphPipeline/Selection.fs
+++ b/src/Terrabuild/Core/GraphPipeline/Selection.fs
@@ -1,0 +1,37 @@
+module GraphPipeline.Selection
+open Collections
+open GraphDef
+
+let build (options: ConfigOptions.Options) (configuration: Configuration.Workspace) (graph: Graph) =
+    let selectedRoots =
+        configuration.SelectedProjects
+        |> Seq.collect (fun projectId ->
+            options.Targets
+            |> Seq.choose (fun target ->
+                configuration.Projects
+                |> Map.tryFind projectId
+                |> Option.bind (fun project ->
+                    if project.Targets |> Map.containsKey target then Some $"{projectId}:{target}"
+                    else None)))
+        |> Set.ofSeq
+
+    let rec visit pending visited =
+        match pending with
+        | [] -> visited
+        | nodeId::rest when visited |> Set.contains nodeId -> visit rest visited
+        | nodeId::rest ->
+            match graph.Nodes |> Map.tryFind nodeId with
+            | Some node ->
+                let next = node.Dependencies |> Set.toList
+                visit (rest @ next) (visited |> Set.add nodeId)
+            | None ->
+                visit rest visited
+
+    let activeNodes = visit (selectedRoots |> Set.toList) Set.empty
+    let nodes =
+        graph.Nodes
+        |> Map.filter (fun nodeId _ -> activeNodes |> Set.contains nodeId)
+
+    { Graph.Nodes = nodes
+      Graph.RootNodes = selectedRoots |> Set.filter (fun nodeId -> nodes |> Map.containsKey nodeId)
+      Graph.Batches = Map.empty }

--- a/src/Terrabuild/Core/GraphPipeline/Selection.fs
+++ b/src/Terrabuild/Core/GraphPipeline/Selection.fs
@@ -32,6 +32,11 @@ let build (options: ConfigOptions.Options) (configuration: Configuration.Workspa
         graph.Nodes
         |> Map.filter (fun nodeId _ -> activeNodes |> Set.contains nodeId)
 
+    let rootNodes =
+        let allNodeIds = nodes |> Map.keys |> Set.ofSeq
+        let allDependencyIds = nodes |> Map.values |> Seq.collect (fun node -> node.Dependencies) |> Set.ofSeq
+        allNodeIds - allDependencyIds
+
     { Graph.Nodes = nodes
-      Graph.RootNodes = selectedRoots |> Set.filter (fun nodeId -> nodes |> Map.containsKey nodeId)
+      Graph.RootNodes = rootNodes
       Graph.Batches = Map.empty }

--- a/src/Terrabuild/Core/Runner.fs
+++ b/src/Terrabuild/Core/Runner.fs
@@ -305,7 +305,7 @@ let buildBatchSchedule flattenBatchProgress (graph: GraphDef.Graph) (targetNode:
       | None ->
           (targetNode.Id, $"{targetNode.Target} {targetNode.ProjectDir}") ]
 
-let run (options: ConfigOptions.Options) (cache: Cache.ICache) (api: Contracts.IApiClient option) (graph: GraphDef.Graph) =
+let run (options: ConfigOptions.Options) (cache: Cache.ICache) (api: Contracts.IApiClient option) (uploadGraph: GraphDef.Graph) (graph: GraphDef.Graph) =
     let startedAt = DateTime.UtcNow
     let repository =
         options.Repository
@@ -323,7 +323,7 @@ let run (options: ConfigOptions.Options) (cache: Cache.ICache) (api: Contracts.I
         api.StartBuild()
 
         let graphNodes =
-            graph.Nodes.Values
+            uploadGraph.Nodes.Values
             |> Seq.sortBy (fun node -> node.Id)
             |> Seq.map (fun node ->
                 { Contracts.BuildGraphNode.Id = node.Id
@@ -339,7 +339,7 @@ let run (options: ConfigOptions.Options) (cache: Cache.ICache) (api: Contracts.I
                   Contracts.BuildGraphNode.Batch = string node.Batch
                   Contracts.BuildGraphNode.Action = string node.Action
                   Contracts.BuildGraphNode.Required = node.Required
-                  Contracts.BuildGraphNode.IsBatchNode = graph.Batches.ContainsKey(node.Id) })
+                  Contracts.BuildGraphNode.IsBatchNode = uploadGraph.Batches.ContainsKey(node.Id) })
             |> List.ofSeq
         let graphHash =
             graphNodes

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -43,8 +43,7 @@ type RunResult = {
     Targets: string list
     StartedAt: DateTime
     EndedAt: DateTime
-    Impacts: Map<string, string>
-    Results: Map<string, string> option
+    Results: Map<string, string>
 }
 
 let private buildResultKey (projectName: string) (target: string) =
@@ -59,93 +58,47 @@ let private mergeRunResultStatus currentStatus nextStatus =
 
     if priority nextStatus > priority currentStatus then nextStatus
     else currentStatus
-
-let private buildImpactAction action =
-    match action with
-    | GraphDef.RunAction.Exec -> "build"
-    | GraphDef.RunAction.Restore -> "restore"
-    | GraphDef.RunAction.Summary -> "report"
-    | GraphDef.RunAction.Ignore -> "ignore"
-
-let private mergeImpactAction currentAction nextAction =
-    let priority action =
-        match action with
-        | "build" -> 3
-        | "restore" -> 2
-        | "report" -> 1
-        | _ -> 0
-
-    if priority nextAction > priority currentAction then nextAction
-    else currentAction
-
-let buildRunResult (graph: GraphDef.Graph) (summary: Runner.Summary option) startedAt endedAt =
-    let impacts =
+let buildRunResult (graph: GraphDef.Graph) (summary: Runner.Summary) =
+    let results =
         graph.Nodes
         |> Map.values
         |> Seq.fold (fun state node ->
             match node.ProjectName with
             | Some projectName ->
                 let key = buildResultKey projectName node.Target
-                let impact = buildImpactAction node.Action
+                let status =
+                    match summary.Nodes |> Map.tryFind node.Id with
+                    | Some nodeSummary when nodeSummary.Status.IsSuccess -> "success"
+                    | Some _ -> "failure"
+                    | None -> "ignored"
+
                 let aggregated =
                     match state |> Map.tryFind key with
-                    | Some existing -> mergeImpactAction existing impact
-                    | None -> impact
+                    | Some existing -> mergeRunResultStatus existing status
+                    | None -> status
+
                 state |> Map.add key aggregated
             | None -> state
         ) Map.empty
 
-    let results =
-        summary
-        |> Option.map (fun summary ->
-            graph.Nodes
-            |> Map.values
-            |> Seq.fold (fun state node ->
-                match node.ProjectName with
-                | Some projectName ->
-                    let key = buildResultKey projectName node.Target
-                    let status =
-                        match summary.Nodes |> Map.tryFind node.Id with
-                        | Some nodeSummary when nodeSummary.Status.IsSuccess -> "success"
-                        | Some _ -> "failure"
-                        | None -> "ignored"
-
-                    let aggregated =
-                        match state |> Map.tryFind key with
-                        | Some existing -> mergeRunResultStatus existing status
-                        | None -> status
-
-                    state |> Map.add key aggregated
-                | None -> state
-            ) Map.empty
-        )
-
-    { RunResult.Status =
-        match summary with
-        | Some summary when summary.IsSuccess -> "success"
-        | Some _ -> "failure"
-        | None -> "what-if"
-      RunResult.Targets =
-        match summary with
-        | Some summary -> summary.Targets |> Set.toList
-        | None -> graph.RootNodes |> Seq.map (fun nodeId -> graph.Nodes[nodeId].Target) |> Set.ofSeq |> Set.toList
-      RunResult.StartedAt = startedAt
-      RunResult.EndedAt = endedAt
-      RunResult.Impacts = impacts
+    { RunResult.Status = if summary.IsSuccess then "success" else "failure"
+      RunResult.Targets = summary.Targets |> Set.toList
+      RunResult.StartedAt = summary.StartedAt
+      RunResult.EndedAt = summary.EndedAt
       RunResult.Results = results }
 
-let writeRunResultFile (filePath: string) (graph: GraphDef.Graph) (summary: Runner.Summary option) startedAt endedAt =
+let writeRunResultFile (filePath: string) (graph: GraphDef.Graph) (summary: Runner.Summary) =
     match Path.GetDirectoryName(filePath) with
     | null -> ()
     | outputDir when String.IsNullOrWhiteSpace(outputDir) -> ()
     | outputDir -> IO.createDirectory outputDir
 
-    buildRunResult graph summary startedAt endedAt
+    buildRunResult graph summary
     |> Json.Serialize
     |> IO.writeTextFile filePath
 
-let tryWriteRunResultFile (filePath: string option) (graph: GraphDef.Graph) (summary: Runner.Summary option) startedAt endedAt =
-    filePath |> Option.iter (fun path -> writeRunResultFile path graph summary startedAt endedAt)
+let tryWriteRunResultFile (filePath: string option) (graph: GraphDef.Graph) (summary: Runner.Summary) =
+    filePath |> Option.iter (fun path -> writeRunResultFile path graph summary)
 
 
 let launchDir = currentDir()
@@ -314,9 +267,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
             markdown |> IO.writeLines (logFile "info.md")
 
         let errCode =
-            if options.WhatIf then
-                tryWriteRunResultFile runResultFile graph None options.StartedAt DateTime.UtcNow
-                0
+            if options.WhatIf then 0
             else
                 Log.Debug("====[ Runner ]========================================================")
                 let summary = runPhase "runner" (fun () -> Runner.run options cache api graph)
@@ -325,7 +276,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
                 if options.Debug then
                     let jsonBuild = Json.Serialize summary
                     jsonBuild |> IO.writeTextFile (logFile "build-result.json")
-                tryWriteRunResultFile runResultFile graph (Some summary) summary.StartedAt summary.EndedAt
+                tryWriteRunResultFile runResultFile graph summary
 
                 if log || not summary.IsSuccess then
                     Logs.dumpLogs runId options cache graph summary

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -354,11 +354,11 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
 
         Log.Debug("====[ GraphPipeline Node ]========================================================")
         let fullGraph = runPhase "graph-node" (fun () -> GraphPipeline.Node.build options config)
-        if options.Debug then fullGraph |> Json.Serialize |> IO.writeTextFile (logFile $"node.json")
+        if options.Debug then fullGraph |> Json.Serialize |> IO.writeTextFile (logFile $"full-node.json")
 
         Log.Debug("====[ GraphPipeline Selection ]========================================================")
         let graph = runPhase "graph-selection" (fun () -> GraphPipeline.Selection.build options config fullGraph)
-        if options.Debug then graph |> Json.Serialize |> IO.writeTextFile (logFile $"selection.json")
+        if options.Debug then graph |> Json.Serialize |> IO.writeTextFile (logFile $"node.json")
 
         Log.Debug("====[ GraphPipeline Action ]========================================================")
         let graph = runPhase "graph-action" (fun () -> GraphPipeline.Action.build options cache graph)

--- a/src/Terrabuild/Program.fs
+++ b/src/Terrabuild/Program.fs
@@ -17,6 +17,7 @@ open Humanizer
 type RunTargetOptions = {
     Workspace: string
     RunResultFile: string option
+    BaseCommit: string option
     WhatIf: bool
     Debug: bool
     MaxConcurrency: int
@@ -46,6 +47,23 @@ type RunResult = {
     Results: Map<string, string>
 }
 
+[<RequireQualifiedAccess>]
+type ImpactResult = {
+    Base: string
+    Head: string
+    Targets: string list
+    Impacts: Map<string, string>
+}
+
+type private PreparedRunTarget = {
+    RunOptions: RunTargetOptions
+    Options: ConfigOptions.Options
+    Cache: Cache.ICache
+    Api: Contracts.IApiClient option
+    FullGraph: GraphDef.Graph
+    Graph: GraphDef.Graph
+}
+
 let private buildResultKey (projectName: string) (target: string) =
     $"{projectName |> String.toLower}:{target}"
 
@@ -58,6 +76,17 @@ let private mergeRunResultStatus currentStatus nextStatus =
 
     if priority nextStatus > priority currentStatus then nextStatus
     else currentStatus
+
+let private mergeImpactStatus currentStatus nextStatus =
+    let priority status =
+        match status with
+        | "changed" -> 2
+        | "dependency" -> 1
+        | _ -> 0
+
+    if priority nextStatus > priority currentStatus then nextStatus
+    else currentStatus
+
 let buildRunResult (graph: GraphDef.Graph) (summary: Runner.Summary) =
     let results =
         graph.Nodes
@@ -87,6 +116,102 @@ let buildRunResult (graph: GraphDef.Graph) (summary: Runner.Summary) =
       RunResult.EndedAt = summary.EndedAt
       RunResult.Results = results }
 
+let buildImpactResult (baseCommit: string) (headCommit: Contracts.Commit) (targets: string set) (currentGraph: GraphDef.Graph) (baseGraph: Contracts.CommitGraph) =
+    let buildCurrentKeyMap (graph: GraphDef.Graph) =
+        graph.Nodes
+        |> Map.values
+        |> Seq.choose (fun node ->
+            node.ProjectName
+            |> Option.map (fun projectName -> buildResultKey projectName node.Target, node))
+        |> Seq.groupBy fst
+        |> Seq.map (fun (key, items) -> key, items |> Seq.map snd |> Seq.toList)
+        |> Map.ofSeq
+
+    let buildBaseKeyMap (graph: Contracts.CommitGraph) =
+        graph.Nodes
+        |> Seq.choose (fun node ->
+            node.ProjectName
+            |> Option.map (fun projectName -> buildResultKey projectName node.Target, node))
+        |> Seq.groupBy fst
+        |> Seq.map (fun (key, items) -> key, items |> Seq.map snd |> Seq.toList)
+        |> Map.ofSeq
+
+    let currentByKey = buildCurrentKeyMap currentGraph
+    let baseByKey = buildBaseKeyMap baseGraph
+
+    let hasChanged key (currentNodes: GraphDef.Node list) =
+        let currentHashes =
+            currentNodes
+            |> Seq.map (fun node -> node.TargetHash)
+            |> Set.ofSeq
+
+        match baseByKey |> Map.tryFind key with
+        | None -> true
+        | Some baseNodes ->
+            let baseHashes =
+                baseNodes
+                |> Seq.map (fun node -> node.TargetHash)
+                |> Set.ofSeq
+
+            if baseNodes |> List.exists (fun node -> String.IsNullOrWhiteSpace(node.TargetHash)) then true
+            else currentHashes <> baseHashes
+
+    let reverseDependencies =
+        currentGraph.Nodes
+        |> Map.values
+        |> Seq.collect (fun node -> node.Dependencies |> Seq.map (fun dependency -> dependency, node.Id))
+        |> Seq.groupBy fst
+        |> Seq.map (fun (dependency, dependents) -> dependency, dependents |> Seq.map snd |> Set.ofSeq)
+        |> Map.ofSeq
+
+    let directChangedNodeIds =
+        currentByKey
+        |> Map.toSeq
+        |> Seq.choose (fun (key, currentNodes) ->
+            if hasChanged key currentNodes then
+                currentNodes |> Seq.map (fun node -> node.Id) |> Set.ofSeq |> Some
+            else None)
+        |> Seq.fold Set.union Set.empty
+
+    let rec visit queue visited =
+        match queue with
+        | [] -> visited
+        | current::rest when visited |> Set.contains current -> visit rest visited
+        | current::rest ->
+            let next =
+                reverseDependencies
+                |> Map.tryFind current
+                |> Option.defaultValue Set.empty
+                |> Set.toList
+            visit (rest @ next) (visited |> Set.add current)
+
+    let impactedNodeIds = visit (directChangedNodeIds |> Set.toList) Set.empty
+
+    let impacts =
+        impactedNodeIds
+        |> Seq.fold (fun state nodeId ->
+            match currentGraph.Nodes |> Map.tryFind nodeId with
+            | Some node ->
+                match node.ProjectName with
+                | Some projectName ->
+                    let key = buildResultKey projectName node.Target
+                    let status =
+                        if directChangedNodeIds |> Set.contains nodeId then "changed"
+                        else "dependency"
+                    let aggregated =
+                        match state |> Map.tryFind key with
+                        | Some existing -> mergeImpactStatus existing status
+                        | None -> status
+                    state |> Map.add key aggregated
+                | None -> state
+            | None -> state
+        ) Map.empty
+
+    { ImpactResult.Base = baseCommit
+      ImpactResult.Head = headCommit.Sha
+      ImpactResult.Targets = targets |> Set.toList
+      ImpactResult.Impacts = impacts }
+
 let writeRunResultFile (filePath: string) (graph: GraphDef.Graph) (summary: Runner.Summary) =
     match Path.GetDirectoryName(filePath) with
     | null -> ()
@@ -94,6 +219,16 @@ let writeRunResultFile (filePath: string) (graph: GraphDef.Graph) (summary: Runn
     | outputDir -> IO.createDirectory outputDir
 
     buildRunResult graph summary
+    |> Json.Serialize
+    |> IO.writeTextFile filePath
+
+let writeImpactResultFile (filePath: string) (impactResult: ImpactResult) =
+    match Path.GetDirectoryName(filePath) with
+    | null -> ()
+    | outputDir when String.IsNullOrWhiteSpace(outputDir) -> ()
+    | outputDir -> IO.createDirectory outputDir
+
+    impactResult
     |> Json.Serialize
     |> IO.writeTextFile filePath
 
@@ -137,13 +272,11 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         Log.Debug("Terrabuild: {Version}", Version.informalVersion())
         Log.Debug("Environment: {OSDescription}, {OSArchitecture}, {Version}", RuntimeInformation.OSDescription, RuntimeInformation.OSArchitecture, Environment.Version)
 
-    let runTarget (options: RunTargetOptions) =
-        System.Environment.CurrentDirectory <- options.Workspace
-        Log.Debug("Changing current directory to {directory}", options.Workspace)
+    let prepareRunTarget (runOptions: RunTargetOptions) =
+        System.Environment.CurrentDirectory <- runOptions.Workspace
+        Log.Debug("Changing current directory to {directory}", runOptions.Workspace)
         Log.Debug("ProcessorCount = {procCount}", Environment.ProcessorCount)
         Terrabuild.Scripting.resetPerformanceMetrics()
-        let runResultFile = options.RunResultFile
-
         let homeDir = Cache.createHome()
         let tmpDir = Cache.createTmp()
         let sharedDir = ".terrabuild"
@@ -152,29 +285,29 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let sourceControl = SourceControls.Factory.create()
 
         let options = {
-            ConfigOptions.Options.Workspace = options.Workspace
+            ConfigOptions.Options.Workspace = runOptions.Workspace
             ConfigOptions.Options.HomeDir = homeDir
             ConfigOptions.Options.TmpDir = tmpDir
             ConfigOptions.Options.SharedDir = sharedDir
-            ConfigOptions.Options.WhatIf = options.WhatIf
-            ConfigOptions.Options.Debug = options.Debug
-            ConfigOptions.Options.MaxConcurrency = options.MaxConcurrency
-            ConfigOptions.Options.Force = options.Force
-            ConfigOptions.Options.Retry = options.Retry
-            ConfigOptions.Options.LocalOnly = options.LocalOnly
-            ConfigOptions.Options.StartedAt = options.StartedAt
-            ConfigOptions.Options.Targets = options.Targets
+            ConfigOptions.Options.WhatIf = runOptions.WhatIf
+            ConfigOptions.Options.Debug = runOptions.Debug
+            ConfigOptions.Options.MaxConcurrency = runOptions.MaxConcurrency
+            ConfigOptions.Options.Force = runOptions.Force
+            ConfigOptions.Options.Retry = runOptions.Retry
+            ConfigOptions.Options.LocalOnly = runOptions.LocalOnly
+            ConfigOptions.Options.StartedAt = runOptions.StartedAt
+            ConfigOptions.Options.Targets = runOptions.Targets
             ConfigOptions.Options.LogTypes = sourceControl.LogTypes
-            ConfigOptions.Options.Configuration = options.Configuration
-            ConfigOptions.Options.Environment = options.Environment
-            ConfigOptions.Options.Note = options.Note
-            ConfigOptions.Options.Label = options.Label
-            ConfigOptions.Options.Types = options.Types
-            ConfigOptions.Options.Labels = options.Labels
-            ConfigOptions.Options.Projects = options.Projects
-            ConfigOptions.Options.Variables = options.Variables
+            ConfigOptions.Options.Configuration = runOptions.Configuration
+            ConfigOptions.Options.Environment = runOptions.Environment
+            ConfigOptions.Options.Note = runOptions.Note
+            ConfigOptions.Options.Label = runOptions.Label
+            ConfigOptions.Options.Types = runOptions.Types
+            ConfigOptions.Options.Labels = runOptions.Labels
+            ConfigOptions.Options.Projects = runOptions.Projects
+            ConfigOptions.Options.Variables = runOptions.Variables
             ConfigOptions.Options.Engine =
-                match options.Engine with
+                match runOptions.Engine with
                 | None | Some Engine.Docker -> ConfigOptions.Engine.Docker
                 | Some Engine.Podman -> ConfigOptions.Engine.Podman
                 | Some Engine.Host -> ConfigOptions.Engine.Host
@@ -220,8 +353,12 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let cache = Cache.Cache(storage, masterKey) :> Cache.ICache
 
         Log.Debug("====[ GraphPipeline Node ]========================================================")
-        let graph = runPhase "graph-node" (fun () -> GraphPipeline.Node.build options config)
-        if options.Debug then graph |> Json.Serialize |> IO.writeTextFile (logFile $"node.json")
+        let fullGraph = runPhase "graph-node" (fun () -> GraphPipeline.Node.build options config)
+        if options.Debug then fullGraph |> Json.Serialize |> IO.writeTextFile (logFile $"node.json")
+
+        Log.Debug("====[ GraphPipeline Selection ]========================================================")
+        let graph = runPhase "graph-selection" (fun () -> GraphPipeline.Selection.build options config fullGraph)
+        if options.Debug then graph |> Json.Serialize |> IO.writeTextFile (logFile $"selection.json")
 
         Log.Debug("====[ GraphPipeline Action ]========================================================")
         let graph = runPhase "graph-action" (fun () -> GraphPipeline.Action.build options cache graph)
@@ -266,17 +403,37 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
                     "" ]
             markdown |> IO.writeLines (logFile "info.md")
 
+        { PreparedRunTarget.RunOptions = runOptions
+          Options = options
+          Cache = cache
+          Api = api
+          FullGraph = fullGraph
+          Graph = graph }
+
+    let runTarget (options: RunTargetOptions) =
+        let prepared = prepareRunTarget options
+        let runOptions = prepared.RunOptions
+        let options = prepared.Options
+        let cache = prepared.Cache
+        let api = prepared.Api
+        let fullGraph = prepared.FullGraph
+        let graph = prepared.Graph
+
         let errCode =
             if options.WhatIf then 0
             else
                 Log.Debug("====[ Runner ]========================================================")
-                let summary = runPhase "runner" (fun () -> Runner.run options cache api graph)
+                let startedAt = DateTime.UtcNow
+                let summary = Runner.run options cache api fullGraph graph
+                let duration = DateTime.UtcNow - startedAt
+                if options.Debug then
+                    Log.Debug("Phase 'runner' duration: {DurationMs}ms", Math.Round(duration.TotalMilliseconds, 2))
 
                 Log.Debug("====[ Report ]========================================================")
                 if options.Debug then
                     let jsonBuild = Json.Serialize summary
                     jsonBuild |> IO.writeTextFile (logFile "build-result.json")
-                tryWriteRunResultFile runResultFile graph summary
+                tryWriteRunResultFile runOptions.RunResultFile graph summary
 
                 if log || not summary.IsSuccess then
                     Logs.dumpLogs runId options cache graph summary
@@ -320,6 +477,32 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         $"{emoji} Completed in {duration.HumanizeAbbreviated()}" |> Terminal.writeLine
         errCode
 
+    let impactTarget (options: RunTargetOptions) =
+        Terminal.mute()
+        let prepared =
+            try
+                prepareRunTarget options
+            finally
+                Terminal.unmute()
+        let runOptions = prepared.RunOptions
+        let options = prepared.Options
+        let api =
+            match prepared.Api with
+            | Some api -> api
+            | None -> raiseInvalidArg "impact requires an Insights connection. Run terrabuild login first."
+
+        let baseCommit =
+            match runOptions.BaseCommit with
+            | Some baseCommit -> baseCommit
+            | None -> raiseInvalidArg "impact requires a base commit."
+
+        let baseGraph = api.GetCommitGraph options.Repository baseCommit
+        let impactResult = buildImpactResult baseCommit options.HeadCommit options.Targets prepared.Graph baseGraph
+        match runOptions.RunResultFile with
+        | Some filePath -> writeImpactResultFile filePath impactResult
+        | None -> raiseInvalidArg "impact requires an output file."
+        0
+
 
     let scaffold (scaffoldArgs: ParseResults<ScaffoldArgs>) =
         let wsDir = scaffoldArgs.GetResult(ScaffoldArgs.Workspace, defaultValue = ".")
@@ -339,7 +522,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let configuration = runArgs.TryGetResult(RunArgs.Configuration)
         let environment = runArgs.TryGetResult(RunArgs.Environment)
         let note = runArgs.TryGetResult(RunArgs.Note)
-        let runResultFile = runArgs.TryGetResult(RunArgs.Result)
+        let runResultFile = runArgs.TryGetResult(RunArgs.Out)
         let types = runArgs.TryGetResult(RunArgs.Type) |> Option.map (fun types -> types |> Seq.map String.toLower |> Set)
         let labels = runArgs.TryGetResult(RunArgs.Label) |> Option.map (fun labels -> labels |> Seq.map String.toLower |> Set)
         let projects = runArgs.TryGetResult(RunArgs.Project) |> Option.map (fun projects -> projects |> Seq.map String.toLower |> Set)
@@ -352,6 +535,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
 
         let options = { RunTargetOptions.Workspace = wsDir |> FS.fullPath
                         RunTargetOptions.RunResultFile = runResultFile |> Option.map FS.fullPath
+                        RunTargetOptions.BaseCommit = None
                         RunTargetOptions.WhatIf = whatIf
                         RunTargetOptions.Debug = debug
                         RunTargetOptions.Force = runArgs.Contains(RunArgs.Force)
@@ -372,6 +556,47 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
                         RunTargetOptions.Engine = engine }
         runTarget options
 
+    let impact (impactArgs: ParseResults<ImpactArgs>) =
+        let wsDir =
+            match impactArgs.TryGetResult(ImpactArgs.Workspace) with
+            | Some ws -> ws
+            | _ ->
+                match currentDir() |> findWorkspace with
+                | Some ws -> ws
+                | _ -> raiseInvalidArg "Can't find workspace root directory. Check you are in a workspace."
+        let targets = impactArgs.GetResult(ImpactArgs.Target) |> Seq.map String.toLower
+        let baseCommit = impactArgs.GetResult(ImpactArgs.Base)
+        let outputFile = impactArgs.GetResult(ImpactArgs.Out)
+        let configuration = impactArgs.TryGetResult(ImpactArgs.Configuration)
+        let environment = impactArgs.TryGetResult(ImpactArgs.Environment)
+        let types = impactArgs.TryGetResult(ImpactArgs.Type) |> Option.map (fun types -> types |> Seq.map String.toLower |> Set)
+        let labels = impactArgs.TryGetResult(ImpactArgs.Label) |> Option.map (fun labels -> labels |> Seq.map String.toLower |> Set)
+        let projects = impactArgs.TryGetResult(ImpactArgs.Project) |> Option.map (fun projects -> projects |> Seq.map String.toLower |> Set)
+        let variables = impactArgs.GetResults(ImpactArgs.Variable) |> Seq.map (fun (k, v) -> (k |> String.toLower, v)) |> Map
+
+        let options = { RunTargetOptions.Workspace = wsDir |> FS.fullPath
+                        RunTargetOptions.RunResultFile = Some (outputFile |> FS.fullPath)
+                        RunTargetOptions.BaseCommit = Some baseCommit
+                        RunTargetOptions.WhatIf = false
+                        RunTargetOptions.Debug = debug
+                        RunTargetOptions.Force = false
+                        RunTargetOptions.MaxConcurrency = 1
+                        RunTargetOptions.Retry = false
+                        RunTargetOptions.StartedAt = DateTime.UtcNow
+                        RunTargetOptions.IsLog = false
+                        RunTargetOptions.Targets = Set targets
+                        RunTargetOptions.LocalOnly = false
+                        RunTargetOptions.Configuration = configuration
+                        RunTargetOptions.Environment = environment
+                        RunTargetOptions.Note = None
+                        RunTargetOptions.Label = None
+                        RunTargetOptions.Types = types
+                        RunTargetOptions.Labels = labels
+                        RunTargetOptions.Projects = projects
+                        RunTargetOptions.Variables = variables
+                        RunTargetOptions.Engine = None }
+        impactTarget options
+
     let serve (serveArgs: ParseResults<ServeArgs>) =
         let wsDir =
             match serveArgs.TryGetResult(ServeArgs.Workspace) with
@@ -388,6 +613,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
         let variables = serveArgs.GetResults(ServeArgs.Variable) |> Seq.map (fun (k, v) -> (k |> String.toLower, v)) |> Map
         let options = { RunTargetOptions.Workspace = wsDir |> FS.fullPath
                         RunTargetOptions.RunResultFile = None
+                        RunTargetOptions.BaseCommit = None
                         RunTargetOptions.WhatIf = false
                         RunTargetOptions.Debug = debug
                         RunTargetOptions.Force = false
@@ -444,6 +670,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
 
         let options = { RunTargetOptions.Workspace = wsDir |> FS.fullPath
                         RunTargetOptions.RunResultFile = None
+                        RunTargetOptions.BaseCommit = None
                         RunTargetOptions.WhatIf = true
                         RunTargetOptions.Debug = debug
                         RunTargetOptions.Force = false
@@ -502,6 +729,7 @@ let processCommandLine (parser: ArgumentParser<TerrabuildArgs>) (result: ParseRe
     | p when p.Contains(TerrabuildArgs.Scaffold) -> p.GetResult(TerrabuildArgs.Scaffold) |> scaffold
     | p when p.Contains(TerrabuildArgs.Logs) -> p.GetResult(TerrabuildArgs.Logs) |> logs
     | p when p.Contains(TerrabuildArgs.Run) -> p.GetResult(TerrabuildArgs.Run) |> run
+    | p when p.Contains(TerrabuildArgs.Impact) -> p.GetResult(TerrabuildArgs.Impact) |> impact
     | p when p.Contains(TerrabuildArgs.Serve) -> p.GetResult(TerrabuildArgs.Serve) |> serve
     | p when p.Contains(TerrabuildArgs.Console) -> p.GetResult(TerrabuildArgs.Console) |> console
     | p when p.Contains(TerrabuildArgs.Clear) -> p.GetResult(TerrabuildArgs.Clear) |> clear

--- a/src/Terrabuild/Terrabuild.fsproj
+++ b/src/Terrabuild/Terrabuild.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="Core/Scaffold.fs" />
     <Compile Include="Core/Configuration.fs" />
     <Compile Include="Core/GraphPipeline/Node.fs" />
+    <Compile Include="Core/GraphPipeline/Selection.fs" />
     <Compile Include="Core/GraphPipeline/Action.fs" />
     <Compile Include="Core/GraphPipeline/Batch.fs" />
     <Compile Include="Core/GraphPipeline/Cascade.fs" />

--- a/website/site-docs/usage.md
+++ b/website/site-docs/usage.md
@@ -68,7 +68,7 @@ OPTIONS:
 
 ### Machine-readable Result Report
 
-Use `--result <path>` to write a JSON report describing the planned impacts of the run and, for normal executions, the final outcomes.
+Use `--result <path>` to write a JSON report describing the final outcomes of a run.
 
 Example:
 
@@ -76,16 +76,8 @@ Example:
 terrabuild run build --result artifacts/run-result.json
 ```
 
-Example with `--what-if`:
-
-```bash
-terrabuild run build --what-if --result artifacts/run-result.json
-```
-
 The report uses `lowercase(ProjectName):target` as the public identifier.
 Projects without an assigned `name` are intentionally omitted from the report.
-
-Normal runs produce both `impacts` and `results`:
 
 ```json
 {
@@ -93,10 +85,6 @@ Normal runs produce both `impacts` and `results`:
   "targets": ["build"],
   "startedAt": "2026-04-11T16:42:46.595161Z",
   "endedAt": "2026-04-11T16:43:28.917020Z",
-  "impacts": {
-    "app:build": "build",
-    "lib:test": "restore"
-  },
   "results": {
     "app:build": "success",
     "lib:test": "ignored"
@@ -104,35 +92,11 @@ Normal runs produce both `impacts` and `results`:
 }
 ```
 
-`impacts` is computed before the runner executes and is always present when `--result` is used.
-Possible impact values are:
-
-- `build`: Terrabuild will execute the target.
-- `restore`: Terrabuild will restore artifacts from cache.
-- `report`: Terrabuild will surface an existing failed state without rebuilding.
-- `ignore`: The node exists in the computed graph but no action is planned.
-
-`results` is written only for non-`--what-if` runs.
 Possible result values are:
 
 - `success`: At least one matching node completed successfully and none failed.
 - `failure`: At least one matching node failed.
 - `ignored`: The named node existed in the graph but produced no runner result.
-
-When `--what-if` is used, the report still includes `impacts` but omits `results`:
-
-```json
-{
-  "status": "what-if",
-  "targets": ["build"],
-  "startedAt": "2026-04-11T16:42:46.595161Z",
-  "endedAt": "2026-04-11T16:42:50.000000Z",
-  "impacts": {
-    "app:build": "build",
-    "lib:test": "restore"
-  }
-}
-```
 
 ## Clear Local Cache
 Command `clear` allows you to clear local cache. This is useful when you want to force a complete build or free up disk space:


### PR DESCRIPTION
## Summary
- add the impact command with base-graph comparison against Insights commit graphs
- add machine-readable JSON file output for run and impact via --out
- upload full graphs for commit-keyed impact analysis and document the new CLI behavior

## Validation
- make test